### PR TITLE
fix: Fixed the device update location

### DIFF
--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -46,8 +46,8 @@ async def heartbeat(device: DeviceOut = Security(get_current_device, scopes=["de
 
 @router.post("/{device_id}/update-location", response_model=DeviceOut)
 async def update_location(payload: UpdatedLocation,
-                          user: UserRead = Security(get_current_user, scopes=["me"]),
-                          device_id: int = Path(..., gt=0)):
+                          device_id: int = Path(..., gt=0),
+                          user: UserRead = Security(get_current_user, scopes=["me"])):
     return await routing.update_location(devices, payload, device_id, user.id)
 
 

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -48,7 +48,7 @@ async def heartbeat(device: DeviceOut = Security(get_current_device, scopes=["de
 async def update_location(payload: UpdatedLocation,
                           user: UserRead = Security(get_current_user, scopes=["me"]),
                           device_id: int = Path(..., gt=0)):
-    return await routing.update_location(devices, payload, device_id=id, user_id=user.id)
+    return await routing.update_location(devices, payload, device_id, user.id)
 
 
 @router.put("/{device_id}/pwd", response_model=DeviceOut)


### PR DESCRIPTION
This PR reorders arguments of `update_location` and fixes the value passed to device_id. Previously the value is the built-in `id` function.