### PR TITLE
fix: Fixed package versioning of databases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.61.1
 uvicorn>=0.11.1
-databases[postgresql]>=0.2.6
+databases[postgresql]>=0.2.6,<=0.4.0
 SQLAlchemy>=1.3.12
 python-jose>=3.2.0
 passlib[bcrypt]>=1.7.4


### PR DESCRIPTION
In #38, tests were failing apparently because of a missing `psycopg2` dependency. So I checked the last previous PR successfully building which is #37:

The build of 37 (https://github.com/pyronear/pyro-api/pull/37/checks?check_run_id=1408361256) installs `databases` v0.4.0 while the other (https://github.com/pyronear/pyro-api/pull/38/checks?check_run_id=1411729940) installs  version 0.4.1. I checked locally and adding an upper bound constraint fixes the issue.

Any feedback is welcome!