### PR TITLE
2 chars Bugfix: fix device route location in client

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -19,8 +19,8 @@ class Client:
     """
 
     routes = {"token": "/login/access-token",
-              "heartbeat": "/device/heartbeat",
-              "update-my-location": "/device/update-my-location",
+              "heartbeat": "/devices/heartbeat",
+              "update-my-location": "/devices/update-my-location",
               "create-event": "/events",
               "send-alert": "/alerts",
               "send-alert-from-device": "/alerts/from-device",


### PR DESCRIPTION
`Device` instead of `Devices`.

No other error typo observed.