### PR TITLE
feat: Added group_id to access table

### DIFF
--- a/scripts/api_e2e.py
+++ b/scripts/api_e2e.py
@@ -49,7 +49,7 @@ def main(args):
     user_pwd = 'my_pwd'
 
     # create a user
-    payload = dict(login=user_login, password=user_pwd, scopes="user")
+    payload = dict(login=user_login, password=user_pwd, scope="user")
     user_id = api_request('post', f"{api_url}/users/", superuser_auth, payload)['id']
     user_auth = {
         "Authorization": f"Bearer {get_token(api_url, user_login, user_pwd)}",

--- a/src/app/api/crud/accesses.py
+++ b/src/app/api/crud/accesses.py
@@ -36,14 +36,14 @@ async def update_login(accesses: Table, login: str, access_id: int):
     return await base.update_entry(accesses, Login(login=login), access_id)
 
 
-async def post_access(accesses: Table, login: str, password: str, scopes: str) -> AccessRead:
+async def post_access(accesses: Table, login: str, password: str, scope: str) -> AccessRead:
     """Insert an access entry in the accesses table, call within a transaction to reuse returned access id."""
     await check_login_existence(accesses, login)
 
     # Hash the password
     pwd = await security.hash_password(password)
 
-    access = AccessCreation(login=login, hashed_password=pwd, scopes=scopes)
+    access = AccessCreation(login=login, hashed_password=pwd, scope=scope)
     entry = await base.create_entry(accesses, access)
 
     return AccessRead(**entry)
@@ -66,7 +66,7 @@ async def create_accessed_entry(
     """Create an access and refers it to a new entry (User, Device, ...)."""
     # Ensure database consistency between tables with a transaction
     async with base.database.transaction():
-        access_entry = await post_access(accesses, payload.login, payload.password, payload.scopes)
+        access_entry = await post_access(accesses, payload.login, payload.password, payload.scope)
         entry = await base.create_entry(table, schema(**payload.dict(), access_id=access_entry.id))
 
     return entry

--- a/src/app/api/routes/login.py
+++ b/src/app/api/routes/login.py
@@ -30,7 +30,7 @@ async def create_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
     if entry is None or not await security.verify_password(form_data.password, entry['hashed_password']):
         raise HTTPException(status_code=400, detail="Invalid credentials")
     # create access token using user user_id/user_scopes
-    token_data = {"sub": str(entry['id']), "scopes": entry['scopes'].split()}
+    token_data = {"sub": str(entry['id']), "scopes": entry['scope'].split()}
     if entry["scopes"] == "device":
         token = await security.create_unlimited_access_token(token_data)
     else:

--- a/src/app/api/routes/login.py
+++ b/src/app/api/routes/login.py
@@ -31,7 +31,7 @@ async def create_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
         raise HTTPException(status_code=400, detail="Invalid credentials")
     # create access token using user user_id/user_scopes
     token_data = {"sub": str(entry['id']), "scopes": entry['scope'].split()}
-    if entry["scopes"] == "device":
+    if entry["scope"] == "device":
         token = await security.create_unlimited_access_token(token_data)
     else:
         token = await security.create_access_token(token_data,

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -39,6 +39,7 @@ class CredHash(BaseModel):
 
 class AccessBase(Login):
     scope: AccessType = AccessType.user
+    group_id: int = Field(None, gt=0)
 
 
 class AccessAuth(AccessBase, Cred):

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -38,7 +38,7 @@ class CredHash(BaseModel):
 
 
 class AccessBase(Login):
-    scopes: AccessType = AccessType.user
+    scope: AccessType = AccessType.user
 
 
 class AccessAuth(AccessBase, Cred):
@@ -66,7 +66,7 @@ class UserRead(UserInfo, _CreatedAt, _Id):
 
 class UserAuth(UserInfo, Cred):
     # Authentication request
-    scopes: AccessType = AccessType.user
+    scope: AccessType = AccessType.user
 
 
 class UserCreation(UserInfo):

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -163,11 +163,11 @@ class DeviceIn(MyDeviceIn):
 
 
 class MyDeviceAuth(MyDeviceIn, Cred):
-    scopes: AccessType = AccessType.device
+    scope: AccessType = AccessType.device
 
 
 class DeviceAuth(DeviceIn, Cred):
-    scopes: AccessType = AccessType.device
+    scope: AccessType = AccessType.device
 
 
 class DeviceCreation(DeviceIn):

--- a/src/app/db/init_db.py
+++ b/src/app/db/init_db.py
@@ -20,7 +20,7 @@ async def init_db():
 
         hashed_password = await hash_password(cfg.SUPERUSER_PWD)
 
-        access = AccessCreation(login=login, hashed_password=hashed_password, scopes="admin")
+        access = AccessCreation(login=login, hashed_password=hashed_password, scope="admin")
         access_entry = await crud.create_entry(accesses, access)
 
         await crud.create_entry(users, UserCreation(login=login, access_id=access_entry["id"]))

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -42,6 +42,7 @@ accesses = Table(
     Column("login", String(50), unique=True, index=True),  # index for fast lookup
     Column("hashed_password", String(70), nullable=False),
     Column("scope", Enum(AccessType), default=AccessType.user, nullable=False),
+    Column("group_id", Integer, ForeignKey("groups.id"), default=None),
 )
 
 groups = Table(

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -49,7 +49,6 @@ groups = Table(
     metadata,
     Column("id", Integer, primary_key=True),
     Column("name", String(50), unique=True),
-    Column("created_at", DateTime, default=func.now())
 )
 
 

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -41,7 +41,7 @@ accesses = Table(
     Column("id", Integer, primary_key=True),
     Column("login", String(50), unique=True, index=True),  # index for fast lookup
     Column("hashed_password", String(70), nullable=False),
-    Column("scopes", Enum(AccessType), default=AccessType.user, nullable=False),
+    Column("scope", Enum(AccessType), default=AccessType.user, nullable=False),
 )
 
 groups = Table(

--- a/src/tests/routes/test_accesses.py
+++ b/src/tests/routes/test_accesses.py
@@ -10,16 +10,21 @@ from app.api import crud
 from tests.db_utils import fill_table
 
 
+GROUP_TABLE = [
+    {"id": 1, "name": "first_group"},
+]
+
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
-    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user", "group_id": 1},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin", "group_id": None},
+    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device", "group_id": 1},
 ]
 
 
 @pytest.fixture(scope="function")
 async def init_test_db(monkeypatch, test_db):
     monkeypatch.setattr(crud.base, "database", test_db)
+    await fill_table(test_db, db.groups, GROUP_TABLE)
     await fill_table(test_db, db.accesses, ACCESS_TABLE)
 
 

--- a/src/tests/routes/test_accesses.py
+++ b/src/tests/routes/test_accesses.py
@@ -11,9 +11,9 @@ from tests.db_utils import fill_table
 
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scopes": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scopes": "admin"},
-    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scopes": "device"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
+    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
 
@@ -38,7 +38,7 @@ async def init_test_db(monkeypatch, test_db):
 async def test_get_access(init_test_db, test_app_asyncio, access_idx, access_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get(f"/accesses/{access_id}", headers=auth)
     assert response.status_code == status_code
@@ -66,7 +66,7 @@ async def test_get_access(init_test_db, test_app_asyncio, access_idx, access_id,
 async def test_fetch_accesses(init_test_db, test_app_asyncio, access_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/accesses/", headers=auth)
     assert response.status_code == status_code

--- a/src/tests/routes/test_alerts.py
+++ b/src/tests/routes/test_alerts.py
@@ -29,10 +29,10 @@ DEVICE_TABLE = [
 ]
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scopes": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scopes": "admin"},
-    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scopes": "device"},
-    {"id": 4, "login": "fourth_login", "hashed_password": "hashed_pwd", "scopes": "device"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
+    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 4, "login": "fourth_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
 MEDIA_TABLE = [
@@ -91,7 +91,7 @@ async def init_test_db(monkeypatch, test_db):
 async def test_get_alert(test_app_asyncio, init_test_db, access_idx, alert_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get(f"/alerts/{alert_id}", headers=auth)
     assert response.status_code == status_code
@@ -116,7 +116,7 @@ async def test_get_alert(test_app_asyncio, init_test_db, access_idx, alert_id, s
 async def test_fetch_alerts(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/alerts/", headers=auth)
     assert response.status_code == status_code
@@ -139,7 +139,7 @@ async def test_fetch_alerts(test_app_asyncio, init_test_db, access_idx, status_c
 async def test_fetch_ongoing_alerts(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/alerts/ongoing", headers=auth)
     assert response.status_code == status_code
@@ -162,7 +162,7 @@ async def test_fetch_ongoing_alerts(test_app_asyncio, init_test_db, access_idx, 
 async def test_fetch_unacknowledged_alerts(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/alerts/unacknowledged", headers=auth)
     assert response.status_code == status_code
@@ -191,7 +191,7 @@ async def test_create_alert(test_app_asyncio, init_test_db, test_db,
                             access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     utc_dt = datetime.utcnow()
     response = await test_app_asyncio.post("/alerts/", data=json.dumps(payload), headers=auth)
@@ -223,7 +223,7 @@ async def test_create_alert_by_device(test_app_asyncio, init_test_db, test_db,
                                       access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     utc_dt = datetime.utcnow()
     response = await test_app_asyncio.post("/alerts/from-device", data=json.dumps(payload), headers=auth)
@@ -274,7 +274,7 @@ async def test_update_alert(test_app_asyncio, init_test_db, test_db,
                             access_idx, payload, alert_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/alerts/{alert_id}/", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -300,7 +300,7 @@ async def test_acknowledge_alert(test_app_asyncio, init_test_db, test_db,
                                  access_idx, alert_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/alerts/{alert_id}/acknowledge", headers=auth)
     assert response.status_code == status_code
@@ -327,7 +327,7 @@ async def test_acknowledge_alert(test_app_asyncio, init_test_db, test_db,
 async def test_delete_alert(test_app_asyncio, init_test_db, access_idx, alert_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.delete(f"/alerts/{alert_id}/", headers=auth)
     assert response.status_code == status_code
@@ -355,7 +355,7 @@ async def test_link_media(test_app_asyncio, init_test_db, test_db,
                           access_idx, payload, alert_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
     response = await test_app_asyncio.put(f"/alerts/{alert_id}/link-media", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
     if isinstance(status_details, str):

--- a/src/tests/routes/test_devices.py
+++ b/src/tests/routes/test_devices.py
@@ -27,10 +27,10 @@ DEVICE_TABLE = [
 ]
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scopes": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scopes": "admin"},
-    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scopes": "device"},
-    {"id": 4, "login": "fourth_login", "hashed_password": "hashed_pwd", "scopes": "device"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
+    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 4, "login": "fourth_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
 USER_TABLE_FOR_DB = list(map(update_only_datetime, USER_TABLE))
@@ -60,7 +60,7 @@ async def init_test_db(monkeypatch, test_db):
 async def test_get_device(test_app_asyncio, init_test_db, access_idx, device_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get(f"/devices/{device_id}", headers=auth)
     assert response.status_code == status_code
@@ -82,7 +82,7 @@ async def test_get_device(test_app_asyncio, init_test_db, access_idx, device_id,
 async def test_fetch_devices(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/devices/", headers=auth)
     assert response.status_code == status_code
@@ -105,7 +105,7 @@ async def test_fetch_devices(test_app_asyncio, init_test_db, access_idx, status_
 async def test_fetch_my_devices(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/devices/my-devices", headers=auth)
     assert response.status_code == status_code
@@ -150,7 +150,7 @@ async def test_register_device(test_app_asyncio, init_test_db, test_db,
                                access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     utc_dt = datetime.utcnow()
     response = await test_app_asyncio.post("/devices/", data=json.dumps(payload), headers=auth)
@@ -202,7 +202,7 @@ async def test_register_my_device(test_app_asyncio, init_test_db, test_db,
                                   access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     utc_dt = datetime.utcnow()
     response = await test_app_asyncio.post("/devices/register", data=json.dumps(payload), headers=auth)
@@ -267,7 +267,7 @@ async def test_update_device(test_app_asyncio, init_test_db, test_db,
                              access_idx, payload, device_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/devices/{device_id}/", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -307,7 +307,7 @@ async def test_update_device_location(test_app_asyncio, init_test_db, test_db,
                                       access_idx, payload, device_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/devices/{device_id}/location", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -336,7 +336,7 @@ async def test_update_my_location(test_app_asyncio, init_test_db, test_db,
                                   access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put("/devices/my-location", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -375,7 +375,7 @@ async def test_update_device_password(test_app_asyncio, init_test_db, test_db,
                                       access_idx, payload, device_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/devices/{device_id}/pwd", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -401,7 +401,7 @@ async def test_update_device_password(test_app_asyncio, init_test_db, test_db,
 async def test_heartbeat(test_app_asyncio, init_test_db, test_db, access_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     utc_dt = datetime.utcnow()
 
@@ -440,7 +440,7 @@ async def test_heartbeat(test_app_asyncio, init_test_db, test_db, access_idx, st
 async def test_delete_device(test_app_asyncio, init_test_db, access_idx, device_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.delete(f"/devices/{device_id}/", headers=auth)
     assert response.status_code == status_code

--- a/src/tests/routes/test_events.py
+++ b/src/tests/routes/test_events.py
@@ -23,9 +23,9 @@ EVENT_TABLE = [
 ]
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scopes": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scopes": "admin"},
-    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scopes": "device"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
+    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
 
@@ -91,7 +91,7 @@ async def test_create_event(test_app_asyncio, init_test_db, test_db,
                             access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     test_response = {"id": len(EVENT_TABLE) + 1, **payload}
 
@@ -129,7 +129,7 @@ async def test_update_event(test_app_asyncio, init_test_db, test_db,
                             access_idx, payload, event_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/events/{event_id}/", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -158,7 +158,7 @@ async def test_update_event(test_app_asyncio, init_test_db, test_db,
 async def test_delete_event(test_app_asyncio, init_test_db, access_idx, event_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.delete(f"/events/{event_id}/", headers=auth)
     assert response.status_code == status_code

--- a/src/tests/routes/test_groups.py
+++ b/src/tests/routes/test_groups.py
@@ -83,7 +83,6 @@ async def test_create_group(test_app_asyncio, init_test_db, test_db,
 
     test_response = {"id": len(GROUP_TABLE) + 1, **payload}
 
-    utc_dt = datetime.utcnow()
     response = await test_app_asyncio.post("/groups/", data=json.dumps(payload), headers=auth)
 
     assert response.status_code == status_code
@@ -94,9 +93,6 @@ async def test_create_group(test_app_asyncio, init_test_db, test_db,
     if response.status_code // 100 == 2:
         json_response = response.json()
         assert {k: v for k, v in json_response.items() if k != 'created_at'} == test_response
-        new_group_in_db = await get_entry(test_db, db.groups, json_response["id"])
-        new_group_in_db = dict(**new_group_in_db)
-        assert new_group_in_db['created_at'] > utc_dt and new_group_in_db['created_at'] < datetime.utcnow()
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_groups.py
+++ b/src/tests/routes/test_groups.py
@@ -19,9 +19,9 @@ GROUP_TABLE = [
 
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scopes": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scopes": "admin"},
-    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scopes": "device"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
+    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
 
@@ -79,7 +79,7 @@ async def test_create_group(test_app_asyncio, init_test_db, test_db,
                             access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     test_response = {"id": len(GROUP_TABLE) + 1, **payload}
 
@@ -117,7 +117,7 @@ async def test_update_group(test_app_asyncio, init_test_db, test_db,
                             access_idx, payload, group_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/groups/{group_id}/", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -145,7 +145,7 @@ async def test_update_group(test_app_asyncio, init_test_db, test_db,
 async def test_delete_group(test_app_asyncio, init_test_db, access_idx, group_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.delete(f"/groups/{group_id}/", headers=auth)
     assert response.status_code == status_code

--- a/src/tests/routes/test_groups.py
+++ b/src/tests/routes/test_groups.py
@@ -13,8 +13,8 @@ from tests.db_utils import get_entry, fill_table
 from tests.utils import update_only_datetime
 
 GROUP_TABLE = [
-    {"id": 1, "name": "first_group", "created_at": "2020-10-13T08:18:45.447773"},
-    {"id": 2, "name": "second_group", "created_at": "2020-09-13T08:18:45.447773"}
+    {"id": 1, "name": "first_group"},
+    {"id": 2, "name": "second_group"}
 ]
 
 

--- a/src/tests/routes/test_installations.py
+++ b/src/tests/routes/test_installations.py
@@ -28,10 +28,10 @@ DEVICE_TABLE = [
 ]
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scopes": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scopes": "admin"},
-    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scopes": "device"},
-    {"id": 4, "login": "fourth_login", "hashed_password": "hashed_pwd", "scopes": "device"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
+    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 4, "login": "fourth_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
 SITE_TABLE = [
@@ -81,7 +81,7 @@ async def test_get_installation(test_app_asyncio, init_test_db,
                                 access_idx, installation_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get(f"/installations/{installation_id}", headers=auth)
     assert response.status_code == status_code
@@ -103,7 +103,7 @@ async def test_get_installation(test_app_asyncio, init_test_db,
 async def test_fetch_installations(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/installations/", headers=auth)
     assert response.status_code == status_code
@@ -139,7 +139,7 @@ async def test_create_installation(test_app_asyncio, init_test_db, test_db,
                                    access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     utc_dt = datetime.utcnow()
     response = await test_app_asyncio.post("/installations/", data=json.dumps(payload), headers=auth)
@@ -195,7 +195,7 @@ async def test_update_installation(test_app_asyncio, init_test_db, test_db,
                                    access_idx, payload, installation_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/installations/{installation_id}/", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -227,7 +227,7 @@ async def test_delete_installation(test_app_asyncio, init_test_db,
                                    access_idx, installation_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.delete(f"/installations/{installation_id}/", headers=auth)
     assert response.status_code == status_code
@@ -258,7 +258,7 @@ async def test_get_active_devices_on_site(test_app_asyncio, init_test_db, test_d
     monkeypatch.setattr(installations, "database", test_db)
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get(f"/installations/site-devices/{installation_id}", headers=auth)
     assert response.status_code == status_code

--- a/src/tests/routes/test_login.py
+++ b/src/tests/routes/test_login.py
@@ -10,8 +10,8 @@ from app.api import crud, security
 from tests.db_utils import fill_table
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_first_pwd", "scopes": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_second_pwd", "scopes": "user"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_first_pwd", "scope": "user"},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_second_pwd", "scope": "user"},
 ]
 
 

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -32,10 +32,10 @@ DEVICE_TABLE = [
 ]
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scopes": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scopes": "admin"},
-    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scopes": "device"},
-    {"id": 4, "login": "fourth_login", "hashed_password": "hashed_pwd", "scopes": "device"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
+    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 4, "login": "fourth_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
 MEDIA_TABLE = [
@@ -72,7 +72,7 @@ async def init_test_db(monkeypatch, test_db):
 async def test_get_media(test_app_asyncio, init_test_db, access_idx, media_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get(f"/media/{media_id}", headers=auth)
     assert response.status_code == status_code
@@ -95,7 +95,7 @@ async def test_get_media(test_app_asyncio, init_test_db, access_idx, media_id, s
 async def test_fetch_media(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/media/", headers=auth)
     assert response.status_code == status_code
@@ -120,7 +120,7 @@ async def test_fetch_media(test_app_asyncio, init_test_db, access_idx, status_co
 async def test_create_media(test_app_asyncio, init_test_db, test_db, access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     utc_dt = datetime.utcnow()
     response = await test_app_asyncio.post("/media/", data=json.dumps(payload), headers=auth)
@@ -153,7 +153,7 @@ async def test_create_media_from_device(test_app_asyncio, init_test_db, test_db,
                                         access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     utc_dt = datetime.utcnow()
     response = await test_app_asyncio.post("/media/from-device", data=json.dumps(payload), headers=auth)
@@ -196,7 +196,7 @@ async def test_update_media(test_app_asyncio, init_test_db, test_db,
                             access_idx, payload, media_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/media/{media_id}/", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -225,7 +225,7 @@ async def test_update_media(test_app_asyncio, init_test_db, test_db,
 async def test_delete_media(test_app_asyncio, init_test_db, access_idx, media_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.delete(f"/media/{media_id}/", headers=auth)
     assert response.status_code == status_code
@@ -249,8 +249,8 @@ async def test_upload_media(test_app_asyncio, init_test_db, test_db, monkeypatch
             device_id = entry['id']
             break
     # Create a custom access token
-    device_auth = await pytest.get_token(ACCESS_TABLE[device_idx]['id'], ACCESS_TABLE[device_idx]['scopes'].split())
-    admin_auth = await pytest.get_token(ACCESS_TABLE[admin_idx]['id'], ACCESS_TABLE[admin_idx]['scopes'].split())
+    device_auth = await pytest.get_token(ACCESS_TABLE[device_idx]['id'], ACCESS_TABLE[device_idx]['scope'].split())
+    admin_auth = await pytest.get_token(ACCESS_TABLE[admin_idx]['id'], ACCESS_TABLE[admin_idx]['scope'].split())
 
     # 1 - Create a media that will have an upload
     payload = {"device_id": device_id}

--- a/src/tests/routes/test_sites.py
+++ b/src/tests/routes/test_sites.py
@@ -20,9 +20,9 @@ SITE_TABLE = [
 ]
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scopes": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scopes": "admin"},
-    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scopes": "device"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
+    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
 
@@ -98,7 +98,7 @@ async def test_create_site(test_app_asyncio, init_test_db, test_db,
                            access_idx, payload, no_alert, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     test_response = {"id": len(SITE_TABLE) + 1, **payload}
     subroute = ""
@@ -140,7 +140,7 @@ async def test_update_site(test_app_asyncio, init_test_db, test_db,
                            access_idx, payload, site_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/sites/{site_id}/", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -168,7 +168,7 @@ async def test_update_site(test_app_asyncio, init_test_db, test_db,
 async def test_delete_site(test_app_asyncio, init_test_db, access_idx, site_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.delete(f"/sites/{site_id}/", headers=auth)
     assert response.status_code == status_code

--- a/src/tests/routes/test_users.py
+++ b/src/tests/routes/test_users.py
@@ -19,9 +19,9 @@ USER_TABLE = [
 ]
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scopes": "user"},
-    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scopes": "admin"},
-    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scopes": "device"},
+    {"id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    {"id": 2, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
+    {"id": 3, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
 
@@ -50,7 +50,7 @@ async def init_test_db(monkeypatch, test_db):
 async def test_get_user(test_app_asyncio, init_test_db, test_db, access_idx, user_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get(f"/users/{user_id}", headers=auth)
     assert response.status_code == status_code
@@ -78,7 +78,7 @@ async def test_get_user(test_app_asyncio, init_test_db, test_db, access_idx, use
 async def test_get_my_user(test_app_asyncio, init_test_db, test_db, access_idx, user_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/users/me", headers=auth)
     assert response.status_code == status_code
@@ -103,7 +103,7 @@ async def test_get_my_user(test_app_asyncio, init_test_db, test_db, access_idx, 
 async def test_fetch_users(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/users/", headers=auth)
     assert response.status_code == status_code
@@ -130,7 +130,7 @@ async def test_create_user(test_app_asyncio, init_test_db, test_db, monkeypatch,
                            access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     max_user_id = max(USER_TABLE_FOR_DB, key=lambda x: x["id"])["id"]
     max_access_id = max(ACCESS_TABLE, key=lambda x: x["id"])["id"]
@@ -179,7 +179,7 @@ async def test_update_user(test_app_asyncio, init_test_db, test_db,
                            access_idx, payload, user_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/users/{user_id}/", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -217,7 +217,7 @@ async def test_update_my_info(test_app_asyncio, init_test_db, test_db,
                               access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put("/users/update-info", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -254,7 +254,7 @@ async def test_update_user_password(test_app_asyncio, init_test_db, test_db, mon
                                     access_idx, payload, user_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/users/{user_id}/pwd", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -287,7 +287,7 @@ async def test_update_my_password(test_app_asyncio, init_test_db, test_db, monke
                                   access_idx, payload, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put("/users/update-pwd", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -316,7 +316,7 @@ async def test_delete_user(test_app_asyncio, init_test_db, monkeypatch,
                            access_idx, user_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scopes'].split())
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.delete(f"/users/{user_id}/", headers=auth)
     assert response.status_code == status_code

--- a/src/tests/test_deps.py
+++ b/src/tests/test_deps.py
@@ -32,11 +32,11 @@ DEVICE_TABLE = [
 ]
 
 ACCESS_TABLE = [
-    {"id": 1, "login": "first_user", "hashed_password": "first_pwd_hashed", "scopes": "user"},
-    {"id": 2, "login": "connected_user", "hashed_password": "first_pwd_hashed", "scopes": "user"},
-    {"id": 3, "login": "first_device", "hashed_password": "first_pwd_hashed", "scopes": "device"},
-    {"id": 4, "login": "second_device", "hashed_password": "second_pwd_hashed", "scopes": "device"},
-    {"id": 5, "login": "connected_device", "hashed_password": "third_pwd_hashed", "scopes": "device"},
+    {"id": 1, "login": "first_user", "hashed_password": "first_pwd_hashed", "scope": "user"},
+    {"id": 2, "login": "connected_user", "hashed_password": "first_pwd_hashed", "scope": "user"},
+    {"id": 3, "login": "first_device", "hashed_password": "first_pwd_hashed", "scope": "device"},
+    {"id": 4, "login": "second_device", "hashed_password": "second_pwd_hashed", "scope": "device"},
+    {"id": 5, "login": "connected_device", "hashed_password": "third_pwd_hashed", "scope": "device"},
 ]
 
 
@@ -68,7 +68,7 @@ async def test_get_current_access(init_test_db, token_data, scope, expected_acce
     if isinstance(token_data, str):
         token = token_data
     else:
-        _data = {"sub": str(token_data['id']), "scopes": token_data['scopes'].split()}
+        _data = {"sub": str(token_data['id']), "scopes": token_data['scope'].split()}
         token = await security.create_access_token(_data)
     # Check that we retrieve the correct access
     if exception:

--- a/src/tests/test_deps.py
+++ b/src/tests/test_deps.py
@@ -57,7 +57,7 @@ async def init_test_db(monkeypatch, test_db):
     [
         [ACCESS_TABLE[3], 'admin', None, True],  # Unsufficient scope
         ['my_false_token', 'admin', None, True],  # Decoding failure
-        [{"id": 100, "scopes": "admin"}, 'admin', None, True],  # Unable to find access in table
+        [{"id": 100, "scope": "admin"}, 'admin', None, True],  # Unable to find access in table
         [ACCESS_TABLE[3], 'device', 3, False],  # Correct
     ],
 )
@@ -68,7 +68,7 @@ async def test_get_current_access(init_test_db, token_data, scope, expected_acce
     if isinstance(token_data, str):
         token = token_data
     else:
-        _data = {"sub": str(token_data['id']), "scopes": token_data['scopes'].split()}
+        _data = {"sub": str(token_data['id']), "scopes": token_data['scope'].split()}
         token = await security.create_access_token(_data)
     # Check that we retrieve the correct access
     if exception:

--- a/src/tests/test_deps.py
+++ b/src/tests/test_deps.py
@@ -68,7 +68,7 @@ async def test_get_current_access(init_test_db, token_data, scope, expected_acce
     if isinstance(token_data, str):
         token = token_data
     else:
-        _data = {"sub": str(token_data['id']), "scopes": token_data['scope'].split()}
+        _data = {"sub": str(token_data['id']), "scopes": token_data['scopes'].split()}
         token = await security.create_access_token(_data)
     # Check that we retrieve the correct access
     if exception:


### PR DESCRIPTION
Following up on https://github.com/pyronear/pyro-api/issues/125#issuecomment-803639387 and #137, this PR introduces the following modifications:
- renamed `scopes` field to `scope` in the access table (a given access cannot cumulate more than one now since we removed "me")
- added group_id to the access table
- updated unittests accordingly

Any feedback is welcome!