### PR TITLE
BUGFIX: Events route accesses as device

### DIFF
--- a/src/app/api/routes/events.py
+++ b/src/app/api/routes/events.py
@@ -3,14 +3,14 @@ from fastapi import APIRouter, Path, Security
 from app.api import crud
 from app.db import events
 from app.api.schemas import EventOut, EventIn
-from app.api.deps import get_current_user
+from app.api.deps import get_current_user, get_current_access
 
 
 router = APIRouter()
 
 
 @router.post("/", response_model=EventOut, status_code=201, summary="Create a new event")
-async def create_event(payload: EventIn, _=Security(get_current_user, scopes=["admin", "device"])):
+async def create_event(payload: EventIn, _=Security(get_current_access, scopes=["admin", "device"])):
     """Creates a new event based on the given information
 
     Below, click on "Schema" for more detailed information about arguments
@@ -39,7 +39,7 @@ async def fetch_events():
 async def update_event(
     payload: EventIn,
     event_id: int = Path(..., gt=0),
-    _=Security(get_current_user, scopes=["admin", "device"])
+    _=Security(get_current_access, scopes=["admin", "device"])
 ):
     """
     Based on a event_id, updates information about the specified event

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -3,8 +3,8 @@ from starlette.testclient import TestClient
 from datetime import datetime
 
 from app.main import app
-from app.api.schemas import UserRead, DeviceOut
-from app.api.deps import get_current_user, get_current_device
+from app.api.schemas import UserRead, DeviceOut, AccessRead
+from app.api.deps import get_current_user, get_current_device, get_current_access
 from tests.conf_test_db import database as test_database
 from tests.conf_test_db import reset_test_db
 from httpx import AsyncClient
@@ -12,6 +12,10 @@ from httpx import AsyncClient
 
 async def mock_current_user():
     return UserRead(id=2, login="connected_user", created_at=datetime.now())
+
+
+async def mock_current_access():
+    return AccessRead(id=2, login="connected_user", scopes="device", created_at=datetime.now())
 
 
 async def mock_current_device():
@@ -38,6 +42,7 @@ def __app():
     # Access-related patching
     app.dependency_overrides[get_current_user] = mock_current_user
     app.dependency_overrides[get_current_device] = mock_current_device
+    app.dependency_overrides[get_current_access] = mock_current_access
 
     yield app  # testing happens here
 


### PR DESCRIPTION
The security of some events routes where decorated with get_current_user with expected scopes ["admin", "device"]. 
But get_urrent_user checks for the access authorization and then that a user exists with the required login. As we were trying to query the route with a device; no such user existed and hence an exception was raised.

In order to make the route works for both admin and device, we replace get_current_user by get_current_access 

