### PR TITLE
[scopes][permissions] update permission condition from "and" to "or" 

### DIFF
--- a/src/app/api/deps.py
+++ b/src/app/api/deps.py
@@ -55,9 +55,8 @@ async def get_current_access(security_scopes: SecurityScopes, token: str = Depen
     if entry is None:
         raise unauthorized_exception("Invalid credentials", authenticate_value)
 
-    for scope in security_scopes.scopes:
-        if scope not in token_data.scopes:
-            raise unauthorized_exception("Permission denied", authenticate_value)
+    if set(token_data.scopes).isdisjoint(security_scopes.scopes):
+        raise unauthorized_exception("Permission denied", authenticate_value)
 
     return AccessRead(**entry)
 


### PR DESCRIPTION
Following the super relevant comment from @florianriche in #45, this PR aims at correcting the authentication behaviour with respect to the scope list.

The list of scopes appears to be an "and" condition, instead of a "or" as we want to design it.

`deps.py` file has been updated to reflect the correct behaviour.

Any feedback is welcome !