### PR TITLE
feat: Added software_hash for device update check

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -37,6 +37,8 @@ ROUTES: Dict[str, str] = {
     "get-site-devices": "/installations/site-devices/{site_id}",
     "get-media-url": "/media/{media_id}/url",
     "get-past-events": "/events/past",
+    "get-my-device": "/devices/me",
+    "update-my-hash": "/devices/hash",
 }
 
 
@@ -413,3 +415,31 @@ class Client:
             HTTP response containing the list of past events
         """
         return requests.get(self.routes["get-past-events"], headers=self.headers)
+
+    def get_my_device(self) -> Response:
+        """Get information about the current device
+
+        Example::
+            >>> from pyroclient import client
+            >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
+            >>> response = api_client.get_my_device()
+
+        Returns:
+            HTTP response containing the device information
+        """
+        return requests.get(self.routes["get-my-device"], headers=self.headers)
+
+    def update_my_hash(self, software_hash: str) -> Response:
+        """Updates the software hash of the current device
+
+        Example::
+            >>> from pyroclient import client
+            >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
+            >>> response = api_client.update_my_hash()
+
+        Returns:
+            HTTP response containing the updated device information
+        """
+        payload = {"software_hash": software_hash}
+
+        return requests.put(self.routes["update-my-hash"], headers=self.headers, json=payload)

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -28,7 +28,7 @@ router = APIRouter()
 
 
 @router.post("/", response_model=DeviceOut, status_code=201, summary="Create a new device")
-async def register_device(payload: DeviceAuth, _=Security(get_current_user, scopes=[AccessType.admin])):
+async def register_device(payload: DeviceAuth, _=Security(get_current_access, scopes=[AccessType.admin])):
     """Creates a new device based on the given information
 
     Below, click on "Schema" for more detailed information about arguments
@@ -54,7 +54,7 @@ async def register_my_device(
 
 
 @router.get("/{device_id}/", response_model=DeviceOut, summary="Get information about a specific device")
-async def get_device(device_id: int = Path(..., gt=0), _=Security(get_current_user, scopes=[AccessType.admin])):
+async def get_device(device_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=[AccessType.admin])):
     """
     Based on a device_id, retrieves information about the specified device
     """
