### PR TITLE
fix: Fixed media content upload to bucket

### DIFF
--- a/.github/workflows/client-main.yml
+++ b/.github/workflows/client-main.yml
@@ -55,15 +55,15 @@ jobs:
             ${{ runner.os }}-deps-${{ env.cache-name }}-
             ${{ runner.os }}-deps-
             ${{ runner.os }}-
+      - name: Build & run API server
+        run: |
+          PORT=8002 docker-compose up -d --build
+          docker ps
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e client/
           pip install coverage
-      - name: Build & run API server
-        run: |
-          PORT=8002 docker-compose up -d --build
-          docker ps
       - name: Run client unittests
         run: |
           coverage --version

--- a/.github/workflows/client-main.yml
+++ b/.github/workflows/client-main.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Run client unittests
         run: |
           coverage --version
+          sleep 5
           cd client && coverage run -m unittest discover test/
 
   flake8-py3:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build & run docker
-        run: PORT=8002 docker-compose up -d --build
+        run: |
+          PORT=8002 docker-compose up -d --build
+          docker ps
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,4 +91,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r scripts/requirements.txt
       - name: End-to-End test
-        run: python scripts/api_e2e.py 8002
+        run: |
+          sleep 5
+          python scripts/api_e2e.py 8002

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -98,7 +98,7 @@ async def upload_media(media_id: int = Path(..., gt=0),
     bucket_key = f"{hash_content_file(file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
     # If files are in a subfolder of the bucket
     if "/" in cfg.BUCKET_NAME:
-        bucket_key = f"{cfg.BUCKET_NAME[cfg.BUCKET_NAME.find('/'):]}/{bucket_key}"
+        bucket_key = f"{cfg.BUCKET_NAME[cfg.BUCKET_NAME.find('/') + 1:]}/{bucket_key}"
 
     upload_success = await bucket_service.upload_file(bucket_key=bucket_key,
                                                       file_binary=file.file)

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -96,7 +96,7 @@ async def upload_media(media_id: int = Path(..., gt=0),
 
     # Concatenate the first 32 chars (to avoid system interactions issues) of SHA256 hash with file extension
     bucket_key = f"{hash_content_file(file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
-    # Reset byte position of the file as per https://fastapi.tiangolo.com/tutorial/request-files/#uploadfile
+    # Reset byte position of the file (cf. https://fastapi.tiangolo.com/tutorial/request-files/#uploadfile)
     await file.seek(0)
     # If files are in a subfolder of the bucket
     if "/" in cfg.BUCKET_NAME:

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -97,7 +97,7 @@ async def upload_media(media_id: int = Path(..., gt=0),
     # Concatenate the first 32 chars (to avoid system interactions issues) of SHA256 hash with file extension
     bucket_key = f"{hash_content_file(file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
     # Reset byte position of the file as per https://fastapi.tiangolo.com/tutorial/request-files/#uploadfile
-    file.seek(0)
+    await file.seek(0)
     # If files are in a subfolder of the bucket
     if "/" in cfg.BUCKET_NAME:
         bucket_key = f"{cfg.BUCKET_NAME[cfg.BUCKET_NAME.find('/') + 1:]}/{bucket_key}"

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -95,7 +95,7 @@ async def upload_media(media_id: int = Path(..., gt=0),
     entry = await check_for_media_existence(media_id, current_device.id)
 
     # Concatenate the first 32 chars (to avoid system interactions issues) of SHA256 hash with file extension
-    bucket_key = f"{hash_content_file(await file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
+    bucket_key = f"{hash_content_file(await file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
     # If files are in a subfolder of the bucket
     if "/" in cfg.BUCKET_NAME:
         bucket_key = f"{cfg.BUCKET_NAME[cfg.BUCKET_NAME.find('/') + 1:]}/{bucket_key}"

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -95,7 +95,7 @@ async def upload_media(media_id: int = Path(..., gt=0),
     entry = await check_for_media_existence(media_id, current_device.id)
 
     # Concatenate the first 32 chars (to avoid system interactions issues) of SHA256 hash with file extension
-    bucket_key = f"{hash_content_file(file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
+    bucket_key = f"{hash_content_file(await file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
     # If files are in a subfolder of the bucket
     if "/" in cfg.BUCKET_NAME:
         bucket_key = f"{cfg.BUCKET_NAME[cfg.BUCKET_NAME.find('/') + 1:]}/{bucket_key}"

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -3,6 +3,7 @@ from fastapi.responses import StreamingResponse
 from typing import List
 from datetime import datetime
 
+import app.config as cfg
 from app.api import crud
 from app.db import media
 from app.api.schemas import MediaOut, MediaIn, MediaCreation, MediaUrl, DeviceOut, BaseMedia
@@ -95,6 +96,9 @@ async def upload_media(media_id: int = Path(..., gt=0),
 
     # Concatenate the first 32 chars (to avoid system interactions issues) of SHA256 hash with file extension
     bucket_key = f"{hash_content_file(file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
+    # If files are in a subfolder of the bucket
+    if "/" in cfg.BUCKET_NAME:
+        bucket_key = f"{cfg.BUCKET_NAME[cfg.BUCKET_NAME.find('/'):]}/{bucket_key}"
 
     upload_success = await bucket_service.upload_file(bucket_key=bucket_key,
                                                       file_binary=file.file)

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -8,7 +8,7 @@ from app.db import media
 from app.api.schemas import MediaOut, MediaIn, MediaCreation, MediaUrl, DeviceOut, BaseMedia
 from app.api.deps import get_current_device, get_current_user
 from app.api.security import hash_content_file
-from app.services import bucket_service, prepend_bucket_folder
+from app.services import bucket_service, resolve_bucket_key
 
 
 router = APIRouter()
@@ -98,7 +98,7 @@ async def upload_media(media_id: int = Path(..., gt=0),
     # Reset byte position of the file (cf. https://fastapi.tiangolo.com/tutorial/request-files/#uploadfile)
     await file.seek(0)
     # If files are in a subfolder of the bucket, prepend the folder path
-    bucket_key = prepend_bucket_folder(file_name)
+    bucket_key = resolve_bucket_key(file_name)
 
     upload_success = await bucket_service.upload_file(bucket_key=bucket_key,
                                                       file_binary=file.file)

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -96,6 +96,8 @@ async def upload_media(media_id: int = Path(..., gt=0),
 
     # Concatenate the first 32 chars (to avoid system interactions issues) of SHA256 hash with file extension
     bucket_key = f"{hash_content_file(file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
+    # Reset byte position of the file as per https://fastapi.tiangolo.com/tutorial/request-files/#uploadfile
+    file.seek(0)
     # If files are in a subfolder of the bucket
     if "/" in cfg.BUCKET_NAME:
         bucket_key = f"{cfg.BUCKET_NAME[cfg.BUCKET_NAME.find('/') + 1:]}/{bucket_key}"

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -95,7 +95,7 @@ async def upload_media(media_id: int = Path(..., gt=0),
     entry = await check_for_media_existence(media_id, current_device.id)
 
     # Concatenate the first 32 chars (to avoid system interactions issues) of SHA256 hash with file extension
-    bucket_key = f"{hash_content_file(await file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
+    bucket_key = f"{hash_content_file(file.file.read())[:32]}.{file.filename.rpartition('.')[-1]}"
     # If files are in a subfolder of the bucket
     if "/" in cfg.BUCKET_NAME:
         bucket_key = f"{cfg.BUCKET_NAME[cfg.BUCKET_NAME.find('/') + 1:]}/{bucket_key}"

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -142,7 +142,7 @@ async def get_media_image(background_tasks: BackgroundTasks,
     if retrieved_file is False:
         raise HTTPException(
             status_code=500,
-            detail="The upload did not succeed"
+            detail="The download did not succeed"
         )
     background_tasks.add_task(bucket_service.flush_after_get_uploaded_file, retrieved_file)
     return StreamingResponse(open(retrieved_file, 'rb'), media_type="image/jpeg")

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -1,1 +1,2 @@
 from .services import *
+from .utils import *

--- a/src/app/services/bucket/qarnotBucketService.py
+++ b/src/app/services/bucket/qarnotBucketService.py
@@ -13,7 +13,7 @@ class QarnotBucketService(BaseBucketService):
     def connect_to_bucket(self):
         if not hasattr(self, 'bucket'):
             conn = connection.Connection(client_token=cfg.QARNOT_TOKEN)
-            self.bucket = bucket.Bucket(conn, cfg.BUCKET_NAME)
+            self.bucket = bucket.Bucket(conn, cfg.BUCKET_NAME.rpartition("/")[0])
         return self.bucket
 
     async def upload_file(self, bucket_key: str, file_binary: bin):

--- a/src/app/services/utils.py
+++ b/src/app/services/utils.py
@@ -2,10 +2,10 @@ from typing import Optional
 
 import app.config as cfg
 
-__all__ = ["prepend_bucket_folder"]
+__all__ = ["resolve_bucket_key"]
 
 
-def prepend_bucket_folder(file_name: str, bucket_folder: Optional[str] = None) -> str:
+def resolve_bucket_key(file_name: str, bucket_folder: Optional[str] = None) -> str:
     """Prepend file name with bucket subfolder"""
 
     if not isinstance(bucket_folder, str) and isinstance(cfg.BUCKET_NAME, str) and "/" in cfg.BUCKET_NAME:

--- a/src/app/services/utils.py
+++ b/src/app/services/utils.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+import app.config as cfg
+
+__all__ = ["prepend_bucket_folder"]
+
+
+def prepend_bucket_folder(file_name: str, bucket_folder: Optional[str] = None) -> str:
+    """Prepend file name with bucket subfolder"""
+
+    if not isinstance(bucket_folder, str) and "/" in cfg.BUCKET_NAME:
+        bucket_folder = cfg.BUCKET_NAME[cfg.BUCKET_NAME.find('/') + 1:]
+
+    return f"{bucket_folder}/{file_name}" if isinstance(bucket_folder, str) else file_name

--- a/src/app/services/utils.py
+++ b/src/app/services/utils.py
@@ -8,7 +8,7 @@ __all__ = ["prepend_bucket_folder"]
 def prepend_bucket_folder(file_name: str, bucket_folder: Optional[str] = None) -> str:
     """Prepend file name with bucket subfolder"""
 
-    if not isinstance(bucket_folder, str) and "/" in cfg.BUCKET_NAME:
+    if not isinstance(bucket_folder, str) and isinstance(cfg.BUCKET_NAME, str) and "/" in cfg.BUCKET_NAME:
         bucket_folder = cfg.BUCKET_NAME[cfg.BUCKET_NAME.find('/') + 1:]
 
     return f"{bucket_folder}/{file_name}" if isinstance(bucket_folder, str) else file_name

--- a/src/tests/test_services.py
+++ b/src/tests/test_services.py
@@ -1,6 +1,23 @@
 from app.services.bucket.baseBucketService import BaseBucketService
-from app.services import bucket_service
+from app.services import bucket_service, resolve_bucket_key
+from app import config as cfg
 
 
 def test_bucket_service_is_BaseBucketService():
     assert isinstance(bucket_service, BaseBucketService), "selected service is not an instance of BaseBucketService"
+
+
+def test_resolve_bucket_key(monkeypatch):
+    file_name = "myfile.jpg"
+    # Check that it returns the same thing when bucket folder is not set
+    assert resolve_bucket_key(file_name) == file_name
+
+    # Check that bucket folder is prepended in bucket key if set
+    bucket_subfolder = "my/bucket/subfolder"
+    origin_value = cfg.BUCKET_NAME
+    monkeypatch.setattr(cfg, "BUCKET_NAME", f"my_bucket_name/{bucket_subfolder}")
+    assert resolve_bucket_key(file_name) == f"{bucket_subfolder}/{file_name}"
+
+    # Same if the bucket folder is specified
+    monkeypatch.setattr(cfg, "BUCKET_NAME", origin_value)
+    assert resolve_bucket_key(file_name, bucket_subfolder) == f"{bucket_subfolder}/{file_name}"


### PR DESCRIPTION
As witnessed over the past day, we've had some troubles with media upload. Some were fixed in #95 and #96 fortunately, but two issues remained: 
- adding the subfolder in the bucket name was not supported by the CSP client
- empty file could be uploaded, if the byte position of a file were to be offset for instance

This PR fixes both issues by adding a generalized bucket key resolution and resetting the byte position after hashing to avoid uploading empty files. I tried it on my end by deploying the feature branch on Heroku, and it works:
![qarnot_bucket](https://user-images.githubusercontent.com/26927750/101555245-8a2e7c00-39b8-11eb-9333-805d6e5f0ccf.png)


Feel free to try by yourself before the next deployment :ok_hand: 

Any feedback is welcome!