### PR TITLE
feat: Added proper scopes to media routes

### DIFF
--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -94,7 +94,7 @@ async def delete_media(media_id: int = Path(..., gt=0), _=Security(get_current_a
 
 
 @router.post("/{media_id}/upload", response_model=MediaOut, status_code=200)
-async def upload_media(
+async def upload_media_from_device(
     background_tasks: BackgroundTasks,
     media_id: int = Path(..., gt=0),
     file: UploadFile = File(...),

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -58,7 +58,7 @@ async def create_media_from_device(payload: BaseMedia,
 
 
 @router.get("/{media_id}/", response_model=MediaOut, summary="Get information about a specific media")
-async def get_media(media_id: int = Path(..., gt=0)):
+async def get_media(media_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=["admin"])):
     """
     Based on a media_id, retrieves information about the specified media
     """
@@ -66,7 +66,7 @@ async def get_media(media_id: int = Path(..., gt=0)):
 
 
 @router.get("/", response_model=List[MediaOut], summary="Get the list of all media")
-async def fetch_media():
+async def fetch_media( _=Security(get_current_access, scopes=["admin"])):
     """
     Retrieves the list of all media and their information
     """

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -66,7 +66,7 @@ async def get_media(media_id: int = Path(..., gt=0), _=Security(get_current_acce
 
 
 @router.get("/", response_model=List[MediaOut], summary="Get the list of all media")
-async def fetch_media( _=Security(get_current_access, scopes=["admin"])):
+async def fetch_media(_=Security(get_current_access, scopes=["admin"])):
     """
     Retrieves the list of all media and their information
     """

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -26,19 +26,17 @@ USER_TABLE = [
     {"id": 2, "login": "connected_user", "access_id": 2, "created_at": "2020-11-13T08:18:45.447773"},
 ]
 
-DEVICE_TABLE = [{"id": 1, "login": "connected_device", "owner_id": 1,
-                 "access_id": 3, "specs": "raspberry", "elevation": None, "lat": None,
-                 "lon": None, "yaw": None, "pitch": None,
-                 "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
-                {"id": 2, "login": "second_device", "owner_id": 2,
-                 "access_id": 4, "specs": "v0.1", "elevation": None, "lat": None,
-                 "lon": None, "yaw": None, "pitch": None,
-                 "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
-                {"id": 3, "login": "third_device", "owner_id": 1,
-                 "access_id": 5, "specs": "v0.1", "elevation": None,
-                 "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None,
-                 "created_at": "2020-10-13T08:18:45.447773"}
-                ]
+DEVICE_TABLE = [
+    {"id": 1, "login": "connected_device", "owner_id": 1, "access_id": 3, "specs": "raspberry",
+     "elevation": None, "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None,
+     "created_at": "2020-10-13T08:18:45.447773"},
+    {"id": 2, "login": "second_device", "owner_id": 2, "access_id": 4, "specs": "v0.1",
+     "elevation": None, "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None,
+     "created_at": "2020-10-13T08:18:45.447773"},
+    {"id": 3, "login": "third_device", "owner_id": 1, "access_id": 5, "specs": "v0.1",
+     "elevation": None, "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None,
+     "created_at": "2020-10-13T08:18:45.447773"},
+]
 
 CONNECTED_DEVICE_ID = 3
 


### PR DESCRIPTION
Following up on #45, this PR introduces the following modifications:
- renamed the media upload route
- added admin scope to media get and fetch routes
- reindented the table in the media route

Any feedback is welcome!

_Note: I think there is an issue with our unittests regarding Security/get_current_access. When I test it manually, the changes from this PR do work. But this means that the current unittests should fail (because the default current access doesn't have admin scope). I'll open an issue about this #119_