### PR TITLE
feat: Added no_alert type to Sites

### DIFF
--- a/src/app/api/routes/sites.py
+++ b/src/app/api/routes/sites.py
@@ -6,8 +6,8 @@
 from typing import List
 from fastapi import APIRouter, Path, Security
 from app.api import crud
-from app.db import sites
-from app.api.schemas import SiteOut, SiteIn
+from app.db import sites, SiteType
+from app.api.schemas import SiteOut, SiteIn, SiteBase
 from app.api.deps import get_current_access
 
 
@@ -22,6 +22,17 @@ async def create_site(payload: SiteIn, _=Security(get_current_access, scopes=["a
     or "Example Value" to get a concrete idea of arguments
     """
     return await crud.create_entry(sites, payload)
+
+
+@router.post("/no-alert/", response_model=SiteOut, status_code=201, summary="Create a new no-alert site")
+async def create_noalert_site(payload: SiteBase, _=Security(get_current_access, scopes=["user"])):
+    """Creates a new no-alert site based on the given information
+
+    Below, click on "Schema" for more detailed information about arguments
+    or "Example Value" to get a concrete idea of arguments
+    """
+
+    return await crud.create_entry(sites, SiteIn(**payload, type=SiteType.no_alert))
 
 
 @router.get("/{site_id}/", response_model=SiteOut, summary="Get information about a specific site")

--- a/src/app/api/routes/sites.py
+++ b/src/app/api/routes/sites.py
@@ -32,7 +32,7 @@ async def create_noalert_site(payload: SiteBase, _=Security(get_current_access, 
     or "Example Value" to get a concrete idea of arguments
     """
 
-    return await crud.create_entry(sites, SiteIn(**payload, type=SiteType.no_alert))
+    return await crud.create_entry(sites, SiteIn(**payload.dict(), type=SiteType.no_alert))
 
 
 @router.get("/{site_id}/", response_model=SiteOut, summary="Get information about a specific site")

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -116,11 +116,14 @@ class DefaultPosition(DefaultLocation, _DefaultRotation):
 
 
 # Sites
-class SiteIn(_FlatLocation):
+class SiteBase(_FlatLocation):
     name: str = Field(..., min_length=3, max_length=50, example="watchtower12")
-    type: SiteType = SiteType.tower
     country: str = Field(..., max_length=5, example="FR")
     geocode: str = Field(..., max_length=10, example="01")
+
+
+class SiteIn(SiteBase):
+    type: SiteType = SiteType.tower
 
 
 class SiteOut(SiteIn, _CreatedAt, _Id):

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -41,6 +41,7 @@ accesses = Table(
 class SiteType(str, enum.Enum):
     tower: str = 'tower'
     station: str = 'station'
+    no_alert: str = 'no_alert'
 
 
 sites = Table(


### PR DESCRIPTION
Following up on #124, this PR introduces the following modifications:
- added a new site type (still default to `tower`)
- added a new route to create sites that doesn't require admin rights but enforces `type='no_alert'` so that users can create them
- added unittest cases to ensure default value, check payload & response

Resolves #124

Any feedback is welcome!