### PR TITLE
fix: Fixed Qarnot image upload and image retrieval

### DIFF
--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -125,4 +125,4 @@ async def get_media_image(background_tasks: BackgroundTasks,
     media = await check_for_media_existence(media_id)
     retrieved_file = await bucket_service.get_uploaded_file(bucket_key=media["bucket_key"])
     background_tasks.add_task(bucket_service.flush_after_get_uploaded_file, retrieved_file)
-    return StreamingResponse(open(retrieved_filename, 'rb'), media_type="image/jpeg")
+    return StreamingResponse(open(retrieved_file, 'rb'), media_type="image/jpeg")

--- a/src/app/services/bucket/baseBucketService.py
+++ b/src/app/services/bucket/baseBucketService.py
@@ -16,3 +16,7 @@ class BaseBucketService(ABC):
     @abstractmethod
     async def fetch_bucket_filenames(self):
         pass
+
+    @abstractmethod
+    async def flush_after_get_uploaded_file(self, filename):
+        pass

--- a/src/app/services/bucket/dummyBucketService.py
+++ b/src/app/services/bucket/dummyBucketService.py
@@ -13,6 +13,6 @@ class DummyBucketService(BaseBucketService):
 
     async def fetch_bucket_filenames(self):
         return []
-    
+
     async def flush_after_get_uploaded_file(self, filename):
         return True

--- a/src/app/services/bucket/dummyBucketService.py
+++ b/src/app/services/bucket/dummyBucketService.py
@@ -13,3 +13,6 @@ class DummyBucketService(BaseBucketService):
 
     async def fetch_bucket_filenames(self):
         return []
+    
+    async def flush_after_get_uploaded_file(self, filename):
+        return True

--- a/src/app/services/bucket/qarnotBucketService.py
+++ b/src/app/services/bucket/qarnotBucketService.py
@@ -1,8 +1,11 @@
 import os
 from qarnot import connection, bucket
+import logging
 
 from app.services.bucket.baseBucketService import BaseBucketService
 from app import config as cfg
+
+logger = logging.getLogger("uvicorn.error")
 
 
 class QarnotBucketService(BaseBucketService):
@@ -17,7 +20,7 @@ class QarnotBucketService(BaseBucketService):
         try:
             self.connect_to_bucket().add_file(file_binary, bucket_key)
         except Exception as e:
-            print(e)
+            logging.error(e)
             return False
         return True
 
@@ -25,7 +28,7 @@ class QarnotBucketService(BaseBucketService):
         try:
             return self.connect_to_bucket().get_file(bucket_key)
         except Exception as e:
-            print(e)
+            logging.error(e)
             return False
         return True
 

--- a/src/app/services/bucket/qarnotBucketService.py
+++ b/src/app/services/bucket/qarnotBucketService.py
@@ -1,3 +1,4 @@
+import os
 from qarnot import connection, bucket
 
 from app.services.bucket.baseBucketService import BaseBucketService
@@ -13,10 +14,24 @@ class QarnotBucketService(BaseBucketService):
         return self.bucket
 
     async def upload_file(self, bucket_key: str, file_binary: bin):
-        return await self.connect_to_bucket().add_file(file_binary, bucket_key)
+        try:
+            self.connect_to_bucket().add_file(file_binary, bucket_key)
+        except Exception as e:
+            print(e)
+            return False
+        return True
 
     async def get_uploaded_file(self, bucket_key: str):
-        return await self.connect_to_bucket().get_file(bucket_key)
+        try:
+            return self.connect_to_bucket().get_file(bucket_key)
+        except Exception as e:
+            print(e)
+            return False
+        return True
 
     async def fetch_bucket_filenames(self):
-        return await self.connect_to_bucket().list_files()
+        return self.connect_to_bucket().list_files()
+
+    async def flush_after_get_uploaded_file(self, filename):
+        os.remove(filename) if os.path.exists(filename) else None
+        

--- a/src/app/services/bucket/qarnotBucketService.py
+++ b/src/app/services/bucket/qarnotBucketService.py
@@ -34,4 +34,3 @@ class QarnotBucketService(BaseBucketService):
 
     async def flush_after_get_uploaded_file(self, filename):
         os.remove(filename) if os.path.exists(filename) else None
-        


### PR DESCRIPTION
Upload routes were not working properly with Qarnot:

1. For the upload: Qarnot doesn't accept an int as a bucket key. Had to convert the hash to a string
2. For the image URL retrieval: Qarnot retrieves the bucket objects by downloading them locally and then simply returning the filepath of the object. It seems here is not way to retrieve a public URL. Hence I didn't touch this part, but we have to be aware it is malfunctioning with Qarnot as it will only return the filename (i.e the bucket_key, which is not very useful)
3. For the image retrieval as Bytes: Used to try to read a URL. Now it reads the Bucket File downloaded by Qarnot, uses it in the Response and launch a Background task to delete that file after the route response..