### PR TITLE
feat: Added angle_of_view to the device table

### DIFF
--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -142,6 +142,7 @@ class EventOut(EventIn, _CreatedAt, _Id):
 class MyDeviceIn(Login, DefaultPosition):
     specs: str = Field(..., min_length=3, max_length=100, example="systemV0.1")
     last_ping: datetime = Field(default=None, example=datetime.utcnow())
+    angle_of_view: float = Field(..., gt=0, lt=360)
 
 
 class DeviceIn(MyDeviceIn):

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -83,6 +83,7 @@ devices = Table(
     Column("owner_id", Integer, ForeignKey("users.id")),
     Column("access_id", Integer, ForeignKey("accesses.id"), unique=True),
     Column("specs", String(50)),
+    Column("angle_of_view", Float(2, asdecimal=True)),
     Column("elevation", Float(1, asdecimal=True), default=None, nullable=True),
     Column("lat", Float(4, asdecimal=True), default=None, nullable=True),
     Column("lon", Float(4, asdecimal=True), default=None, nullable=True),

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -24,7 +24,8 @@ async def mock_current_access():
 
 
 async def mock_current_device():
-    return DeviceOut(id=3, owner_id=1, specs="raspberry", login="connected_device", created_at=datetime.now())
+    return DeviceOut(id=3, owner_id=1, specs="raspberry", login="connected_device", angle_of_view=68.,
+                     created_at=datetime.now())
 
 
 async def mock_hash_password(password):

--- a/src/tests/routes/test_alerts.py
+++ b/src/tests/routes/test_alerts.py
@@ -34,11 +34,13 @@ USER_TABLE = [
 DEVICE_TABLE = [
     {"id": 1, "login": "first_device", "owner_id": 1,
      "access_id": 3, "specs": "v0.1", "elevation": None, "lat": None,
-     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
+     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68.,
+     "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 2, "login": "second_device", "owner_id": 2, "access_id": 4, "specs": "v0.1", "elevation": None, "lat": None,
-     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
+     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68.,
+     "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 3, "login": "connected_device", "owner_id": 1, "access_id": 5, "specs": "raspberry", "elevation": None,
-     "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None,
+     "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68.,
      "created_at": "2020-10-13T08:18:45.447773"},
 ]
 

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -27,13 +27,13 @@ USER_TABLE = [
 ]
 
 DEVICE_TABLE = [
-    {"id": 1, "login": "connected_device", "owner_id": 1, "access_id": 3, "specs": "raspberry",
+    {"id": 1, "login": "connected_device", "owner_id": 1, "access_id": 3, "specs": "raspberry", "angle_of_view": 68.,
      "elevation": None, "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None,
      "created_at": "2020-10-13T08:18:45.447773"},
-    {"id": 2, "login": "second_device", "owner_id": 2, "access_id": 4, "specs": "v0.1",
+    {"id": 2, "login": "second_device", "owner_id": 2, "access_id": 4, "specs": "v0.1", "angle_of_view": 68.,
      "elevation": None, "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None,
      "created_at": "2020-10-13T08:18:45.447773"},
-    {"id": 3, "login": "third_device", "owner_id": 1, "access_id": 5, "specs": "v0.1",
+    {"id": 3, "login": "third_device", "owner_id": 1, "access_id": 5, "specs": "v0.1", "angle_of_view": 68.,
      "elevation": None, "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None,
      "created_at": "2020-10-13T08:18:45.447773"},
 ]

--- a/src/tests/test_deps.py
+++ b/src/tests/test_deps.py
@@ -18,12 +18,13 @@ USER_TABLE = [
 
 DEVICE_TABLE = [
     {"id": 1, "login": "connected_device", "owner_id": 1, "access_id": 3,
-     "specs": "raspberry", "elevation": None, "lat": None,
+     "specs": "raspberry", "elevation": None, "lat": None, "angle_of_view": 68,
      "lon": None, "yaw": None, "pitch": None, "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 2, "login": "second_device", "owner_id": 2, "access_id": 4, "specs": "v0.1", "elevation": None, "lat": None,
-     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
+     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68,
+     "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 3, "login": "third_device", "owner_id": 1, "access_id": 5, "specs": "v0.1", "elevation": None,
-     "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None,
+     "lat": None, "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68,
      "created_at": "2020-10-13T08:18:45.447773"},
 ]
 


### PR DESCRIPTION
Following up on #131, this PR introduces the following modifications:
- added a float field `angle_of_view` to the device table (mandatory in payload)
- added unittest cases to ensure  value constraints (between 0 and 360), check payload & response
- updated other unittests to make it compatible

Resolves #131

Any feedback is welcome!