### PR TITLE
fix: Fixed client header refresh

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -74,7 +74,6 @@ class Client:
     api: str
     routes: Dict[str, str]
     token: str
-    headers: Dict[str, str]
 
     def __init__(self, api_url: str, credentials_login: str, credentials_password: str) -> None:
         self.api = api_url

--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -81,10 +81,10 @@ class Client:
         # Prepend API url to each route
         self.routes = {k: urljoin(self.api, v) for k, v in ROUTES.items()}
         self.refresh_token(credentials_login, credentials_password)
-        self.headers = {"Authorization": f"Bearer {self.token}"}
 
     def refresh_token(self, login: str, password: str) -> None:
         self.token = self._retrieve_token(login, password)
+        self.headers = {"Authorization": f"Bearer {self.token}"}
 
     def _retrieve_token(self, login: str, password: str) -> str:
         response = requests.post(self.routes["token"],

--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -82,9 +82,12 @@ class Client:
         self.routes = {k: urljoin(self.api, v) for k, v in ROUTES.items()}
         self.refresh_token(credentials_login, credentials_password)
 
+    @property
+    def headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}"}
+
     def refresh_token(self, login: str, password: str) -> None:
         self.token = self._retrieve_token(login, password)
-        self.headers = {"Authorization": f"Bearer {self.token}"}
 
     def _retrieve_token(self, login: str, password: str) -> str:
         response = requests.post(self.routes["token"],

--- a/client/test/test_client.py
+++ b/client/test/test_client.py
@@ -66,9 +66,9 @@ class ClientTester(unittest.TestCase):
             self.assertTrue(updated_event['is_acknowledged'])
 
         # Check token refresh
-        prev_token = api_client.token
+        prev_headers = api_client.headers
         api_client.refresh_token("dummy_login", "dummy_pwd")
-        self.assertNotEqual(prev_token, api_client.token)
+        self.assertNotEqual(prev_headers, api_client.headers)
 
 
 if __name__ == '__main__':

--- a/client/test/test_client.py
+++ b/client/test/test_client.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import unittest
+from copy import deepcopy
 from requests import ConnectionError
 
 from pyroclient import client
@@ -66,7 +67,7 @@ class ClientTester(unittest.TestCase):
             self.assertTrue(updated_event['is_acknowledged'])
 
         # Check token refresh
-        prev_headers = api_client.headers
+        prev_headers = deepcopy(api_client.headers)
         api_client.refresh_token("dummy_login", "dummy_pwd")
         self.assertNotEqual(prev_headers, api_client.headers)
 


### PR DESCRIPTION
This PR introduces the following modifications:
- ensures that headers are refreshed after the token refresh
- extended unittest to make sure that the headers are refreshed

Any feedback is welcome!