### PR TITLE
[groups] Add group logic to fetching routes

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -23,7 +23,7 @@ Client for the [Pyronear API](https://github.com/pyronear/pyro-api)
 
 ### Prerequisites
 
-- Python 3.6 (or more recent)
+- Python 3.6   (or more recent)
 - [pip](https://pip.pypa.io/en/stable/)
 
 ### Installation

--- a/client/README.md
+++ b/client/README.md
@@ -23,7 +23,7 @@ Client for the [Pyronear API](https://github.com/pyronear/pyro-api)
 
 ### Prerequisites
 
-- Python 3.6   (or more recent)
+- Python 3.6 (or more recent)
 - [pip](https://pip.pypa.io/en/stable/)
 
 ### Installation

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -107,7 +107,6 @@ async def fetch_alerts(requester=Security(get_current_access, scopes=[AccessType
                             .join(models.Accesses)
                             .filter(models.Accesses.group_id == requester.group_id).all())
         retrieved_alerts = [x.__dict__ for x in retrieved_alerts]
-        print("retrieved_alert:", retrieved_alerts)
         return retrieved_alerts
 
 

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -94,7 +94,7 @@ async def get_alert(alert_id: int = Path(..., gt=0), _=Security(get_current_acce
 
 
 @router.get("/", response_model=List[AlertOut], summary="Get the list of all alerts")
-async def fetch_alerts(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]), 
+async def fetch_alerts(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
                        session=Depends(get_session)):
     """
     Retrieves the list of all alerts and their information
@@ -102,12 +102,12 @@ async def fetch_alerts(requester=Security(get_current_access, scopes=[AccessType
     if await is_admin_access(requester.id):
         return await crud.fetch_all(alerts)
     else:
-        print(session.query(models.Alerts).first())
         retrieved_alerts = (session.query(models.Alerts)
                             .join(models.Devices)
                             .join(models.Accesses)
                             .filter(models.Accesses.group_id == requester.group_id).all())
         retrieved_alerts = [x.__dict__ for x in retrieved_alerts]
+        print("retrieved_alert:", retrieved_alerts)
         return retrieved_alerts
 
 

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -4,13 +4,13 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from typing import List
-from fastapi import APIRouter, Path, Security, HTTPException, status, BackgroundTasks
+from fastapi import APIRouter, Path, Security, HTTPException, status, BackgroundTasks, Depends
 from sqlalchemy import select
 from functools import partial
 from datetime import datetime, timedelta
 
 from app.api import crud
-from app.db import alerts, events, media
+from app.db import alerts, events, media, get_session, models
 from app.api.schemas import (
     AlertBase,
     AlertOut,
@@ -22,6 +22,7 @@ from app.api.schemas import (
     AccessType)
 from app.api.deps import get_current_device, get_current_access
 from app.api.external import post_request
+from app.api.crud.authorizations import is_admin_access, is_in_same_group
 
 
 router = APIRouter()
@@ -93,11 +94,21 @@ async def get_alert(alert_id: int = Path(..., gt=0), _=Security(get_current_acce
 
 
 @router.get("/", response_model=List[AlertOut], summary="Get the list of all alerts")
-async def fetch_alerts(_=Security(get_current_access, scopes=[AccessType.admin])):
+async def fetch_alerts(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]), 
+                       session=Depends(get_session)):
     """
     Retrieves the list of all alerts and their information
     """
-    return await crud.fetch_all(alerts)
+    if await is_admin_access(requester.id):
+        return await crud.fetch_all(alerts)
+    else:
+        print(session.query(models.Alerts).first())
+        retrieved_alerts = (session.query(models.Alerts)
+                            .join(models.Devices)
+                            .join(models.Accesses)
+                            .filter(models.Accesses.group_id == requester.group_id).all())
+        retrieved_alerts = [x.__dict__ for x in retrieved_alerts]
+        return retrieved_alerts
 
 
 @router.put("/{alert_id}/", response_model=AlertOut, summary="Update information about a specific alert")

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -22,7 +22,7 @@ from app.api.schemas import (
     AccessType)
 from app.api.deps import get_current_device, get_current_access
 from app.api.external import post_request
-from app.api.crud.authorizations import is_admin_access, is_in_same_group
+from app.api.crud.authorizations import is_admin_access
 
 
 router = APIRouter()
@@ -94,7 +94,8 @@ async def get_alert(alert_id: int = Path(..., gt=0), _=Security(get_current_acce
 
 
 @router.get("/", response_model=List[AlertOut], summary="Get the list of all alerts")
-async def fetch_alerts(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+async def fetch_alerts(requester=Security(get_current_access,
+                       scopes=[AccessType.admin, AccessType.user]),
                        session=Depends(get_session)):
     """
     Retrieves the list of all alerts and their information

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -86,7 +86,6 @@ async def fetch_devices(requester=Security(get_current_access,
     if await is_admin_access(requester.id):
         return await crud.fetch_all(devices)
     else:
-        print(session.query(models.Devices).first().access)
         retrieved_devices = (session.query(models.Devices)
                              .join(models.Accesses)
                              .filter(models.Accesses.group_id == requester.group_id).all())

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -85,7 +85,7 @@ async def fetch_devices(requester=Security(get_current_access, scopes=[AccessTyp
     Retrieves the list of all devices and their information
     """
     if await is_admin_access(requester.id):
-        return await crud.fetch_all(users)
+        return await crud.fetch_all(devices)
     else:
         print(session.query(models.Devices).first().access)
         retrieved_devices = (session.query(models.Devices)
@@ -94,8 +94,6 @@ async def fetch_devices(requester=Security(get_current_access, scopes=[AccessTyp
         retrieved_devices = [x.__dict__ for x in retrieved_devices]
 
         return retrieved_devices
-
-    return await crud.fetch_all(devices)
 
 
 @router.put("/{device_id}/", response_model=DeviceOut, summary="Update information about a specific device")

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -92,7 +92,7 @@ async def fetch_devices(requester=Security(get_current_access, scopes=[AccessTyp
                              .join(models.Accesses)
                              .filter(models.Accesses.group_id == requester.group_id).all())
         retrieved_devices = [x.__dict__ for x in retrieved_devices]
-        print(retrieved_devices)
+
         return retrieved_devices
 
     return await crud.fetch_all(devices)

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -24,9 +24,7 @@ from app.api.schemas import (
 )
 from app.api.deps import get_current_device, get_current_user, get_current_access
 from app.api.crud.groups import get_entity_group_id
-
-
-from app.api.crud.authorizations import is_admin_access, is_in_same_group
+from app.api.crud.authorizations import is_admin_access
 
 
 router = APIRouter()
@@ -79,7 +77,8 @@ async def get_my_device(me: DeviceOut = Security(get_current_device, scopes=["de
 
 
 @router.get("/", response_model=List[DeviceOut], summary="Get the list of all devices")
-async def fetch_devices(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+async def fetch_devices(requester=Security(get_current_access,
+                        scopes=[AccessType.admin, AccessType.user]),
                         session=Depends(get_session)):
     """
     Retrieves the list of all devices and their information

--- a/src/app/api/routes/events.py
+++ b/src/app/api/routes/events.py
@@ -9,7 +9,7 @@ from app.api import crud
 from app.db import events, get_session, models
 from app.api.schemas import EventOut, EventIn, AccessType
 from app.api.deps import get_current_access
-from app.api.crud.authorizations import is_admin_access, is_in_same_group
+from app.api.crud.authorizations import is_admin_access
 
 router = APIRouter()
 
@@ -34,7 +34,8 @@ async def get_event(event_id: int = Path(..., gt=0)):
 
 
 @router.get("/", response_model=List[EventOut], summary="Get the list of all events")
-async def fetch_events(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+async def fetch_events(requester=Security(get_current_access,
+                       scopes=[AccessType.admin, AccessType.user]),
                        session=Depends(get_session)):
     """
     Retrieves the list of all events and their information
@@ -46,8 +47,8 @@ async def fetch_events(requester=Security(get_current_access, scopes=[AccessType
                             .join(models.Alerts)
                             .join(models.Devices)
                             .join(models.Accesses)
-                            .filter(models.Accesses.group_id == requester.group_id).all())
-        retrieved_events = [x.__dict__ for x in retrieved_events]
+                            .filter(models.Accesses.group_id == requester.group_id))
+        retrieved_events = [x.__dict__ for x in retrieved_events.all()]
         return retrieved_events
 
 

--- a/src/app/api/routes/events.py
+++ b/src/app/api/routes/events.py
@@ -74,7 +74,8 @@ async def update_event(
 
 
 @router.delete("/{event_id}/", response_model=EventOut, summary="Delete a specific event")
-async def delete_event(event_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=[AccessType.admin])):
+async def delete_event(event_id: int = Path(..., gt=0), _=Security(get_current_access, scopes=[AccessType.admin]),
+                       session=Depends(get_session)):
     """
     Based on a event_id, deletes the specified event
     """

--- a/src/app/api/routes/events.py
+++ b/src/app/api/routes/events.py
@@ -42,13 +42,13 @@ async def fetch_events(requester=Security(get_current_access, scopes=[AccessType
     if await is_admin_access(requester.id):
         return await crud.fetch_all(events)
     else:
-        print(session.query(models.Events).first().access)
         retrieved_events = (session.query(models.Events)
                             .join(models.Alerts)
                             .join(models.Devices)
                             .join(models.Accesses)
                             .filter(models.Accesses.group_id == requester.group_id).all())
         retrieved_events = [x.__dict__ for x in retrieved_events]
+        print("retrieved_events:", retrieved_events)
         return retrieved_events
 
 

--- a/src/app/api/routes/events.py
+++ b/src/app/api/routes/events.py
@@ -48,7 +48,6 @@ async def fetch_events(requester=Security(get_current_access, scopes=[AccessType
                             .join(models.Accesses)
                             .filter(models.Accesses.group_id == requester.group_id).all())
         retrieved_events = [x.__dict__ for x in retrieved_events]
-        print("retrieved_events:", retrieved_events)
         return retrieved_events
 
 

--- a/src/app/api/routes/events.py
+++ b/src/app/api/routes/events.py
@@ -4,11 +4,12 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from typing import List
-from fastapi import APIRouter, Path, Security, status, HTTPException
+from fastapi import APIRouter, Path, Security, status, HTTPException, Depends
 from app.api import crud
-from app.db import events
+from app.db import events, get_session, models
 from app.api.schemas import EventOut, EventIn, AccessType
 from app.api.deps import get_current_access
+from app.api.crud.authorizations import is_admin_access, is_in_same_group
 
 router = APIRouter()
 
@@ -33,12 +34,22 @@ async def get_event(event_id: int = Path(..., gt=0)):
 
 
 @router.get("/", response_model=List[EventOut], summary="Get the list of all events")
-async def fetch_events():
+async def fetch_events(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+                       session=Depends(get_session)):
     """
     Retrieves the list of all events and their information
     """
-    # TODO fetch only group
-    return await crud.fetch_all(events)
+    if await is_admin_access(requester.id):
+        return await crud.fetch_all(events)
+    else:
+        print(session.query(models.Events).first().access)
+        retrieved_events = (session.query(models.Events)
+                            .join(models.Alerts)
+                            .join(models.Devices)
+                            .join(models.Accesses)
+                            .filter(models.Accesses.group_id == requester.group_id).all())
+        retrieved_events = [x.__dict__ for x in retrieved_events]
+        return retrieved_events
 
 
 @router.get("/past", response_model=List[EventOut], summary="Get the list of all past events")

--- a/src/app/api/routes/installations.py
+++ b/src/app/api/routes/installations.py
@@ -46,7 +46,6 @@ async def fetch_installations(requester=Security(get_current_access, scopes=[Acc
     if await is_admin_access(requester.id):
         return await crud.fetch_all(installations)
     else:
-        print(session.query(models.Installations).first().access)
         retrieved_installations = (session.query(models.Installations)
                                    .join(models.Sites)
                                    .filter(models.Sites.group_id == requester.group_id).all())

--- a/src/app/api/routes/installations.py
+++ b/src/app/api/routes/installations.py
@@ -4,13 +4,14 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from typing import List
-from fastapi import APIRouter, Path, Security
+from fastapi import APIRouter, Path, Security, Depends
 from sqlalchemy import and_, or_
 from datetime import datetime
 from app.api import crud
-from app.db import installations, database
+from app.db import installations, database, get_session, models
 from app.api.schemas import InstallationOut, InstallationIn, AccessType
 from app.api.deps import get_current_access
+from app.api.crud.authorizations import is_admin_access, is_in_same_group
 
 
 router = APIRouter()
@@ -37,11 +38,20 @@ async def get_installation(installation_id: int = Path(..., gt=0),
 
 
 @router.get("/", response_model=List[InstallationOut], summary="Get the list of all installations")
-async def fetch_installations(_=Security(get_current_access, scopes=[AccessType.admin])):
+async def fetch_installations(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+                              session=Depends(get_session)):
     """
     Retrieves the list of all installations and their information
     """
-    return await crud.fetch_all(installations)
+    if await is_admin_access(requester.id):
+        return await crud.fetch_all(installations)
+    else:
+        print(session.query(models.Installations).first().access)
+        retrieved_installations = (session.query(models.Installations)
+                                   .join(models.Sites)
+                                   .filter(models.Sites.group_id == requester.group_id).all())
+        retrieved_installations = [x.__dict__ for x in retrieved_installations]
+        return retrieved_installations
 
 
 @router.put("/{installation_id}/", response_model=InstallationOut,

--- a/src/app/api/routes/installations.py
+++ b/src/app/api/routes/installations.py
@@ -11,7 +11,7 @@ from app.api import crud
 from app.db import installations, database, get_session, models
 from app.api.schemas import InstallationOut, InstallationIn, AccessType
 from app.api.deps import get_current_access
-from app.api.crud.authorizations import is_admin_access, is_in_same_group
+from app.api.crud.authorizations import is_admin_access
 
 
 router = APIRouter()
@@ -38,7 +38,8 @@ async def get_installation(installation_id: int = Path(..., gt=0),
 
 
 @router.get("/", response_model=List[InstallationOut], summary="Get the list of all installations")
-async def fetch_installations(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+async def fetch_installations(requester=Security(get_current_access,
+                              scopes=[AccessType.admin, AccessType.user]),
                               session=Depends(get_session)):
     """
     Retrieves the list of all installations and their information

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -3,15 +3,16 @@
 # This program is licensed under the Apache License version 2.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-from fastapi import APIRouter, Path, Security, File, UploadFile, HTTPException, BackgroundTasks, status
+from fastapi import APIRouter, Path, Security, File, UploadFile, HTTPException, BackgroundTasks, status, Depends
 from typing import List, Optional
 
 from app.api import crud
-from app.db import media
+from app.db import media, get_session, models
 from app.api.schemas import MediaOut, MediaIn, MediaCreation, MediaUrl, DeviceOut, BaseMedia, AccessType
 from app.api.deps import get_current_device, get_current_user, get_current_access
 from app.api.security import hash_content_file
 from app.services import bucket_service, resolve_bucket_key
+from app.api.crud.authorizations import is_admin_access, is_in_same_group
 
 
 router = APIRouter()
@@ -67,12 +68,22 @@ async def get_media(media_id: int = Path(..., gt=0), requester=Security(get_curr
 
 
 @router.get("/", response_model=List[MediaOut], summary="Get the list of all media")
-async def fetch_media(_=Security(get_current_access, scopes=[AccessType.admin])):
+async def fetch_media(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+                      session=Depends(get_session)):
     """
     Retrieves the list of all media and their information
     """
     # TODO fetch only group
-    return await crud.fetch_all(media)
+    if await is_admin_access(requester.id):
+        return await crud.fetch_all(media)
+    else:
+        print(session.query(models.Media).first().access)
+        retrieved_media = (session.query(models.Media)
+                                   .join(models.Devices)
+                                   .join(models.Accesses)
+                                   .filter(models.Accesses.group_id == requester.group_id).all())
+        retrieved_media = [x.__dict__ for x in retrieved_media]
+        return retrieved_media
 
 
 @router.put("/{media_id}/", response_model=MediaOut, summary="Update information about a specific media")

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -68,7 +68,8 @@ async def get_media(media_id: int = Path(..., gt=0), requester=Security(get_curr
 
 
 @router.get("/", response_model=List[MediaOut], summary="Get the list of all media")
-async def fetch_media(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+async def fetch_media(requester=Security(get_current_access,
+                      scopes=[AccessType.admin, AccessType.user]),
                       session=Depends(get_session)):
     """
     Retrieves the list of all media and their information
@@ -81,7 +82,6 @@ async def fetch_media(requester=Security(get_current_access, scopes=[AccessType.
                                   .join(models.Accesses)
                                   .filter(models.Accesses.group_id == requester.group_id).all())
         retrieved_media = [x.__dict__ for x in retrieved_media]
-        print("retrieved_media:", retrieved_media)
         return retrieved_media
 
 

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -73,16 +73,15 @@ async def fetch_media(requester=Security(get_current_access, scopes=[AccessType.
     """
     Retrieves the list of all media and their information
     """
-    # TODO fetch only group
     if await is_admin_access(requester.id):
         return await crud.fetch_all(media)
     else:
-        print(session.query(models.Media).first().access)
         retrieved_media = (session.query(models.Media)
-                                   .join(models.Devices)
-                                   .join(models.Accesses)
-                                   .filter(models.Accesses.group_id == requester.group_id).all())
+                                  .join(models.Devices)
+                                  .join(models.Accesses)
+                                  .filter(models.Accesses.group_id == requester.group_id).all())
         retrieved_media = [x.__dict__ for x in retrieved_media]
+        print("retrieved_media:", retrieved_media)
         return retrieved_media
 
 

--- a/src/app/api/routes/sites.py
+++ b/src/app/api/routes/sites.py
@@ -10,7 +10,7 @@ from app.api.crud.authorizations import check_group_update
 from app.db import sites, SiteType, get_session
 from app.api.schemas import SiteOut, SiteIn, SiteBase, AccessType
 from app.api.deps import get_current_access
-from app.api.crud.authorizations import is_admin_access, is_in_same_group
+from app.api.crud.authorizations import is_admin_access
 
 
 router = APIRouter()
@@ -54,7 +54,8 @@ async def get_site(site_id: int = Path(..., gt=0)):
 
 
 @router.get("/", response_model=List[SiteOut], summary="Get the list of all sites in your group")
-async def fetch_sites(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+async def fetch_sites(requester=Security(get_current_access,
+                      scopes=[AccessType.admin, AccessType.user]),
                       session=Depends(get_session)):
     """
     Retrieves the list of all sites and their information

--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -74,7 +74,6 @@ async def fetch_users(requester=Security(get_current_access,
     if await is_admin_access(requester.id):
         return await crud.fetch_all(users)
     else:
-        print(session.query(models.Users).first().access)
         retrieved_users = (session.query(models.Users)
                            .join(models.Accesses)
                            .filter(models.Accesses.group_id == requester.group_id).all())

--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -11,7 +11,7 @@ from app.api import crud
 from app.db import users, accesses, get_session, models
 from app.api.schemas import UserInfo, UserCreation, Cred, UserRead, UserAuth, AccessType
 from app.api.deps import get_current_user, get_current_access
-from app.api.crud.authorizations import is_admin_access, is_in_same_group
+from app.api.crud.authorizations import is_admin_access
 
 
 router = APIRouter()
@@ -65,7 +65,8 @@ async def get_user(user_id: int = Path(..., gt=0), _=Security(get_current_user, 
 
 
 @router.get("/", response_model=List[UserRead], summary="Get the list of all users")
-async def fetch_users(requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+async def fetch_users(requester=Security(get_current_access,
+                      scopes=[AccessType.admin, AccessType.user]),
                       session=Depends(get_session)):
     """
     Retrieves the list of all users and their information

--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -71,14 +71,11 @@ async def fetch_users(requester=Security(get_current_access, scopes=[AccessType.
     Retrieves the list of all users and their information
     """
     if await is_admin_access(requester.id):
-        blouauser = await crud.fetch_all(users)
-        print("blouauser:", blouauser)
-        return blouauser
+        return await crud.fetch_all(users)
     else:
         print(session.query(models.Users).first().access)
         retrieved_users = session.query(models.Users).join(models.Accesses).filter(models.Accesses.group_id == requester.group_id).all()
         retrieved_users = [x.__dict__ for x in retrieved_users]
-        print("retrieved_users," , retrieved_users)
         return retrieved_users
 
 

--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -74,7 +74,9 @@ async def fetch_users(requester=Security(get_current_access, scopes=[AccessType.
         return await crud.fetch_all(users)
     else:
         print(session.query(models.Users).first().access)
-        retrieved_users = session.query(models.Users).join(models.Accesses).filter(models.Accesses.group_id == requester.group_id).all()
+        retrieved_users = (session.query(models.Users)
+                           .join(models.Accesses)
+                           .filter(models.Accesses.group_id == requester.group_id).all())
         retrieved_users = [x.__dict__ for x in retrieved_users]
         return retrieved_users
 

--- a/src/app/db/__init__.py
+++ b/src/app/db/__init__.py
@@ -1,4 +1,14 @@
 from .tables import *
-from .session import engine, database, Base, get_session
+from .session import engine, database, Base, SessionLocal
 from .init_db import init_db
 from .models import AccessType, EventType, MediaType, SiteType
+
+
+# Dependency
+def get_session():
+    db = SessionLocal()
+    print("Called")
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/app/db/__init__.py
+++ b/src/app/db/__init__.py
@@ -7,7 +7,6 @@ from .models import AccessType, EventType, MediaType, SiteType
 # Dependency
 def get_session():
     db = SessionLocal()
-    print("Called")
     try:
         yield db
     finally:

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -106,8 +106,8 @@ class Events(Base):
     alerts = relationship("Alerts", back_populates="event")
 
     def __repr__(self):
-        return "<Event(lat='%s', lon='%s', country='%s', geocode='%s', type='%s')>" % (
-            self.lat, self.lon, self.country, self.geocode, self.type)
+        return "<Event(lat='%s', lon='%s', type='%s')>" % (
+            self.lat, self.lon, self.type)
 
 
 # Linked tables

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -7,6 +7,7 @@ import enum
 from .session import Base
 from sqlalchemy.sql import func
 from sqlalchemy import Column, DateTime, Integer, Float, String, Enum, Boolean, ForeignKey, MetaData
+from sqlalchemy.orm import relationship
 
 
 class Users(Base):
@@ -16,6 +17,11 @@ class Users(Base):
     login = Column(String(50), unique=True)
     access_id = Column(Integer, ForeignKey("accesses.id", ondelete="CASCADE"), unique=True)
     created_at = Column(DateTime, default=func.now())
+
+    access = relationship("Accesses", uselist=False, back_populates="user")
+
+    def __repr__(self):
+        return "<User(login='%s', created_at='%s'>" % (self.login, self.created_at)
 
 
 class AccessType(str, enum.Enum):
@@ -32,6 +38,11 @@ class Accesses(Base):
     hashed_password = Column(String(70), nullable=False)
     scope = Column(Enum(AccessType), default=AccessType.user, nullable=False)
     group_id = Column(Integer, ForeignKey("groups.id", ondelete="CASCADE"), nullable=False)
+
+    user = relationship("Users", uselist=False, back_populates="access")
+
+    def __repr__(self):
+        return "<Access(login='%s', scope='%s', group_id='%s')>" % (self.login, self.scope, self.group_id)
 
 
 class Groups(Base):

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -103,8 +103,7 @@ class Events(Base):
     end_ts = Column(DateTime, default=None, nullable=True)
     created_at = Column(DateTime, default=func.now())
 
-    # alerts = relationship("Alerts", back_populates="event")
-    alerts = relationship("Alerts")
+    alerts = relationship("Alerts", back_populates="event")
 
     def __repr__(self):
         return "<Event(lat='%s', lon='%s', country='%s', geocode='%s', type='%s')>" % (
@@ -187,7 +186,7 @@ class Alerts(Base):
 
     id = Column(Integer, primary_key=True)
     device_id = Column(Integer, ForeignKey("devices.id"))
-    event_id = Column(Integer, ForeignKey("events.id", ondelete="CASCADE"))
+    event_id = Column(Integer, ForeignKey("events.id", onupdate="CASCADE", ondelete="CASCADE"), nullable=True)
     media_id = Column(Integer, ForeignKey("media.id"), default=None)
     azimuth = Column(Float(4, asdecimal=True), default=None)
     lat = Column(Float(4, asdecimal=True))
@@ -196,7 +195,7 @@ class Alerts(Base):
     created_at = Column(DateTime, default=func.now())
 
     device = relationship("Devices", back_populates="alerts")
-    # event = relationship("Events", back_populates="alerts")
+    event = relationship("Events", back_populates="alerts")
     media = relationship("Media", back_populates="alerts")
 
     def __repr__(self):

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -19,6 +19,7 @@ class Users(Base):
     created_at = Column(DateTime, default=func.now())
 
     access = relationship("Accesses", uselist=False, back_populates="user")
+    device = relationship("Devices", uselist=False, back_populates="owner")
 
     def __repr__(self):
         return "<User(login='%s', created_at='%s'>" % (self.login, self.created_at)
@@ -40,6 +41,8 @@ class Accesses(Base):
     group_id = Column(Integer, ForeignKey("groups.id", ondelete="CASCADE"), nullable=False)
 
     user = relationship("Users", uselist=False, back_populates="access")
+    device = relationship("Devices", uselist=False, back_populates="access")
+    group = relationship("Groups", uselist=False, back_populates="accesses")
 
     def __repr__(self):
         return "<Access(login='%s', scope='%s', group_id='%s')>" % (self.login, self.scope, self.group_id)
@@ -50,6 +53,12 @@ class Groups(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String(50), unique=True)
+
+    accesses = relationship("Accesses", back_populates="group")
+    sites = relationship("Sites", back_populates="group")
+
+    def __repr__(self):
+        return "<Group(name='%s')>" % (self.name)
 
 
 class SiteType(str, enum.Enum):
@@ -71,6 +80,13 @@ class Sites(Base):
     type = Column(Enum(SiteType), default=SiteType.tower)
     created_at = Column(DateTime, default=func.now())
 
+    installations = relationship("Installations", back_populates="site")
+    group = relationship("Groups", uselist=False, back_populates="sites")
+
+    def __repr__(self):
+        return "<Site(name='%s', group_id='%s', lat='%s', lon='%s', country='%s', geocode='%s', type='%s')>" % (
+            self.name, self.group_id, self.lat, self.lon, self.country, self.geocode, self.type)
+
 
 class EventType(str, enum.Enum):
     wildfire: str = 'wildfire'
@@ -86,6 +102,12 @@ class Events(Base):
     start_ts = Column(DateTime, default=None, nullable=True)
     end_ts = Column(DateTime, default=None, nullable=True)
     created_at = Column(DateTime, default=func.now())
+
+    alerts = relationship("Alerts", back_populates="event")
+
+    def __repr__(self):
+        return "<Event(lat='%s', lon='%s', country='%s', geocode='%s', type='%s')>" % (
+            self.lat, self.lon, self.country, self.geocode, self.type)
 
 
 # Linked tables
@@ -107,6 +129,16 @@ class Devices(Base):
     last_ping = Column(DateTime, default=None, nullable=True)
     created_at = Column(DateTime, default=func.now())
 
+    access = relationship("Accesses", uselist=False, back_populates="device")
+    owner = relationship("Users", uselist=False, back_populates="device")
+    media = relationship("Media", back_populates="device")
+    alerts = relationship("Alerts", back_populates="device")
+    installation = relationship("Installations", back_populates="device")
+
+    def __repr__(self):
+        return "<Device(login='%s', owner_id='%s', access_id='%s', specs='%s', software_hash='%s', last_ping='%s')>" % (
+            self.login, self.owner_id, self.access_id, self.specs, self.software_hash, self.last_ping)
+
 
 class MediaType(str, enum.Enum):
     image: str = 'image'
@@ -122,6 +154,13 @@ class Media(Base):
     type = Column(Enum(MediaType), default=MediaType.image)
     created_at = Column(DateTime, default=func.now())
 
+    device = relationship("Devices", uselist=False, back_populates="media")
+    alerts = relationship("Alerts", back_populates="media")
+
+    def __repr__(self):
+        return "<Media(device_id='%s', bucket_key='%s', type='%s'>" % (
+            self.device_id, self.bucket_key, self.type)
+
 
 class Installations(Base):
     __tablename__ = "installations"
@@ -133,6 +172,13 @@ class Installations(Base):
     end_ts = Column(DateTime, default=None, nullable=True)
     is_trustworthy = Column(Boolean, default=True)
     created_at = Column(DateTime, default=func.now())
+
+    device = relationship("Devices", back_populates="installation")
+    site = relationship("Sites", back_populates="installations")
+
+    def __repr__(self):
+        return "<Installation(device_id='%s', site_id='%s', is_trustworthy='%s'>" % (
+            self.device_id, self.site_id, self.is_trustworthy)
 
 
 class Alerts(Base):
@@ -148,6 +194,14 @@ class Alerts(Base):
     is_acknowledged = Column(Boolean, default=False)
     created_at = Column(DateTime, default=func.now())
 
+    device = relationship("Devices", back_populates="alerts")
+    event = relationship("Events", back_populates="alerts")
+    media = relationship("Media", back_populates="alerts")
+
+    def __repr__(self):
+        return "<Alert(device_id='%s', event_id='%s', media_id='%s', is_acknowledged='%s'>" % (
+            self.device_id, self.event_id, self.media_id, self.is_acknowledged)
+
 
 class Webhooks(Base):
     __tablename__ = "webhooks"
@@ -155,3 +209,7 @@ class Webhooks(Base):
     id = Column(Integer, primary_key=True)
     callback = Column(String(50), nullable=False)
     url = Column(String(100), nullable=False)
+
+    def __repr__(self):
+        return "<Webhook(callback='%s', url='%s'>" % (
+            self.callback, self.url)

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -103,7 +103,8 @@ class Events(Base):
     end_ts = Column(DateTime, default=None, nullable=True)
     created_at = Column(DateTime, default=func.now())
 
-    alerts = relationship("Alerts", back_populates="event")
+    # alerts = relationship("Alerts", back_populates="event")
+    alerts = relationship("Alerts")
 
     def __repr__(self):
         return "<Event(lat='%s', lon='%s', country='%s', geocode='%s', type='%s')>" % (
@@ -186,7 +187,7 @@ class Alerts(Base):
 
     id = Column(Integer, primary_key=True)
     device_id = Column(Integer, ForeignKey("devices.id"))
-    event_id = Column(Integer, ForeignKey("events.id"))
+    event_id = Column(Integer, ForeignKey("events.id", ondelete="CASCADE"))
     media_id = Column(Integer, ForeignKey("media.id"), default=None)
     azimuth = Column(Float(4, asdecimal=True), default=None)
     lat = Column(Float(4, asdecimal=True))
@@ -195,7 +196,7 @@ class Alerts(Base):
     created_at = Column(DateTime, default=func.now())
 
     device = relationship("Devices", back_populates="alerts")
-    event = relationship("Events", back_populates="alerts")
+    # event = relationship("Events", back_populates="alerts")
     media = relationship("Media", back_populates="alerts")
 
     def __repr__(self):

--- a/src/app/db/session.py
+++ b/src/app/db/session.py
@@ -16,4 +16,3 @@ database = Database(cfg.DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
-

--- a/src/app/db/session.py
+++ b/src/app/db/session.py
@@ -17,11 +17,3 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
 
-
-# Dependency
-def get_session():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()

--- a/src/tests/db_utils.py
+++ b/src/tests/db_utils.py
@@ -7,6 +7,7 @@ import contextlib
 from typing import List, Dict, Any, Mapping
 from sqlalchemy import create_engine, Table
 from databases import Database
+from sqlalchemy.orm import sessionmaker
 
 from app.db import metadata
 import app.config as cfg
@@ -17,6 +18,7 @@ engine = create_engine(
 )
 metadata.create_all(bind=engine)
 database = Database(SQLALCHEMY_DATABASE_URL)
+TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
 async def reset_test_db():

--- a/src/tests/routes/test_alerts.py
+++ b/src/tests/routes/test_alerts.py
@@ -36,7 +36,7 @@ GROUP_TABLE = [
 ACCESS_TABLE = [
     {"id": 1, "group_id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
     {"id": 2, "group_id": 1, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
-    {"id": 3, "group_id": 2, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 3, "group_id": 1, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
     {"id": 4, "group_id": 2, "login": "fourth_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
@@ -114,15 +114,16 @@ async def test_get_alert(test_app_asyncio, init_test_db, access_idx, alert_id, s
 
 
 @pytest.mark.parametrize(
-    "access_idx, status_code, status_details",
+    "access_idx, status_code, status_details, expected_results",
     [
-        [0, 200, None],
-        [1, 200, None],
-        [2, 401, "Permission denied"],
+        [0, 200, None, [ALERT_TABLE[0], ALERT_TABLE[1], ALERT_TABLE[3]]],
+        [1, 200, None, ALERT_TABLE],
+        [2, 401, "Permission denied", None],
     ],
 )
 @pytest.mark.asyncio
-async def test_fetch_alerts(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
+async def test_fetch_alerts(test_app_asyncio, init_test_db, access_idx, status_code,
+                            status_details, expected_results):
 
     # Create a custom access token
     auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
@@ -133,9 +134,7 @@ async def test_fetch_alerts(test_app_asyncio, init_test_db, access_idx, status_c
         assert response.json()['detail'] == status_details
 
     if response.status_code // 100 == 2:
-        print(response.json())
-        print("Alert Table", ALERT_TABLE)
-        assert response.json() == ALERT_TABLE
+        assert response.json() == expected_results
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_devices.py
+++ b/src/tests/routes/test_devices.py
@@ -25,7 +25,7 @@ DEVICE_TABLE = [
     {"id": 2, "login": "fourth_login", "owner_id": 2, "access_id": 4, "specs": "v0.1", "elevation": None, "lat": None,
      "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68., "software_hash": None,
      "created_at": "2020-10-13T08:18:45.447773"},
-    {"id": 3, "login": "fifth_login", "owner_id": 3, "access_id": 5, "specs": "v0.1", "elevation": None, "lat": None,
+    {"id": 3, "login": "fifth_login", "owner_id": 3, "access_id": 6, "specs": "v0.1", "elevation": None, "lat": None,
      "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68., "software_hash": None,
      "created_at": "2020-10-13T08:18:45.447773"},
 ]

--- a/src/tests/routes/test_devices.py
+++ b/src/tests/routes/test_devices.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from app import db
 from app.api import crud, security
-from tests.db_utils import get_entry, fill_table
+from tests.db_utils import get_entry, fill_table, TestSessionLocal
 from tests.utils import update_only_datetime, parse_time
 
 USER_TABLE = [
@@ -46,6 +46,7 @@ DEVICE_TABLE_FOR_DB = list(map(update_only_datetime, DEVICE_TABLE))
 async def init_test_db(monkeypatch, test_db):
     monkeypatch.setattr(security, "hash_password", pytest.mock_hash_password)
     monkeypatch.setattr(crud.base, "database", test_db)
+    monkeypatch.setattr(db, "SessionLocal", TestSessionLocal)
     await fill_table(test_db, db.groups, GROUP_TABLE)
     await fill_table(test_db, db.accesses, ACCESS_TABLE)
     await fill_table(test_db, db.users, USER_TABLE_FOR_DB)

--- a/src/tests/routes/test_devices.py
+++ b/src/tests/routes/test_devices.py
@@ -15,6 +15,7 @@ from tests.utils import update_only_datetime, parse_time
 USER_TABLE = [
     {"id": 1, "login": "first_login", "access_id": 1, "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 2, "login": "second_login", "access_id": 2, "created_at": "2020-11-13T08:18:45.447773"},
+    {"id": 3, "login": "sixth_login", "access_id": 5, "created_at": "2020-11-13T08:18:45.447773"},
 ]
 
 DEVICE_TABLE = [
@@ -22,6 +23,9 @@ DEVICE_TABLE = [
      "access_id": 3, "specs": "v0.1", "elevation": None, "lat": None, "angle_of_view": 68., "software_hash": None,
      "lon": None, "yaw": None, "pitch": None, "last_ping": None, "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 2, "login": "fourth_login", "owner_id": 2, "access_id": 4, "specs": "v0.1", "elevation": None, "lat": None,
+     "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68., "software_hash": None,
+     "created_at": "2020-10-13T08:18:45.447773"},
+    {"id": 3, "login": "fifth_login", "owner_id": 3, "access_id": 5, "specs": "v0.1", "elevation": None, "lat": None,
      "lon": None, "yaw": None, "pitch": None, "last_ping": None, "angle_of_view": 68., "software_hash": None,
      "created_at": "2020-10-13T08:18:45.447773"},
 ]
@@ -34,8 +38,11 @@ GROUP_TABLE = [
 ACCESS_TABLE = [
     {"id": 1, "group_id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
     {"id": 2, "group_id": 1, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
-    {"id": 3, "group_id": 2, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
-    {"id": 4, "group_id": 2, "login": "fourth_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 3, "group_id": 1, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 4, "group_id": 1, "login": "fourth_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 5, "group_id": 2, "login": "fifth_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    {"id": 6, "group_id": 2, "login": "sixth_login", "hashed_password": "hashed_pwd", "scope": "user"},
+    
 ]
 
 USER_TABLE_FOR_DB = list(map(update_only_datetime, USER_TABLE))
@@ -106,15 +113,16 @@ async def test_get_my_device(test_app_asyncio, init_test_db, access_idx, status_
 
 
 @pytest.mark.parametrize(
-    "access_idx, status_code, status_details",
+    "access_idx, status_code, status_details, expected_devices",
     [
-        [0, 401, "Permission denied"],
-        [1, 200, None],
-        [2, 401, "Permission denied"],
+        [0, 200, None, [DEVICE_TABLE[0], DEVICE_TABLE[1]]],
+        [5, 200, None, [DEVICE_TABLE[-1]]],
+        [1, 200, None, DEVICE_TABLE],
+        [2, 401, "Permission denied", None],
     ],
 )
 @pytest.mark.asyncio
-async def test_fetch_devices(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
+async def test_fetch_devices(test_app_asyncio, init_test_db, access_idx, status_code, status_details, expected_devices):
 
     # Create a custom access token
     auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
@@ -125,7 +133,7 @@ async def test_fetch_devices(test_app_asyncio, init_test_db, access_idx, status_
         assert response.json()['detail'] == status_details
 
     if response.status_code // 100 == 2:
-        assert response.json() == [{k: v for k, v in entry.items() if k != "access_id"} for entry in DEVICE_TABLE]
+        assert response.json() == [{k: v for k, v in entry.items() if k != "access_id"} for entry in expected_devices]
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_devices.py
+++ b/src/tests/routes/test_devices.py
@@ -42,7 +42,6 @@ ACCESS_TABLE = [
     {"id": 4, "group_id": 1, "login": "fourth_login", "hashed_password": "hashed_pwd", "scope": "device"},
     {"id": 5, "group_id": 2, "login": "fifth_login", "hashed_password": "hashed_pwd", "scope": "user"},
     {"id": 6, "group_id": 2, "login": "sixth_login", "hashed_password": "hashed_pwd", "scope": "user"},
-    
 ]
 
 USER_TABLE_FOR_DB = list(map(update_only_datetime, USER_TABLE))

--- a/src/tests/routes/test_events.py
+++ b/src/tests/routes/test_events.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from app import db
 from app.api import crud
-from tests.db_utils import get_entry, fill_table
+from tests.db_utils import get_entry, fill_table, TestSessionLocal
 from tests.utils import update_only_datetime
 
 
@@ -41,6 +41,7 @@ EVENT_TABLE_FOR_DB = list(map(update_only_datetime, EVENT_TABLE))
 @pytest.fixture(scope="function")
 async def init_test_db(monkeypatch, test_db):
     monkeypatch.setattr(crud.base, "database", test_db)
+    monkeypatch.setattr(db, "SessionLocal", TestSessionLocal)
     await fill_table(test_db, db.groups, GROUP_TABLE)
     await fill_table(test_db, db.accesses, ACCESS_TABLE)
     await fill_table(test_db, db.events, EVENT_TABLE_FOR_DB)

--- a/src/tests/routes/test_events.py
+++ b/src/tests/routes/test_events.py
@@ -117,8 +117,6 @@ async def test_fetch_events(test_app_asyncio, init_test_db, access_idx, status_c
         assert response.json()['detail'] == status_details
 
     if response.status_code // 100 == 2:
-        print("response.json():", response.json())
-        print("expected_result:", expected_results)
         assert response.json() == expected_results
 
 

--- a/src/tests/routes/test_groups.py
+++ b/src/tests/routes/test_groups.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from app import db
 from app.api import crud
-from tests.db_utils import get_entry, fill_table
+from tests.db_utils import get_entry, fill_table, TestSessionLocal
 from tests.utils import update_only_datetime
 
 GROUP_TABLE = [
@@ -52,6 +52,7 @@ DEVICE_TABLE_FOR_DB = list(map(update_only_datetime, DEVICE_TABLE))
 @pytest.fixture(scope="function")
 async def init_test_db(monkeypatch, test_db):
     monkeypatch.setattr(crud.base, "database", test_db)
+    monkeypatch.setattr(db, "SessionLocal", TestSessionLocal)
     await fill_table(test_db, db.groups, GROUP_TABLE_FOR_DB)
     await fill_table(test_db, db.accesses, ACCESS_TABLE)
     await fill_table(test_db, db.users, USER_TABLE_FOR_DB)

--- a/src/tests/routes/test_installations.py
+++ b/src/tests/routes/test_installations.py
@@ -97,15 +97,16 @@ async def test_get_installation(test_app_asyncio, init_test_db,
 
 
 @pytest.mark.parametrize(
-    "access_idx, status_code, status_details",
+    "access_idx, status_code, status_details, expected_results",
     [
-        [0, 401, "Permission denied"],
-        [1, 200, None],
-        [2, 401, "Permission denied"],
+        [0, 200, None, [INSTALLATION_TABLE[0]]],
+        [1, 200, None, INSTALLATION_TABLE],
+        [2, 401, "Permission denied", None],
     ],
 )
 @pytest.mark.asyncio
-async def test_fetch_installations(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
+async def test_fetch_installations(test_app_asyncio, init_test_db,
+                                   access_idx, status_code, status_details, expected_results):
 
     # Create a custom access token
     auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
@@ -115,7 +116,7 @@ async def test_fetch_installations(test_app_asyncio, init_test_db, access_idx, s
     if isinstance(status_details, str):
         assert response.json()['detail'] == status_details
     if response.status_code // 100 == 2:
-        assert response.json() == INSTALLATION_TABLE
+        assert response.json() == expected_results
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_installations.py
+++ b/src/tests/routes/test_installations.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from app import db
 from app.api import crud
 from app.api.routes import installations
-from tests.db_utils import get_entry, fill_table
+from tests.db_utils import get_entry, fill_table, TestSessionLocal
 from tests.utils import update_only_datetime, parse_time
 
 USER_TABLE = [
@@ -62,6 +62,7 @@ INSTALLATION_TABLE_FOR_DB = list(map(update_only_datetime, INSTALLATION_TABLE))
 @pytest.fixture(scope="function")
 async def init_test_db(monkeypatch, test_db):
     monkeypatch.setattr(crud.base, "database", test_db)
+    monkeypatch.setattr(db, "SessionLocal", TestSessionLocal)
     await fill_table(test_db, db.groups, GROUP_TABLE)
     await fill_table(test_db, db.accesses, ACCESS_TABLE)
     await fill_table(test_db, db.users, USER_TABLE_FOR_DB)

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from app import db
 from app.api import crud
 from app.services import bucket_service
-from tests.db_utils import get_entry, fill_table
+from tests.db_utils import get_entry, fill_table, TestSessionLocal
 from tests.utils import update_only_datetime
 
 
@@ -57,6 +57,7 @@ MEDIA_TABLE_FOR_DB = list(map(update_only_datetime, MEDIA_TABLE))
 @pytest.fixture(scope="function")
 async def init_test_db(monkeypatch, test_db):
     monkeypatch.setattr(crud.base, "database", test_db)
+    monkeypatch.setattr(db, "SessionLocal", TestSessionLocal)
     await fill_table(test_db, db.groups, GROUP_TABLE)
     await fill_table(test_db, db.accesses, ACCESS_TABLE)
     await fill_table(test_db, db.users, USER_TABLE_FOR_DB)

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -39,13 +39,13 @@ GROUP_TABLE = [
 ACCESS_TABLE = [
     {"id": 1, "group_id": 1, "login": "first_login", "hashed_password": "hashed_pwd", "scope": "user"},
     {"id": 2, "group_id": 1, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
-    {"id": 3, "group_id": 2, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 3, "group_id": 1, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
     {"id": 4, "group_id": 2, "login": "fourth_login", "hashed_password": "hashed_pwd", "scope": "device"},
 ]
 
 MEDIA_TABLE = [
     {"id": 1, "device_id": 1, "type": "image", "created_at": "2020-10-13T08:18:45.447773"},
-    {"id": 2, "device_id": 1, "type": "video", "created_at": "2020-10-13T09:18:45.447773"},
+    {"id": 2, "device_id": 2, "type": "video", "created_at": "2020-10-13T09:18:45.447773"},
 ]
 
 
@@ -91,15 +91,15 @@ async def test_get_media(test_app_asyncio, init_test_db, access_idx, media_id, s
 
 
 @pytest.mark.parametrize(
-    "access_idx, status_code, status_details",
+    "access_idx, status_code, status_details, expected_results",
     [
-        [0, 401, "Permission denied"],
-        [1, 200, None],
-        [2, 401, "Permission denied"],
+        [0, 200, None, [MEDIA_TABLE[0]]],
+        [1, 200, None, MEDIA_TABLE],
+        [2, 401, "Permission denied", None],
     ],
 )
 @pytest.mark.asyncio
-async def test_fetch_media(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
+async def test_fetch_media(test_app_asyncio, init_test_db, access_idx, status_code, status_details, expected_results):
 
     # Create a custom access token
     auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
@@ -110,7 +110,7 @@ async def test_fetch_media(test_app_asyncio, init_test_db, access_idx, status_co
         assert response.json()['detail'] == status_details
 
     if response.status_code // 100 == 2:
-        assert response.json() == MEDIA_TABLE
+        assert response.json() == expected_results
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_sites.py
+++ b/src/tests/routes/test_sites.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from app import db
 from app.api import crud
-from tests.db_utils import get_entry, fill_table
+from tests.db_utils import get_entry, fill_table, TestSessionLocal
 from tests.utils import update_only_datetime
 
 
@@ -50,6 +50,7 @@ SITE_TABLE_FOR_DB = list(map(update_only_datetime, SITE_TABLE))
 @pytest.fixture(scope="function")
 async def init_test_db(monkeypatch, test_db):
     monkeypatch.setattr(crud.base, "database", test_db)
+    monkeypatch.setattr(db, "SessionLocal", TestSessionLocal)
     await fill_table(test_db, db.groups, GROUP_TABLE)
     await fill_table(test_db, db.accesses, ACCESS_TABLE)
     await fill_table(test_db, db.sites, SITE_TABLE_FOR_DB)

--- a/src/tests/routes/test_sites.py
+++ b/src/tests/routes/test_sites.py
@@ -99,7 +99,6 @@ async def test_fetch_sites(test_app_asyncio, init_test_db, access_idx, status_co
 
         for (i, entry) in enumerate(response.json()):
             compare_entries(entry, expected_sites[i])
-            # assert response.json() == [{k: v for k, v in entry.items() if k != "access_id"} for entry in expected_sites]
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_users.py
+++ b/src/tests/routes/test_users.py
@@ -111,7 +111,7 @@ async def test_get_my_user(test_app_asyncio, init_test_db, test_db, access_idx, 
     ],
 )
 @pytest.mark.asyncio
-async def test_fetch_users(test_app_asyncio, init_test_db, access_idx, 
+async def test_fetch_users(test_app_asyncio, init_test_db, access_idx,
                            status_code, status_details, expected_users):
 
     # Create a custom access token

--- a/src/tests/routes/test_users.py
+++ b/src/tests/routes/test_users.py
@@ -16,6 +16,7 @@ from tests.utils import update_only_datetime, parse_time
 USER_TABLE = [
     {"id": 1, "login": "first_login", "access_id": 1, "created_at": "2020-10-13T08:18:45.447773"},
     {"id": 2, "login": "second_login", "access_id": 2, "created_at": "2020-11-13T08:18:45.447773"},
+    {"id": 3, "login": "fifth_login", "access_id": 5, "created_at": "2020-11-13T08:18:45.447773"},
 ]
 
 GROUP_TABLE = [
@@ -28,6 +29,7 @@ ACCESS_TABLE = [
     {"id": 2, "group_id": 1, "login": "second_login", "hashed_password": "hashed_pwd", "scope": "admin"},
     {"id": 3, "group_id": 2, "login": "third_login", "hashed_password": "hashed_pwd", "scope": "device"},
     {"id": 4, "group_id": 2, "login": "fourth_login", "hashed_password": "hashed_pwd", "scope": "device"},
+    {"id": 5, "group_id": 2, "login": "fifth_login", "hashed_password": "hashed_pwd", "scope": "user"},
 ]
 
 
@@ -100,15 +102,17 @@ async def test_get_my_user(test_app_asyncio, init_test_db, test_db, access_idx, 
 
 
 @pytest.mark.parametrize(
-    "access_idx, status_code, status_details",
+    "access_idx, status_code, status_details, expected_users",
     [
-        [0, 401, "Permission denied"],
-        [1, 200, None],
-        [2, 401, "Permission denied"],
+        [0, 200, None, [USER_TABLE[0], USER_TABLE[1]]],
+        [4, 200, None, [USER_TABLE[-1]]],
+        [1, 200, None, USER_TABLE],
+        [2, 401, "Permission denied", None],
     ],
 )
 @pytest.mark.asyncio
-async def test_fetch_users(test_app_asyncio, init_test_db, access_idx, status_code, status_details):
+async def test_fetch_users(test_app_asyncio, init_test_db, access_idx, 
+                           status_code, status_details, expected_users):
 
     # Create a custom access token
     auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
@@ -119,7 +123,7 @@ async def test_fetch_users(test_app_asyncio, init_test_db, access_idx, status_co
     if isinstance(status_details, str):
         assert response.json()['detail'] == status_details
     if response.status_code // 100 == 2:
-        assert response.json() == [{k: v for k, v in entry.items() if k != "access_id"} for entry in USER_TABLE]
+        assert response.json() == [{k: v for k, v in entry.items() if k != "access_id"} for entry in expected_users]
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_users.py
+++ b/src/tests/routes/test_users.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from app import db
 from app.api import crud, security
-from tests.db_utils import get_entry, fill_table
+from tests.db_utils import get_entry, fill_table, TestSessionLocal
 from tests.utils import update_only_datetime, parse_time
 
 
@@ -37,6 +37,7 @@ USER_TABLE_FOR_DB = list(map(update_only_datetime, USER_TABLE))
 @pytest.fixture(scope="function")
 async def init_test_db(monkeypatch, test_db):
     monkeypatch.setattr(crud.base, "database", test_db)
+    monkeypatch.setattr(db, "SessionLocal", TestSessionLocal)
     await fill_table(test_db, db.groups, GROUP_TABLE)
     await fill_table(test_db, db.accesses, ACCESS_TABLE)
     await fill_table(test_db, db.users, USER_TABLE_FOR_DB)


### PR DESCRIPTION
# Context
Now that we have added SQLAlchemy models, we can now use them to ease the implementation of queries that rely on multiple joins.
Among those queries are the fetching routes that must return results only limited in a specified group_id.

# Content of the PR
* Add relationships in SQLALchemy models
* Add group_id in standard fetching routes (not yet implemented for all fetching routes)
* Adapted the unit Tests
* Fixed the relationship between events/alerts and the deletion cascading function (previous behavior was buggy.

## Reviews
Can you please check that:
* You agree with this new fetching behavior
* You are fine with the implementation and code organization

## Next steps
* PR to include the group_id logic in the remaining fetching functions
* PR to include the group_id logic in the update functions