### PR TITLE
refactor: Renamed repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           PORT=8002 docker-compose exec -T web coverage run -m pytest .
           PORT=8002 docker-compose exec -T web coverage xml
-          docker cp pyronear-api_web_1:/usr/src/app/coverage.xml .
+          docker cp pyro-api_web_1:/usr/src/app/coverage.xml .
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to pyronear-api
+# Contributing to pyro-api
 
 Everything you need to know to contribute efficiently to the project.
 
@@ -6,9 +6,9 @@ Everything you need to know to contribute efficiently to the project.
 
 ## Codebase structure
 
-- [src](https://github.com/pyronear/pyronear-api/blob/master/src) - The actual [FastAPI](https://fastapi.tiangolo.com/) project
-- [src/app](https://github.com/pyronear/pyronear-api/blob/master/src/app) - The source code of the API
-- [src/tests](https://github.com/pyronear/pyronear-api/blob/master/src/tests) - The unittests for the app
+- [src](https://github.com/pyronear/pyro-api/blob/master/src) - The actual [FastAPI](https://fastapi.tiangolo.com/) project
+- [src/app](https://github.com/pyronear/pyro-api/blob/master/src/app) - The source code of the API
+- [src/tests](https://github.com/pyronear/pyro-api/blob/master/src/tests) - The unittests for the app
 
 
 
@@ -27,11 +27,11 @@ As a contributor, you will only have to ensure coverage of your code by adding a
 
 ## Issues
 
-Use Github [issues](https://github.com/pyronear/pyronear-api/issues) for feature requests, or bug reporting. When doing so, use issue templates whenever possible and provide enough information for other contributors to jump in.
+Use Github [issues](https://github.com/pyronear/pyro-api/issues) for feature requests, or bug reporting. When doing so, use issue templates whenever possible and provide enough information for other contributors to jump in.
 
 
 
-## Developing pyronear-api
+## Developing pyro-api
 
 
 ### Commits

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pyronear API
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/3bea1a63e4aa44258cfd08831d713478)](https://www.codacy.com/gh/pyronear/pyronear-api/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pyronear/pyronear-api&amp;utm_campaign=Badge_Grade)![Build Status](https://github.com/pyronear/pyronear-api/workflows/fastapi-project/badge.svg) [![codecov](https://codecov.io/gh/pyronear/pyronear-api/branch/master/graph/badge.svg)](https://codecov.io/gh/pyronear/pyronear-api) [![Docs](https://img.shields.io/badge/docs-available-blue.svg)](http://pyronear-api.herokuapp.com/redoc)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/3bea1a63e4aa44258cfd08831d713478)](https://www.codacy.com/gh/pyronear/pyro-api/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pyronear/pyro-api&amp;utm_campaign=Badge_Grade)![Build Status](https://github.com/pyronear/pyro-api/workflows/fastapi-project/badge.svg) [![codecov](https://codecov.io/gh/pyronear/pyro-api/branch/master/graph/badge.svg)](https://codecov.io/gh/pyronear/pyro-api) [![Docs](https://img.shields.io/badge/docs-available-blue.svg)](http://pyronear-api.herokuapp.com/redoc)
 
 The building blocks of our wildfire detection & monitoring API.
 
@@ -32,8 +32,8 @@ The building blocks of our wildfire detection & monitoring API.
 You can clone and install the project dependencies as follows:
 
 ```bash
-git clone https://github.com/pyronear/pyronear-api.git
-pip install -r pyronear-api/requirements.txt
+git clone https://github.com/pyronear/pyro-api.git
+pip install -r pyro-api/requirements.txt
 ```
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - ${PORT}:8000
     environment:
-      - DATABASE_URL=postgresql://pyronear_api:pyronear_api@db/pyronear_api_dev
+      - DATABASE_URL=postgresql://pyro_api:pyro_api@db/pyro_api_dev
   db:
     image: postgres:12.1-alpine
     volumes:
@@ -17,9 +17,9 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_USER=pyronear_api
-      - POSTGRES_PASSWORD=pyronear_api
-      - POSTGRES_DB=pyronear_api_dev
+      - POSTGRES_USER=pyro_api
+      - POSTGRES_PASSWORD=pyro_api
+      - POSTGRES_DB=pyro_api_dev
 
 volumes:
   postgres_data:


### PR DESCRIPTION
This PR reflects changes to the repo name. I wasn't able to update the name of the Heroku deployment since pyro-api.herokuapp.com is already taken.

Any feedback is welcome :ok_hand: 
