### PR TITLE
feat: add missing link between site and group

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -132,7 +132,8 @@ class Client:
                    "lon": lon}
         return requests.post(self.routes["create-event"], headers=self.headers, json=payload)
 
-    def create_no_alert_site(self, lat: float, lon: float, name: str, country: str, geocode: str) -> Response:
+    def create_no_alert_site(self, lat: float, lon: float, name: str, country: str,
+                             geocode: str, group_id: int = None) -> Response:
         """Create a site that is not supposed to generate alerts.
 
         Example::
@@ -155,6 +156,8 @@ class Client:
                    "name": name,
                    "country": country,
                    "geocode": geocode}
+        if group_id is not None:
+            payload["group_id"] = group_id
         return requests.post(self.routes["no-alert-site"], headers=self.headers, json=payload)
 
     def send_alert(self, lat: float, lon: float, event_id: int, device_id: int, media_id: int = None) -> Response:

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -128,6 +128,7 @@ class DefaultPosition(DefaultLocation, _DefaultRotation):
 # Sites
 class SiteBase(_FlatLocation):
     name: str = Field(..., min_length=3, max_length=50, example="watchtower12")
+    group_id: int = Field(None, gt=0)
     country: str = Field(..., max_length=5, example="FR")
     geocode: str = Field(..., max_length=10, example="01")
 

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -64,6 +64,7 @@ sites = Table(
     metadata,
     Column("id", Integer, primary_key=True),
     Column("name", String(50)),
+    Column("group_id", Integer, ForeignKey("groups.id"), default=None),
     Column("lat", Float(4, asdecimal=True)),
     Column("lon", Float(4, asdecimal=True)),
     Column("country", String(5), nullable=False),

--- a/src/tests/routes/test_sites.py
+++ b/src/tests/routes/test_sites.py
@@ -12,10 +12,18 @@ from app.api import crud
 from tests.db_utils import get_entry, fill_table
 from tests.utils import update_only_datetime
 
+
+GROUP_TABLE = [
+    {"id": 1, "name": "first_group"},
+    {"id": 2, "name": "second_group"}
+]
+
 SITE_TABLE = [
-    {"id": 1, "name": "my_first_tower", "lat": 44.1, "lon": -0.7, "type": "tower", "country": "FR", "geocode": "40",
+    {"id": 1, "name": "my_first_tower", "group_id": 1,
+     "lat": 44.1, "lon": -0.7, "type": "tower", "country": "FR", "geocode": "40",
      "created_at": "2020-10-13T08:18:45.447773"},
-    {"id": 2, "name": "my_first_station", "lat": 44.1, "lon": 3.9, "type": "station", "country": "FR", "geocode": "30",
+    {"id": 2, "name": "my_first_station", "group_id": 2,
+     "lat": 44.1, "lon": 3.9, "type": "station", "country": "FR", "geocode": "30",
      "created_at": "2020-09-13T08:18:45.447773"},
 ]
 
@@ -42,6 +50,7 @@ SITE_TABLE_FOR_DB = list(map(update_only_datetime, SITE_TABLE))
 async def init_test_db(monkeypatch, test_db):
     monkeypatch.setattr(crud.base, "database", test_db)
     await fill_table(test_db, db.accesses, ACCESS_TABLE)
+    await fill_table(test_db, db.groups, GROUP_TABLE)
     await fill_table(test_db, db.sites, SITE_TABLE_FOR_DB)
 
 
@@ -79,18 +88,26 @@ async def test_fetch_sites(test_app_asyncio, init_test_db):
 @pytest.mark.parametrize(
     "access_idx, payload, no_alert, status_code, status_details",
     [
-        [1, {"name": "my_site", "lat": 0., "lon": 0., "type": "tower", "country": "FR", "geocode": "01"}, False,
+        [1, {"name": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
+             "type": "tower", "country": "FR", "geocode": "01"}, False,
          201, None],
-        [1, {"name": "my_site", "lat": 0., "lon": 0., "type": "station", "country": "FR", "geocode": "01"}, False,
+        [1, {"name": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
+             "type": "station", "country": "FR", "geocode": "01"}, False,
          201, None],
-        [1, {"name": "my_site", "lat": 0., "lon": 0., "country": "FR", "geocode": "01"}, True, 201, None],
-        [0, {"name": "my_site", "lat": 0., "lon": 0., "country": "FR", "geocode": "01"}, False,
+        [1, {"name": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
+             "country": "FR", "geocode": "01"}, True, 201, None],
+        [0, {"name": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
+             "country": "FR", "geocode": "01"}, False,
          401, "Permission denied"],
-        [0, {"name": "my_site", "lat": 0., "lon": 0., "country": "FR", "geocode": "01"}, True, 201, None],
-        [2, {"name": "my_site", "lat": 0., "lon": 0., "country": "FR", "geocode": "01"}, False,
+        [0, {"name": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
+             "country": "FR", "geocode": "01"}, True, 201, None],
+        [2, {"name": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
+             "country": "FR", "geocode": "01"}, False,
          401, "Permission denied"],
-        [1, {"names": "my_site", "lat": 0., "lon": 0., "country": "FR", "geocode": "01"}, False, 422, None],
-        [1, {"name": "my_site", "lat": 0., "country": "FR", "geocode": "01"}, False, 422, None],
+        [1, {"names": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
+             "country": "FR", "geocode": "01"}, False, 422, None],
+        [1, {"name": "my_site", "group_id": 1, "lat": 0.,
+             "country": "FR", "geocode": "01"}, False, 422, None],
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
Parts of #137 

This PR ensure that all objects can be linked to a group.
At a first glance, it appears that only site needed some modifications.

Content of the PR:

- Add group_id to site table
- Add group_id to site schema
- Adapted no-alert-site in client
- Adapted UnitTest for site