### PR TITLE
feat: Added a route for alert acknowledgement

### DIFF
--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -2,7 +2,7 @@ from typing import List
 from fastapi import APIRouter, Path, Security, HTTPException
 from app.api import crud
 from app.db import alerts, AlertType, media
-from app.api.schemas import AlertBase, AlertOut, AlertIn, AlertMediaId, DeviceOut
+from app.api.schemas import AlertBase, AlertOut, AlertIn, AlertMediaId, DeviceOut, Ackowledgement, AcknowledgementOut
 from app.api.deps import get_current_device
 
 
@@ -70,14 +70,12 @@ async def update_alert(payload: AlertIn, alert_id: int = Path(..., gt=0)):
     return await crud.update_entry(alerts, payload, alert_id)
 
 
-@router.put("/{alert_id}/acknowledge", response_model=AlertOut, summary="Acknowledge an existing alert")
+@router.put("/{alert_id}/acknowledge", response_model=AcknowledgementOut, summary="Acknowledge an existing alert")
 async def acknowledge_alert(alert_id: int = Path(..., gt=0)):
     """
     Based on a alert_id, acknowledge the specified alert
     """
-    payload = await crud.get_entry(alerts, alert_id)
-    payload['is_acknowledged'] = True
-    return await crud.update_entry(alerts, AlertIn(**payload), alert_id)
+    return await crud.update_entry(alerts, Ackowledgement(is_acknowledged=True), alert_id)
 
 
 @router.delete("/{alert_id}/", response_model=AlertOut)

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -75,9 +75,9 @@ async def acknowledge_alert(alert_id: int = Path(..., gt=0)):
     """
     Based on a alert_id, acknowledge the specified alert
     """
-    payload = await crud.get(alert_id, alerts)
-    payload.is_acknowledged = True
-    return await crud.update_entry(alerts, payload, alert_id)
+    payload = await crud.get_entry(alerts, alert_id)
+    payload['is_acknowledged'] = True
+    return await crud.update_entry(alerts, AlertIn(**payload), alert_id)
 
 
 @router.delete("/{alert_id}/", response_model=AlertOut)

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -70,6 +70,16 @@ async def update_alert(payload: AlertIn, alert_id: int = Path(..., gt=0)):
     return await crud.update_entry(alerts, payload, alert_id)
 
 
+@router.put("/{alert_id}/acknowledge", response_model=AlertOut, summary="Acknowledge an existing alert")
+async def acknowledge_alert(alert_id: int = Path(..., gt=0)):
+    """
+    Based on a alert_id, acknowledge the specified alert
+    """
+    payload = await crud.get(alert_id, alerts)
+    payload.is_acknowledged = True
+    return await crud.update_entry(alerts, payload, alert_id)
+
+
 @router.delete("/{alert_id}/", response_model=AlertOut)
 async def delete_alert(alert_id: int = Path(..., gt=0), summary="Delete a specific alert"):
     """

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -211,3 +211,11 @@ class AlertIn(AlertBase):
 
 class AlertOut(AlertIn, _CreatedAt, _Id):
     pass
+
+
+class Ackowledgement(BaseModel):
+    is_acknowledged: bool = Field(False)
+
+
+class AcknowledgementOut(Ackowledgement, _Id):
+    pass

--- a/src/tests/test_alerts.py
+++ b/src/tests/test_alerts.py
@@ -195,7 +195,7 @@ async def test_acknowledge_alert(test_app_asyncio, test_db, monkeypatch):
     assert response.status_code == 200
     updated_alert_in_db = await get_entry_in_db(test_db, db.alerts, 3)
     updated_alert_in_db = dict(**updated_alert_in_db)
-    assert updated_alert_in_db.is_acknowledged == True
+    assert updated_alert_in_db.is_acknowledged
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_alerts.py
+++ b/src/tests/test_alerts.py
@@ -195,7 +195,7 @@ async def test_acknowledge_alert(test_app_asyncio, test_db, monkeypatch):
     assert response.status_code == 200
     updated_alert_in_db = await get_entry_in_db(test_db, db.alerts, 3)
     updated_alert_in_db = dict(**updated_alert_in_db)
-    assert updated_alert_in_db.is_acknowledged
+    assert updated_alert_in_db['is_acknowledged']
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_alerts.py
+++ b/src/tests/test_alerts.py
@@ -187,6 +187,17 @@ async def test_update_alert(test_app_asyncio, test_db, monkeypatch):
         assert v == updated_alert_in_db[k]
 
 
+@pytest.mark.asyncio
+async def test_acknowledge_alert(test_app_asyncio, test_db, monkeypatch):
+    await init_test_db(monkeypatch, test_db)
+
+    response = await test_app_asyncio.put("/alerts/3/acknowledge")
+    assert response.status_code == 200
+    updated_alert_in_db = await get_entry_in_db(test_db, db.alerts, 3)
+    updated_alert_in_db = dict(**updated_alert_in_db)
+    assert updated_alert_in_db.is_acknowledged == True
+
+
 @pytest.mark.parametrize(
     "alert_id, payload, status_code",
     [


### PR DESCRIPTION
As per #63, this PR adds a route for alert acknowledgement. As discussed in the issue, the question of the route scope will be deferred to #45 and not be handled in this PR.

This will close #63 

Any feedback is welcome!