### PR TITLE
feat: Added admin scopes on tables to protect

### DIFF
--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Path, Security, HTTPException
 from app.api import crud
 from app.db import alerts, AlertType, media
 from app.api.schemas import AlertBase, AlertOut, AlertIn, AlertMediaId, DeviceOut, Ackowledgement, AcknowledgementOut
-from app.api.deps import get_current_device
+from app.api.deps import get_current_device, get_current_access
 
 
 router = APIRouter()
@@ -19,7 +19,7 @@ async def check_media_existence(media_id):
 
 
 @router.post("/", response_model=AlertOut, status_code=201, summary="Create a new alert")
-async def create_alert(payload: AlertIn):
+async def create_alert(payload: AlertIn, _=Security(get_current_access, scopes=["admin"])):
     """
     Creates a new alert based on the given information
 
@@ -63,7 +63,11 @@ async def fetch_alerts():
 
 
 @router.put("/{alert_id}/", response_model=AlertOut, summary="Update information about a specific alert")
-async def update_alert(payload: AlertIn, alert_id: int = Path(..., gt=0)):
+async def update_alert(
+    payload: AlertIn,
+    alert_id: int = Path(..., gt=0),
+    _=Security(get_current_access, scopes=["admin"])
+):
     """
     Based on a alert_id, updates information about the specified alert
     """
@@ -78,8 +82,8 @@ async def acknowledge_alert(alert_id: int = Path(..., gt=0)):
     return await crud.update_entry(alerts, Ackowledgement(is_acknowledged=True), alert_id)
 
 
-@router.delete("/{alert_id}/", response_model=AlertOut)
-async def delete_alert(alert_id: int = Path(..., gt=0), summary="Delete a specific alert"):
+@router.delete("/{alert_id}/", response_model=AlertOut, summary="Delete a specific alert")
+async def delete_alert(alert_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=["admin"])):
     """
     Based on a alert_id, deletes the specified alert
     """

--- a/src/app/api/routes/events.py
+++ b/src/app/api/routes/events.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Path, Security
 from app.api import crud
 from app.db import events
 from app.api.schemas import EventOut, EventIn
-from app.api.deps import get_current_user, get_current_access
+from app.api.deps import get_current_access
 
 
 router = APIRouter()
@@ -48,7 +48,7 @@ async def update_event(
 
 
 @router.delete("/{event_id}/", response_model=EventOut, summary="Delete a specific event")
-async def delete_event(event_id: int = Path(..., gt=0), _=Security(get_current_user, scopes=["admin"])):
+async def delete_event(event_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=["admin"])):
     """
     Based on a event_id, deletes the specified event
     """

--- a/src/app/api/routes/installations.py
+++ b/src/app/api/routes/installations.py
@@ -1,17 +1,18 @@
 from typing import List
-from fastapi import APIRouter, Path
+from fastapi import APIRouter, Path, Security
 from sqlalchemy import and_, or_
 from datetime import datetime
 from app.api import crud
 from app.db import installations, database
 from app.api.schemas import InstallationOut, InstallationIn
+from app.api.deps import get_current_access
 
 
 router = APIRouter()
 
 
 @router.post("/", response_model=InstallationOut, status_code=201, summary="Create a new installation")
-async def create_installation(payload: InstallationIn):
+async def create_installation(payload: InstallationIn, _=Security(get_current_access, scopes=["admin"])):
     """Creates a new installation based on the given information
 
     Below, click on "Schema" for more detailed information about arguments
@@ -39,7 +40,11 @@ async def fetch_installations():
 
 @router.put("/{installation_id}/", response_model=InstallationOut,
             summary="Update information about a specific installation")
-async def update_installation(payload: InstallationIn, installation_id: int = Path(..., gt=0)):
+async def update_installation(
+    payload: InstallationIn,
+    installation_id: int = Path(..., gt=0),
+    _=Security(get_current_access, scopes=["admin"])
+):
     """
     Based on a installation_id, updates information about the specified installation
     """
