### PR TITLE
refactor: Refactored db module

### DIFF
--- a/src/app/db/__init__.py
+++ b/src/app/db/__init__.py
@@ -1,0 +1,2 @@
+from .tables import *
+from .session import engine, database

--- a/src/app/db/session.py
+++ b/src/app/db/session.py
@@ -1,0 +1,8 @@
+from sqlalchemy import create_engine
+from databases import Database
+
+from app import config as cfg
+
+
+engine = create_engine(cfg.DATABASE_URL)
+database = Database(cfg.DATABASE_URL)

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -1,15 +1,16 @@
 import enum
 from sqlalchemy import (Column, DateTime, Integer, Float, String, Table, Enum, Boolean,
-                        ForeignKey, MetaData, create_engine)
+                        ForeignKey, MetaData)
 from sqlalchemy.sql import func
 from app import config as cfg
-from databases import Database
+
+
+__all__ = ['metadata', 'SiteType', 'EventType', 'MediaType', 'AlertType',
+           'users', 'accesses', 'sites', 'events', 'devices', 'media', 'installations', 'alerts']
 
 
 # SQLAlchemy
 # databases query builder
-database = Database(cfg.DATABASE_URL)
-engine = create_engine(cfg.DATABASE_URL)
 metadata = MetaData()
 
 # Cores tables


### PR DESCRIPTION
Following up on suggestions about db initialization in #26, this PR splits table definition and session creation and puts them both in the same module.

The `__init__.py` preserves all imports from other files for ideal compatibility.