### PR TITLE
Check login existence when updating user/access/device

### DIFF
--- a/src/app/api/routes/accesses.py
+++ b/src/app/api/routes/accesses.py
@@ -76,7 +76,7 @@ async def update_access(payload: AccessBase, access_id: int = Path(..., gt=0)):
     Based on a access_id, updates information about the specified access
     """
     if payload.login is not None:
-        updated_acccess = await crud.fetch_one(accesses, {"id": access_id})
+        updated_acccess = await crud.get(access_id, accesses)
         if (updated_acccess is not None) and (updated_acccess["login"] != payload.login):
             await check_for_access_login_existence(payload.login)
     return await crud.update_entry(accesses, payload, access_id)

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -10,7 +10,7 @@ router = APIRouter()
 
 
 async def check_media_existence(media_id):
-    existing_media = await crud.fetch_one(media, {"id": media_id})
+    existing_media = await crud.get(media_id, media)
     if existing_media is None:
         raise HTTPException(
             status_code=404,

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -58,7 +58,7 @@ async def update_device(payload: DeviceIn, device_id: int = Path(..., gt=0)):
     Based on a device_id, updates information about the specified device
     """
     if payload.login is not None:
-        updated_device = await crud.fetch_one(devices, {"id": device_id})
+        updated_device = await crud.get(device_id, devices)
         if updated_device is not None and payload.login != updated_device["login"]:
             await check_for_access_login_existence(payload.login)
             updated_acccess = await crud.fetch_one(accesses, {"login": updated_device["login"]})

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -59,10 +59,8 @@ async def update_device(payload: DeviceIn, device_id: int = Path(..., gt=0)):
     """
     if payload.login is not None:
         updated_device = await crud.fetch_one(devices, {"id": device_id})
-        if updated_device is not None:
-            if payload.login != updated_device["login"]:
-                await check_for_access_login_existence(payload.login)
-
+        if updated_device is not None and payload.login != updated_device["login"]:
+            await check_for_access_login_existence(payload.login)
             updated_acccess = await crud.fetch_one(accesses, {"login": updated_device["login"]})
             await update_access_login(payload.login, updated_acccess["id"])
 

--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -33,7 +33,7 @@ async def update_my_info(payload: UserInfo, me: UserRead = Security(get_current_
         await check_for_access_login_existence(payload.login)
         if updated_acccess["login"] != payload.login:
             await check_for_access_login_existence(payload.login)
-        await update_access_login(payload.login, updated_acccess["id"])
+            await update_access_login(payload.login, updated_acccess["id"])
 
     return await crud.update_entry(users, payload, me.id)
 
@@ -89,10 +89,8 @@ async def update_user(
     # Check for access login
     if payload.login is not None:
         updated_user = await crud.fetch_one(users, {"id": user_id})
-        if updated_user is not None:
-            if updated_user["login"] != payload.login:
-                await check_for_access_login_existence(payload.login)
-
+        if updated_user is not None and updated_user["login"] != payload.login:
+            await check_for_access_login_existence(payload.login)
             updated_acccess = await crud.fetch_one(accesses, {"login": updated_user["login"]})
             await update_access_login(payload.login, updated_acccess["id"])
 

--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -30,7 +30,6 @@ async def update_my_info(payload: UserInfo, me: UserRead = Security(get_current_
     # Check for access login
     if payload.login is not None:
         updated_acccess = await crud.fetch_one(accesses, {"login": me.login})
-        await check_for_access_login_existence(payload.login)
         if updated_acccess["login"] != payload.login:
             await check_for_access_login_existence(payload.login)
             await update_access_login(payload.login, updated_acccess["id"])
@@ -88,7 +87,7 @@ async def update_user(
     """
     # Check for access login
     if payload.login is not None:
-        updated_user = await crud.fetch_one(users, {"id": user_id})
+        updated_user = await crud.get(user_id, users)
         if updated_user is not None and updated_user["login"] != payload.login:
             await check_for_access_login_existence(payload.login)
             updated_acccess = await crud.fetch_one(accesses, {"login": updated_user["login"]})

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -24,6 +24,10 @@ class Timestamp(BaseModel):
 
 
 # Accesses
+class Login(BaseModel):
+    login: str = Field(..., min_length=3, max_length=50, example="JohnDoe")
+
+
 class Cred(BaseModel):
     password: str = Field(..., min_length=3, example="PickARobustOne")
 
