### PR TITLE
refactor: Added admin to authorized scopes of selfID routes

### DIFF
--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -39,7 +39,7 @@ async def delete_device(device_id: int = Path(..., gt=0), _=Security(get_current
 
 
 @router.get("/my-devices", response_model=List[DeviceOut])
-async def fetch_my_devices(me: UserRead = Security(get_current_user, scopes=["admin me"])):
+async def fetch_my_devices(me: UserRead = Security(get_current_user, scopes=["admin", "me"])):
     return await crud.fetch_all(devices, [("owner_id", me.id)])
 
 
@@ -54,7 +54,7 @@ async def heartbeat(device: DeviceOut = Security(get_current_device, scopes=["de
 async def update_device_location(
     payload: DefaultPosition,
     device_id: int = Path(..., gt=0),
-    user: UserRead = Security(get_current_user, scopes=["admin me"])
+    user: UserRead = Security(get_current_user, scopes=["admin", "me"])
 ):
     # Check that device is accessible to this user
     entry = await crud.fetch_one(devices, [("id", device_id), ("owner_id", user.id)])

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -39,7 +39,7 @@ async def delete_device(device_id: int = Path(..., gt=0), _=Security(get_current
 
 
 @router.get("/my-devices", response_model=List[DeviceOut])
-async def fetch_my_devices(me: UserRead = Security(get_current_user, scopes=["me"])):
+async def fetch_my_devices(me: UserRead = Security(get_current_user, scopes=["admin me"])):
     return await crud.fetch_all(devices, [("owner_id", me.id)])
 
 
@@ -54,7 +54,7 @@ async def heartbeat(device: DeviceOut = Security(get_current_device, scopes=["de
 async def update_device_location(
     payload: DefaultPosition,
     device_id: int = Path(..., gt=0),
-    user: UserRead = Security(get_current_user, scopes=["me"])
+    user: UserRead = Security(get_current_user, scopes=["admin me"])
 ):
     # Check that device is accessible to this user
     entry = await crud.fetch_one(devices, [("id", device_id), ("owner_id", user.id)])

--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -14,17 +14,17 @@ router = APIRouter()
 
 
 @router.get("/me", response_model=UserRead)
-async def get_my_user(me: UserRead = Security(get_current_user, scopes=["me"])):
+async def get_my_user(me: UserRead = Security(get_current_user, scopes=["admin me"])):
     return me
 
 
 @router.put("/update-info", response_model=UserRead)
-async def update_my_info(payload: UserInfo, me: UserRead = Security(get_current_user, scopes=["me"])):
+async def update_my_info(payload: UserInfo, me: UserRead = Security(get_current_user, scopes=["admin me"])):
     return await crud.update_entry(users, payload, me.id)
 
 
 @router.put("/update-pwd", response_model=UserInfo)
-async def update_my_password(payload: Cred, me: UserRead = Security(get_current_user, scopes=["me"])):
+async def update_my_password(payload: Cred, me: UserRead = Security(get_current_user, scopes=["admin me"])):
     entry = await crud.get_entry(users, me.id)
     await update_access_pwd(payload, entry["access_id"])
     return entry

--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -14,17 +14,17 @@ router = APIRouter()
 
 
 @router.get("/me", response_model=UserRead)
-async def get_my_user(me: UserRead = Security(get_current_user, scopes=["admin me"])):
+async def get_my_user(me: UserRead = Security(get_current_user, scopes=["admin", "me"])):
     return me
 
 
 @router.put("/update-info", response_model=UserRead)
-async def update_my_info(payload: UserInfo, me: UserRead = Security(get_current_user, scopes=["admin me"])):
+async def update_my_info(payload: UserInfo, me: UserRead = Security(get_current_user, scopes=["admin", "me"])):
     return await crud.update_entry(users, payload, me.id)
 
 
 @router.put("/update-pwd", response_model=UserInfo)
-async def update_my_password(payload: Cred, me: UserRead = Security(get_current_user, scopes=["admin me"])):
+async def update_my_password(payload: Cred, me: UserRead = Security(get_current_user, scopes=["admin", "me"])):
     entry = await crud.get_entry(users, me.id)
     await update_access_pwd(payload, entry["access_id"])
     return entry


### PR DESCRIPTION
This PR adjusts the authorized scope of self-ID routes. Initially, admin was not enabled, this fixes it.