### PR TITLE
feat: Added azimuth float field to alert table

### DIFF
--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -206,6 +206,7 @@ class AlertBase(_FlatLocation, AlertMediaId):
     event_id: int = Field(..., gt=0)
     type: AlertType = AlertType.start
     is_acknowledged: bool = Field(False)
+    azimuth: float = Field(default=None, gt=0, lt=360)
 
 
 class AlertIn(AlertBase):

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -138,7 +138,7 @@ alerts = Table(
     Column("device_id", Integer, ForeignKey("devices.id")),
     Column("event_id", Integer, ForeignKey("events.id")),
     Column("media_id", Integer, ForeignKey("media.id"), default=None),
-    Column("azimuth", Float(4, asdecimal=True, default=None)),
+    Column("azimuth", Float(4, asdecimal=True), default=None),
     Column("lat", Float(4, asdecimal=True)),
     Column("lon", Float(4, asdecimal=True)),
     Column("type", Enum(AlertType), default=AlertType.start),

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -138,6 +138,7 @@ alerts = Table(
     Column("device_id", Integer, ForeignKey("devices.id")),
     Column("event_id", Integer, ForeignKey("events.id")),
     Column("media_id", Integer, ForeignKey("media.id"), default=None),
+    Column("azimuth", Float(4, asdecimal=True, default=None)),
     Column("lat", Float(4, asdecimal=True)),
     Column("lon", Float(4, asdecimal=True)),
     Column("type", Enum(AlertType), default=AlertType.start),


### PR DESCRIPTION
Following up on #126, this PR introduces the following modifications:
- added a float field `azimuth` to the alert table (default to `None`)
- added unittest cases to ensure default value and value constraints (between 0 and 360), check payload & response

Resolves #126

Any feedback is welcome!