@@ -32,8 +36,7 @@ class CredHash(BaseModel):
     hashed_password: str
 
 
-class AccessBase(BaseModel):
-    login: str = Field(..., min_length=3, max_length=50, example="JohnDoe")
+class AccessBase(Login):
     scopes: str = Field(..., example="me")
 
 
@@ -50,9 +53,9 @@ class AccessRead(AccessBase, _Id):
 
 
 # Users
-class UserInfo(BaseModel):
+class UserInfo(Login):
     # Abstract information about a user
-    login: str = Field(..., min_length=3, max_length=50, example="JohnDoe")
+    pass
 
 
 class UserRead(UserInfo, _CreatedAt, _Id):
@@ -135,8 +138,7 @@ class EventOut(EventIn, _CreatedAt, _Id):
 
 
 # Device
-class MyDeviceIn(DefaultPosition):
-    login: str = Field(..., min_length=3, max_length=50, example="pyronearEngine51")
+class MyDeviceIn(Login, DefaultPosition):
     specs: str = Field(..., min_length=3, max_length=100, example="systemV0.1")
     last_ping: datetime = Field(default=None, example=datetime.utcnow())
 

--- a/src/tests/test_accesses.py
+++ b/src/tests/test_accesses.py
@@ -107,6 +107,7 @@ async def test_update_access(test_app_asyncio, test_db, monkeypatch):
         [999, {"login": "first_login", "scopes": "me", "password": "PickAnotherRobustOne"}, 404],
         [1, {"login": 1, "scopes": "me", "password": "PickAnotherRobustOne"}, 422],
         [0, {"login": "first_login", "scopes": "me", "password": "PickAnotherRobustOne"}, 422],
+        [1, {"login": "second_login", "scopes": "me", "password": "PickAnotherRobustOne"}, 400],
     ],
 )
 @pytest.mark.asyncio
@@ -115,6 +116,7 @@ async def test_update_access_invalid(test_app_asyncio, test_db, monkeypatch, acc
     await populate_db(test_db, db.accesses, ACCESS_TABLE)
 
     response = await test_app_asyncio.put(f"/accesses/{access_id}/", data=json.dumps(payload))
+    print(response.content)
     assert response.status_code == status_code, print(payload)
 
 

--- a/src/tests/test_accesses.py
+++ b/src/tests/test_accesses.py
@@ -116,7 +116,6 @@ async def test_update_access_invalid(test_app_asyncio, test_db, monkeypatch, acc
     await populate_db(test_db, db.accesses, ACCESS_TABLE)
 
     response = await test_app_asyncio.put(f"/accesses/{access_id}/", data=json.dumps(payload))
-    print(response.content)
     assert response.status_code == status_code, print(payload)
 
 

--- a/src/tests/test_devices.py
+++ b/src/tests/test_devices.py
@@ -186,6 +186,8 @@ async def test_update_device(test_app_asyncio, test_db, monkeypatch):
         [1, {"login": 1, "owner_id": 1, "access_id": 1, "specs": "v0.1"}, 422],
         [1, {"login": "renamed_device"}, 422],
         [0, {"login": "renamed_device", "owner_id": 1, "access_id": 1, "specs": "v0.1"}, 422],
+        # renamed to already existing login
+        [1, {"login": "second_device", "owner_id": 1, "access_id": 1, "specs": "v0.1"}, 400],
     ],
 )
 @pytest.mark.asyncio

--- a/src/tests/test_users.py
+++ b/src/tests/test_users.py
@@ -165,6 +165,7 @@ async def test_update_user(test_app_asyncio, test_db, monkeypatch):
         [1, {"login": 1}, 422],
         [1, {"login": "me"}, 422],
         [0, {"login": "renamed_user"}, 422],
+        [1, {"login": "connected_user"}, 400],  # renamed to already existing login
     ],
 )
 @pytest.mark.asyncio
@@ -183,6 +184,7 @@ async def test_update_user_invalid(test_app_asyncio, test_db, monkeypatch, user_
         [{}, 422],
         [{"login": 1}, 422],
         [{"login": "me"}, 422],
+        [{"login": "first_user"}, 400],  # renamed to already existing login
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
When an access/user/device is updated; if the login is in the payload, we check if the updated login doesn't already belong to another user/access/device.

Close #30 