@@ -47,7 +52,7 @@ async def update_installation(payload: InstallationIn, installation_id: int = Pa
 
 
 @router.delete("/{installation_id}/", response_model=InstallationOut, summary="Delete a specific installation")
-async def delete_installation(installation_id: int = Path(..., gt=0)):
+async def delete_installation(installation_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=["admin"])):
     """
     Based on a installation_id, deletes the specified installation
     """

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from app.api import crud
 from app.db import media
 from app.api.schemas import MediaOut, MediaIn, MediaCreation, MediaUrl, DeviceOut, BaseMedia
-from app.api.deps import get_current_device, get_current_user
+from app.api.deps import get_current_device, get_current_user, get_current_access
 from app.api.security import hash_content_file
 from app.services import bucket_service
 
@@ -29,7 +29,7 @@ async def check_for_media_existence(media_id, device_id=None):
 
 
 @router.post("/", response_model=MediaOut, status_code=201, summary="Create a media related to a specific device")
-async def create_media(payload: MediaIn):
+async def create_media(payload: MediaIn, _=Security(get_current_access, scopes=["admin"])):
     """
     Creates a media related to specific device, based on device_id as argument
 
@@ -69,7 +69,11 @@ async def fetch_media():
 
 
 @router.put("/{media_id}/", response_model=MediaOut, summary="Update information about a specific media")
-async def update_media(payload: MediaIn, media_id: int = Path(..., gt=0)):
+async def update_media(
+    payload: MediaIn,
+    media_id: int = Path(..., gt=0),
+    _=Security(get_current_access, scopes=["admin"])
+):
     """
     Based on a media_id, updates information about the specified media
     """
@@ -77,7 +81,7 @@ async def update_media(payload: MediaIn, media_id: int = Path(..., gt=0)):
 
 
 @router.delete("/{media_id}/", response_model=MediaOut, summary="Delete a specific media")
-async def delete_media(media_id: int = Path(..., gt=0)):
+async def delete_media(media_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=["admin"])):
     """
     Based on a media_id, deletes the specified media
     """

--- a/src/app/api/routes/sites.py
+++ b/src/app/api/routes/sites.py
@@ -3,14 +3,14 @@ from fastapi import APIRouter, Path, Security
 from app.api import crud
 from app.db import sites
 from app.api.schemas import SiteOut, SiteIn
-from app.api.deps import get_current_user
+from app.api.deps import get_current_access
 
 
 router = APIRouter()
 
 
 @router.post("/", response_model=SiteOut, status_code=201, summary="Create a new site")
-async def create_site(payload: SiteIn, _=Security(get_current_user, scopes=["admin"])):
+async def create_site(payload: SiteIn, _=Security(get_current_access, scopes=["admin"])):
     """Creates a new site based on the given information
 
     Below, click on "Schema" for more detailed information about arguments
@@ -36,7 +36,11 @@ async def fetch_sites():
 
 
 @router.put("/{site_id}/", response_model=SiteOut, summary="Update information about a specific site")
-async def update_site(payload: SiteIn, site_id: int = Path(..., gt=0), _=Security(get_current_user, scopes=["admin"])):
+async def update_site(
+    payload: SiteIn,
+    site_id: int = Path(..., gt=0),
+    _=Security(get_current_access, scopes=["admin"])
+):
     """
     Based on a site_id, updates information about the specified site
     """
@@ -44,7 +48,7 @@ async def update_site(payload: SiteIn, site_id: int = Path(..., gt=0), _=Securit
 
 
 @router.delete("/{site_id}/", response_model=SiteOut, summary="Delete a specific site")
-async def delete_site(site_id: int = Path(..., gt=0), _=Security(get_current_user, scopes=["admin"])):
+async def delete_site(site_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=["admin"])):
     """
     Based on a site_id, deletes the specified site
     """


### PR DESCRIPTION
Following up on #45, I realized I was able to delete all entries in the alerts & media tables without any authentication. So this PR adds admin scope where it's best to start protecting the API.

Any feedback is welcome!