### PR TITLE
Align devices update 

### DIFF
--- a/src/app/api/crud/accesses.py
+++ b/src/app/api/crud/accesses.py
@@ -72,7 +72,7 @@ async def create_accessed_entry(
     return entry
 
 
-async def update_accessed_entry(table: Table, accesses: Table, entry_id: int, payload: Any):
+async def update_accessed_entry(table: Table, accesses: Table, entry_id: int, payload: Any, only_provided=False):
     """Update an entry with a special treatment regarding login: if login is set -> update corresponding access."""
     # Ensure database consistency between tables with a transaction (login must remain the same in table & accesses)
     async with base.database.transaction():
@@ -89,7 +89,7 @@ async def update_accessed_entry(table: Table, accesses: Table, entry_id: int, pa
                 await update_login(accesses, payload.login, origin_entry["access_id"])
 
         # Update entry with input payload
-        entry = await base.update_entry(table, payload, entry_id)
+        entry = await base.update_entry(table, payload, entry_id, only_provided)
 
     return entry
 

--- a/src/app/api/crud/accesses.py
+++ b/src/app/api/crud/accesses.py
@@ -72,7 +72,7 @@ async def create_accessed_entry(
     return entry
 
 
-async def update_accessed_entry(table: Table, accesses: Table, entry_id: int, payload: Any, only_provided=False):
+async def update_accessed_entry(table: Table, accesses: Table, entry_id: int, payload: Any, only_specified=True):
     """Update an entry with a special treatment regarding login: if login is set -> update corresponding access."""
     # Ensure database consistency between tables with a transaction (login must remain the same in table & accesses)
     async with base.database.transaction():
@@ -89,7 +89,7 @@ async def update_accessed_entry(table: Table, accesses: Table, entry_id: int, pa
                 await update_login(accesses, payload.login, origin_entry["access_id"])
 
         # Update entry with input payload
-        entry = await base.update_entry(table, payload, entry_id, only_provided)
+        entry = await base.update_entry(table, payload, entry_id, only_specified)
 
     return entry
 

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -74,11 +74,11 @@ async def get_entry(table: Table, entry_id: int = Path(..., gt=0)) -> Dict[str, 
 
 
 async def update_entry(
-    table: Table, payload: BaseModel, entry_id: int = Path(..., gt=0), only_provided: bool = False
+    table: Table, payload: BaseModel, entry_id: int = Path(..., gt=0), only_specified: bool = True
 ) -> Dict[str, Any]:
     payload_dict = payload.dict()
 
-    if only_provided:
+    if only_specified:
         # Dont update columns for null fields
         payload_dict = {k: v for k, v in payload_dict.items() if v is not None}
 
@@ -87,7 +87,7 @@ async def update_entry(
     if not isinstance(entry_id, int):
         raise HTTPException(status_code=404, detail="Entry not found")
 
-    if only_provided:
+    if only_specified:
         # Retrieve complete record values
         return dict(await get(entry_id, table))
     else:

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -50,8 +50,8 @@ async def fetch_one(table: Table, query_filters: Dict[str, Any]) -> Mapping[str,
     return await database.fetch_one(query=query)
 
 
-async def put(entry_id: int, payload: BaseModel, table: Table) -> int:
-    query = table.update().where(entry_id == table.c.id).values(**payload.dict()).returning(table.c.id)
+async def put(entry_id: int, payload: Dict, table: Table) -> int:
+    query = table.update().where(entry_id == table.c.id).values(**payload).returning(table.c.id)
     return await database.execute(query=query)
 
 
@@ -73,13 +73,25 @@ async def get_entry(table: Table, entry_id: int = Path(..., gt=0)) -> Dict[str, 
     return dict(entry)
 
 
-async def update_entry(table: Table, payload: BaseModel, entry_id: int = Path(..., gt=0)) -> Dict[str, Any]:
-    entry_id = await put(entry_id, payload, table)
+async def update_entry(
+    table: Table, payload: BaseModel, entry_id: int = Path(..., gt=0), only_provided: bool = False
+) -> Dict[str, Any]:
+    payload_dict = payload.dict()
+
+    if only_provided:
+        # Dont update columns for null fields
+        payload_dict = {k: v for k, v in payload_dict.items() if v is not None}
+
+    entry_id = await put(entry_id, payload_dict, table)
 
     if not isinstance(entry_id, int):
         raise HTTPException(status_code=404, detail="Entry not found")
 
-    return {**payload.dict(), "id": entry_id}
+    if only_provided:
+        # Retrieve complete record values
+        return dict(await get(entry_id, table))
+    else:
+        return {**payload.dict(), "id": entry_id}
 
 
 async def delete_entry(table: Table, entry_id: int = Path(..., gt=0)) -> Dict[str, Any]:

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -96,7 +96,7 @@ async def heartbeat(device: DeviceOut = Security(get_current_device, scopes=["de
     Updates the last ping of the current device with the current datetime
     """
     device.last_ping = datetime.utcnow()
-    await crud.put(device.id, device, devices)
+    await crud.update_entry(devices, device, device.id)
     return device
 
 
@@ -116,7 +116,7 @@ async def update_device_location(
     # Update only the location
     device.update(payload.dict())
     device = DeviceOut(**device)
-    await crud.put(device.id, device, devices)
+    await crud.update_entry(devices, device, device.id)
     return device
 
 
@@ -130,7 +130,7 @@ async def update_my_location(
     # Update only the position
     for k, v in payload.dict().items():
         setattr(device, k, v)
-    await crud.put(device.id, device, devices)
+    await crud.update_entry(devices, device, device.id)
     return device
 
 

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -71,7 +71,7 @@ async def update_device(
     """
     Based on a device_id, updates information about the specified device
     """
-    return await crud.accesses.update_accessed_entry(devices, accesses, device_id, payload, only_provided=True)
+    return await crud.accesses.update_accessed_entry(devices, accesses, device_id, payload, only_specified=True)
 
 
 @router.delete("/{device_id}/", response_model=DeviceOut, summary="Delete a specific device")

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -65,11 +65,13 @@ async def fetch_devices(_=Security(get_current_user, scopes=["admin"])):
 
 
 @router.put("/{device_id}/", response_model=DeviceOut, summary="Update information about a specific device")
-async def update_device(payload: DeviceIn, device_id: int = Path(..., gt=0)):
+async def update_device(
+    payload: DeviceIn, device_id: int = Path(..., gt=0), _=Security(get_current_user, scopes=["admin"])
+):
     """
     Based on a device_id, updates information about the specified device
     """
-    return await crud.accesses.update_accessed_entry(devices, accesses, device_id, payload)
+    return await crud.accesses.update_accessed_entry(devices, accesses, device_id, payload, only_provided=True)
 
 
 @router.delete("/{device_id}/", response_model=DeviceOut, summary="Delete a specific device")

--- a/src/tests/routes/test_devices.py
+++ b/src/tests/routes/test_devices.py
@@ -172,18 +172,26 @@ async def test_register_my_device_invalid(test_app_asyncio, test_db, monkeypatch
     assert response.status_code == status_code, print(payload)
 
 
+@pytest.mark.parametrize(
+    "device_id, payload, status_code",
+    [
+        [1, {"login": "renamed_device", "owner_id": 1, "access_id": 3, "specs": "v0.1"}, 200],
+        [1, {"login": "renamed_device", "owner_id": 1, "access_id": 3, "specs": "v0.1", "yaw": 8}, 200],
+    ]
+)
 @pytest.mark.asyncio
-async def test_update_device(test_app_asyncio, test_db, monkeypatch):
+async def test_update_device(test_app_asyncio, test_db, monkeypatch, device_id, payload, status_code):
     # Sterilize DB interactions
     await init_test_db(monkeypatch, test_db)
 
-    test_payload = {"login": "renamed_device", "owner_id": 1, "access_id": 3, "specs": "v0.1"}
-    response = await test_app_asyncio.put("/devices/1/", data=json.dumps(test_payload))
-    assert response.status_code == 200
-    updated_device_in_db = await get_entry_in_db(test_db, db.devices, 1)
+    response = await test_app_asyncio.put(f"/devices/{device_id}/", data=json.dumps(payload))
+    assert response.status_code == status_code
+
+    updated_device_in_db = await get_entry_in_db(test_db, db.devices, device_id)
     updated_device_in_db = dict(**updated_device_in_db)
+
     for k, v in updated_device_in_db.items():
-        assert v == test_payload.get(k, DEVICE_TABLE_FOR_DB[0][k])
+        assert v == payload.get(k, DEVICE_TABLE_FOR_DB[0][k])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Relates to discussion in #45 (devices route) and closes #103 for the route `PUT /devices/{device_id}/`

* Add admin scope (let's say that only admin can change the `owner_id`)
* Use the option `only_provided` defined in `crud.update_entry` that updates only the fields provided in the payload (eg. the admin only updates the `owner_id`, the device still gets its position, etc.)
* Change low level `payload` argument of crud.base.put to dictionary instead of `pydantic.BaseModel` & migrate routes that used the function
* Add the only_provided option that remove None values from payload, retrieve from table record afterwards to get all fields ? Waiting for feedbacks on this one


This is first iteration, more concret than issue comments haha
