### PR TITLE
fix: Fixed DB initialization

### DIFF
--- a/src/app/db/init_db.py
+++ b/src/app/db/init_db.py
@@ -10,7 +10,7 @@ async def init_db():
     login = cfg.SUPERUSER_LOGIN
 
     # check if access login does not already exist
-    entry = await crud.fetch_one(accesses, [("login", login)])
+    entry = await crud.fetch_one(accesses, {"login": login})
     if entry is None:
 
         hashed_password = await hash_password(cfg.SUPERUSER_PWD)


### PR DESCRIPTION
Since query filters were recently changed in #37, the db initialization was still using the legacy interface. This PR fixes it

_To prevent this type of issue from happening again, perhaps we should have a github action checking the status of the Heroku deployment upon build completion (pinging the documentation for instance?). I noticed this after trying to access the documentation, and I looked at the logs to find out what was causing the crash_