@@ -70,7 +70,7 @@ async def get_my_device(me: DeviceOut = Security(get_current_device, scopes=["de
 
 
 @router.get("/", response_model=List[DeviceOut], summary="Get the list of all devices")
-async def fetch_devices(_=Security(get_current_user, scopes=[AccessType.admin])):
+async def fetch_devices(_=Security(get_current_access, scopes=[AccessType.admin])):
     """
     Retrieves the list of all devices and their information
     """
@@ -79,7 +79,7 @@ async def fetch_devices(_=Security(get_current_user, scopes=[AccessType.admin]))
 
 @router.put("/{device_id}/", response_model=DeviceOut, summary="Update information about a specific device")
 async def update_device(
-    payload: DeviceIn, device_id: int = Path(..., gt=0), _=Security(get_current_user, scopes=[AccessType.admin])
+    payload: DeviceIn, device_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=[AccessType.admin])
 ):
     """
     Based on a device_id, updates information about the specified device
@@ -88,7 +88,7 @@ async def update_device(
 
 
 @router.delete("/{device_id}/", response_model=DeviceOut, summary="Delete a specific device")
-async def delete_device(device_id: int = Path(..., gt=0), _=Security(get_current_user, scopes=[AccessType.admin])):
+async def delete_device(device_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=[AccessType.admin])):
     """
     Based on a device_id, deletes the specified device
     """
@@ -166,7 +166,7 @@ async def update_device_hash(
 
 @router.put("/{device_id}/pwd", response_model=DeviceOut, summary="Update the password of a specific device")
 async def update_device_password(
-    payload: Cred, device_id: int = Path(..., gt=0), _=Security(get_current_user, scopes=[AccessType.admin])
+    payload: Cred, device_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=[AccessType.admin])
 ):
     """
     Based on a device_id, updates the password of the specified device

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -154,9 +154,9 @@ async def update_my_hash(
     payload: SoftwareHash, device: DeviceOut = Security(get_current_device, scopes=["device"])
 ):
     """
-    Updates the location of the current device
+    Updates the expected software hash of the device
     """
-    # Update only the position
+    # Update only the corresponding field
     for k, v in payload.dict().items():
         setattr(device, k, v)
     await crud.update_entry(devices, device, device.id)

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -18,6 +18,7 @@ from app.api.schemas import (
     UserRead,
     DefaultPosition,
     Cred,
+    SoftwareHash,
 )
 from app.api.deps import get_current_device, get_current_user
 
@@ -128,6 +129,20 @@ async def update_device_location(
 @router.put("/my-location", response_model=DeviceOut, summary="Update the location of the current device")
 async def update_my_location(
     payload: DefaultPosition, device: DeviceOut = Security(get_current_device, scopes=["device"])
+):
+    """
+    Updates the location of the current device
+    """
+    # Update only the position
+    for k, v in payload.dict().items():
+        setattr(device, k, v)
+    await crud.update_entry(devices, device, device.id)
+    return device
+
+
+@router.put("/hash", response_model=DeviceOut, summary="Update the software hash of the current device")
+async def update_my_hash(
+    payload: SoftwareHash, device: DeviceOut = Security(get_current_device, scopes=["device"])
 ):
     """
     Updates the location of the current device

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -60,6 +60,14 @@ async def get_device(device_id: int = Path(..., gt=0), _=Security(get_current_us
     return await crud.get_entry(devices, device_id)
 
 
+@router.get("/me", response_model=DeviceOut, summary="Get information about the current device")
+async def get_my_device(me: DeviceOut = Security(get_current_device, scopes=["device"])):
+    """
+    Retrieves information about the current device
+    """
+    return me
+
+
 @router.get("/", response_model=List[DeviceOut], summary="Get the list of all devices")
 async def fetch_devices(_=Security(get_current_user, scopes=["admin"])):
     """

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -153,7 +153,10 @@ class EventOut(EventIn, _CreatedAt, _Id):
 
 
 # Device
-class MyDeviceIn(Login, DefaultPosition):
+class SoftwareHash(BaseModel):
+    software_hash: str = Field(None, min_length=8, max_length=16)
+
+class MyDeviceIn(Login, DefaultPosition, SoftwareHash):
     specs: str = Field(..., min_length=3, max_length=100, example="systemV0.1")
     last_ping: datetime = Field(default=None, example=datetime.utcnow())
     angle_of_view: float = Field(..., gt=0, lt=360)

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -156,6 +156,7 @@ class EventOut(EventIn, _CreatedAt, _Id):
 class SoftwareHash(BaseModel):
     software_hash: str = Field(..., min_length=8, max_length=16)
 
+
 class MyDeviceIn(Login, DefaultPosition):
     specs: str = Field(..., min_length=3, max_length=100, example="systemV0.1")
     last_ping: datetime = Field(default=None, example=datetime.utcnow())

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -154,12 +154,13 @@ class EventOut(EventIn, _CreatedAt, _Id):
 
 # Device
 class SoftwareHash(BaseModel):
-    software_hash: str = Field(None, min_length=8, max_length=16)
+    software_hash: str = Field(..., min_length=8, max_length=16)
 
-class MyDeviceIn(Login, DefaultPosition, SoftwareHash):
+class MyDeviceIn(Login, DefaultPosition):
     specs: str = Field(..., min_length=3, max_length=100, example="systemV0.1")
     last_ping: datetime = Field(default=None, example=datetime.utcnow())
     angle_of_view: float = Field(..., gt=0, lt=360)
+    software_hash: str = Field(None, min_length=8, max_length=16)
 
 
 class DeviceIn(MyDeviceIn):

--- a/src/app/db/tables.py
+++ b/src/app/db/tables.py
@@ -100,6 +100,7 @@ devices = Table(
     Column("owner_id", Integer, ForeignKey("users.id")),
     Column("access_id", Integer, ForeignKey("accesses.id"), unique=True),
     Column("specs", String(50)),
+    Column("software_hash", String(16), default=None, nullable=True),
     Column("angle_of_view", Float(2, asdecimal=True)),
     Column("elevation", Float(1, asdecimal=True), default=None, nullable=True),
     Column("lat", Float(4, asdecimal=True), default=None, nullable=True),

--- a/src/tests/routes/test_alerts.py
+++ b/src/tests/routes/test_alerts.py
@@ -21,10 +21,10 @@ USER_TABLE = [
 
 DEVICE_TABLE = [
     {"id": 1, "login": "third_login", "owner_id": 1,
-     "access_id": 3, "specs": "v0.1", "elevation": None, "lat": None, "angle_of_view": 68.,
+     "access_id": 3, "specs": "v0.1", "elevation": None, "lat": None, "angle_of_view": 68., "software_hash": None,
      "lon": None, "yaw": None, "pitch": None, "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 2, "login": "fourth_login", "owner_id": 2, "access_id": 4, "specs": "v0.1", "elevation": None, "lat": None,
-     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68.,
+     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68., "software_hash": None,
      "created_at": "2020-10-13T08:18:45.447773"},
 ]
 

--- a/src/tests/routes/test_devices.py
+++ b/src/tests/routes/test_devices.py
@@ -95,7 +95,7 @@ async def test_get_my_device(test_app_asyncio, init_test_db, access_idx, status_
             if device['access_id'] == ACCESS_TABLE[access_idx]['id']:
                 entry = device
                 break
-        assert response.json() == {k: v for k, v in device.items() if k != "access_id"}
+        assert response.json() == {k: v for k, v in entry.items() if k != "access_id"}
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_devices.py
+++ b/src/tests/routes/test_devices.py
@@ -85,7 +85,7 @@ async def test_get_my_device(test_app_asyncio, init_test_db, access_idx, status_
     # Create a custom access token
     auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
-    response = await test_app_asyncio.get(f"/devices/me", headers=auth)
+    response = await test_app_asyncio.get("/devices/me", headers=auth)
     assert response.status_code == status_code
     if isinstance(status_details, str):
         assert response.json()['detail'] == status_details
@@ -369,7 +369,7 @@ async def test_update_my_hash(test_app_asyncio, init_test_db, test_db,
     # Create a custom access token
     auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
-    response = await test_app_asyncio.put(f"/devices/hash", data=json.dumps(payload), headers=auth)
+    response = await test_app_asyncio.put("/devices/hash", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
     if isinstance(status_details, str):
         assert response.json()['detail'] == status_details

--- a/src/tests/routes/test_devices.py
+++ b/src/tests/routes/test_devices.py
@@ -19,10 +19,10 @@ USER_TABLE = [
 
 DEVICE_TABLE = [
     {"id": 1, "login": "third_login", "owner_id": 1,
-     "access_id": 3, "specs": "v0.1", "elevation": None, "lat": None, "angle_of_view": 68.,
+     "access_id": 3, "specs": "v0.1", "elevation": None, "lat": None, "angle_of_view": 68., "software_hash": None,
      "lon": None, "yaw": None, "pitch": None, "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 2, "login": "fourth_login", "owner_id": 2, "access_id": 4, "specs": "v0.1", "elevation": None, "lat": None,
-     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68.,
+     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68., "software_hash": None,
      "created_at": "2020-10-13T08:18:45.447773"},
 ]
 
@@ -68,6 +68,34 @@ async def test_get_device(test_app_asyncio, init_test_db, access_idx, device_id,
         assert response.json()['detail'] == status_details
     if response.status_code // 100 == 2:
         assert response.json() == {k: v for k, v in DEVICE_TABLE[device_id - 1].items() if k != "access_id"}
+
+
+@pytest.mark.parametrize(
+    "access_idx, status_code, status_details",
+    [
+        [0, 401, "Permission denied"],
+        [1, 401, "Permission denied"],
+        [2, 200, None],
+        [3, 200, None],
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_my_device(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
+
+    # Create a custom access token
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
+
+    response = await test_app_asyncio.get(f"/devices/me", headers=auth)
+    assert response.status_code == status_code
+    if isinstance(status_details, str):
+        assert response.json()['detail'] == status_details
+    if response.status_code // 100 == 2:
+        entry = None
+        for device in DEVICE_TABLE:
+            if device['access_id'] == ACCESS_TABLE[access_idx]['id']:
+                entry = device
+                break
+        assert response.json() == {k: v for k, v in device.items() if k != "access_id"}
 
 
 @pytest.mark.parametrize(
@@ -320,6 +348,41 @@ async def test_update_device_location(test_app_asyncio, init_test_db, test_db,
 
         assert all(updated_device[k] == v for k, v in payload.items())
         assert all(updated_device[k] == v for k, v in DEVICE_TABLE_FOR_DB[device_id - 1].items() if k not in payload)
+
+
+@pytest.mark.parametrize(
+    "access_idx, payload, status_code, status_details",
+    [
+        [0, {"software_hash": "my_sha256hash"}, 401, "Permission denied"],
+        [1, {"software_hash": "my_sha256hash"}, 401, "Permission denied"],
+        [2, {"software_hash": "my_sha256hash"}, 200, None],
+        [3, {"software_hash": "my_sha256hash"}, 200, None],
+        [3, {}, 422, None],
+        [3, {"software_hash": "my_hash"}, 422, None],
+        [3, {"software_hash": "my_way_too_long_sha26_hash"}, 422, None],
+    ],
+)
+@pytest.mark.asyncio
+async def test_update_my_hash(test_app_asyncio, init_test_db, test_db,
+                              access_idx, payload, status_code, status_details):
+
+    # Create a custom access token
+    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
+
+    response = await test_app_asyncio.put(f"/devices/hash", data=json.dumps(payload), headers=auth)
+    assert response.status_code == status_code
+    if isinstance(status_details, str):
+        assert response.json()['detail'] == status_details
+
+    if response.status_code // 100 == 2:
+        device_id = None
+        for device in DEVICE_TABLE:
+            if device['access_id'] == ACCESS_TABLE[access_idx]['id']:
+                device_id = device["id"]
+                break
+        updated_device = await get_entry(test_db, db.devices, device_id)
+        updated_device = dict(**updated_device)
+        assert updated_device['software_hash'] == payload['software_hash']
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_installations.py
+++ b/src/tests/routes/test_installations.py
@@ -20,10 +20,10 @@ USER_TABLE = [
 
 DEVICE_TABLE = [
     {"id": 1, "login": "third_login", "owner_id": 1,
-     "access_id": 3, "specs": "v0.1", "elevation": None, "lat": None, "angle_of_view": 68.,
+     "access_id": 3, "specs": "v0.1", "elevation": None, "lat": None, "angle_of_view": 68., "software_hash": None,
      "lon": None, "yaw": None, "pitch": None, "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 2, "login": "fourth_login", "owner_id": 2, "access_id": 4, "specs": "v0.1", "elevation": None, "lat": None,
-     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68.,
+     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68., "software_hash": None,
      "created_at": "2020-10-13T08:18:45.447773"},
 ]
 

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -24,10 +24,10 @@ USER_TABLE = [
 
 DEVICE_TABLE = [
     {"id": 1, "login": "third_login", "owner_id": 1,
-     "access_id": 3, "specs": "v0.1", "elevation": None, "lat": None, "angle_of_view": 68.,
+     "access_id": 3, "specs": "v0.1", "elevation": None, "lat": None, "angle_of_view": 68., "software_hash": None,
      "lon": None, "yaw": None, "pitch": None, "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 2, "login": "fourth_login", "owner_id": 2, "access_id": 4, "specs": "v0.1", "elevation": None, "lat": None,
-     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68.,
+     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68., "software_hash": None,
      "created_at": "2020-10-13T08:18:45.447773"},
 ]
 


### PR DESCRIPTION
Following up on #150, this PR introduces the following modifications:
- adds a device route for self GET
- adds a `software_hash` string field to the `devices` table
- adds a route to update the `software_hash` of the current device
- adds corresponding unittests
- adds corresponding client methods

Resolves #150

Any feedback is welcome!