### PR TITLE
fix: get_all_at_given_ts_and_site timestamp call

### DIFF
--- a/src/app/api/routes/installations.py
+++ b/src/app/api/routes/installations.py
@@ -38,6 +38,6 @@ async def delete_installation(installation_id: int = Path(..., gt=0)):
 async def get_all_at_given_ts_and_site(payload: Timestamp, site_id: int = Path(..., gt=0)):
 
     query = installations.select(installations.c.device_id).where(and_(installations.c.site_id == site_id,
-                                                                       installations.c.start_ts <= timestamp,
-                                                                       installations.c.end_ts >= timestamp))
+                                                                       installations.c.start_ts <= payload.timestamp,
+                                                                       installations.c.end_ts >= payload.timestamp))
     return await database.fetch_all(query=query)


### PR DESCRIPTION
small error (caught by pyflakes on my machine): timestamp was not defined but belonged to the payload object.