### PR TITLE
feat: Upgraded bucket file naming with SHA256

### DIFF
--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter, Path, Security, File, UploadFile, HTTPException, 
 from fastapi.responses import StreamingResponse
 from typing import List
 from datetime import datetime
-import hashlib
 
 from app.api import crud
 from app.db import media

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -93,7 +93,7 @@ async def upload_media(media_id: int = Path(..., gt=0),
     """
     entry = await check_for_media_existence(media_id, current_device.id)
 
-    # Concatenate the first 32 chars of SHA256 hash with file extension
+    # Concatenate the first 32 chars (to avoid system interactions issues) of SHA256 hash with file extension
     bucket_key = f"{hash_content_file(file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
 
     upload_success = await bucket_service.upload_file(bucket_key=bucket_key,

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -2,12 +2,15 @@ from fastapi import APIRouter, Path, Security, File, UploadFile, HTTPException, 
 from fastapi.responses import StreamingResponse
 from typing import List
 from datetime import datetime
+import hashlib
 
 from app.api import crud
 from app.db import media
 from app.api.schemas import MediaOut, MediaIn, MediaCreation, MediaUrl, DeviceOut, BaseMedia
 from app.api.deps import get_current_device, get_current_user
+from app.api.security import hash_content_file
 from app.services import bucket_service
+
 
 router = APIRouter()
 
@@ -90,7 +93,9 @@ async def upload_media(media_id: int = Path(..., gt=0),
     Upload a media (image or video) linked to an existing media object in the DB
     """
     entry = await check_for_media_existence(media_id, current_device.id)
-    bucket_key = str(hash(datetime.utcnow()))
+
+    # Concatenate the first 32 chars of SHA256 hash with file extension
+    bucket_key = f"{hash_content_file(file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
 
     upload_success = await bucket_service.upload_file(bucket_key=bucket_key,
                                                       file_binary=file.file)

--- a/src/app/api/security.py
+++ b/src/app/api/security.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
 
+import hashlib
 from jose import jwt
 from passlib.context import CryptContext
 
@@ -29,3 +30,7 @@ async def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 async def hash_password(password: str) -> str:
     return pwd_context.hash(password)
+
+
+def hash_content_file(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()

--- a/src/tests/test_security.py
+++ b/src/tests/test_security.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 from app.api import security
 
@@ -23,3 +24,20 @@ async def test_verify_password():
 
     assert await security.verify_password(pwd1, hash_pwd1)
     assert not await security.verify_password("another_try", hash_pwd1)
+
+
+def test_hash_content_file():
+
+    # Download a small file
+    file_url1 = ("https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/"
+                 "Davies-Meyer_hash.svg/230px-Davies-Meyer_hash.svg.png")
+    file_url2 = ("https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/"
+                 "Matyas-Meyer-Oseas_hash.svg/230px-Matyas-Meyer-Oseas_hash.svg.png")
+
+    # Hash it
+    hash1 = security.hash_content_file(requests.get(file_url1).content)
+    hash2 = security.hash_content_file(requests.get(file_url2).content)
+
+    # Check data integrity
+    assert security.hash_content_file(requests.get(file_url1).content) == hash1
+    assert hash1 != hash2


### PR DESCRIPTION
This PR addresses the naming of bucket file on the CSP by:
- switching from hashing the timestamp to hashing the file content with SHA256
- taking the 32 first characters of the hexadecimal digested string and concatenate it with the file extension
- adding a unittest for the hashing function

Any feedback is welcome!