### PR TITLE
feat: Added is_trustworthy boolean field to installation table

### DIFF
--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -191,6 +191,7 @@ class InstallationIn(Location, _Rotation):
     site_id: int = Field(..., gt=0)
     start_ts: datetime
     end_ts: datetime = None
+    is_trustworthy: bool = Field(True)
 
 
 class InstallationOut(InstallationIn, _CreatedAt, _Id):

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -122,6 +122,7 @@ installations = Table(
     Column("pitch", Float(1, asdecimal=True)),
     Column("start_ts", DateTime, nullable=False),
     Column("end_ts", DateTime, default=None, nullable=True),
+    Column("is_trustworthy", Boolean, default=True),
     Column("created_at", DateTime, default=func.now()),
 )
 


### PR DESCRIPTION
Following up on #123, this PR introduces the following modifications:
- added a boolean field `is_trustworthy` to the installation (default to True)
- added unittest cases to ensure the default value is True and check payload & response

Resolves #123

Any feedback is welcome!