### PR TITLE
feat: Specified HTTP status code and error messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ In order to run the same unit tests as the CI workflows, you can run the dockeri
 ```bash
 docker-compose up -d --build
 docker-compose exec -T pyroapi pip install -r requirements-dev.txt
-docker-compose exec -T pyroapi coverage run -m pytest test/
+docker-compose exec -T pyroapi pytest tests/
 ```
 Please note that you can pick another port number, it only has to be consistent once you have started your containers.
 

--- a/src/app/api/crud/accesses.py
+++ b/src/app/api/crud/accesses.py
@@ -5,7 +5,7 @@
 
 from typing import Dict, Any, Union, Type
 from sqlalchemy import Table
-from fastapi import HTTPException
+from fastapi import HTTPException, status
 
 from app.api import security
 from app.api.crud import base
@@ -30,7 +30,7 @@ async def check_login_existence(table: Table, login: str):
     """Check that the login does not already exist, raises a 400 exception if do so."""
     if await base.fetch_one(table, {"login": login}) is not None:
         raise HTTPException(
-            status_code=400,
+            status_code=status.HTTP_409_CONFLICT,
             detail=f"An entry with login='{login}' already exists.",
         )
 

--- a/src/app/api/crud/authorizations.py
+++ b/src/app/api/crud/authorizations.py
@@ -29,7 +29,10 @@ async def is_admin_access(access_id: int) -> bool:
 
 async def check_group_read(access_id: int, group_id: int) -> bool:
     if (not await is_admin_access(access_id)) and not (await is_access_in_group(access_id, group_id)):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="You can't access this ressource")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"This access can't read resources from group_id={group_id}"
+        )
     return True
 
 
@@ -38,5 +41,8 @@ async def check_group_update(access_id: int, group_id: int) -> bool:
             (group_id is not None)
             and (not await is_admin_access(access_id))
             and (not await is_access_in_group(access_id, group_id))):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="You can't specify another group")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"This access can't update resources for group_id={group_id}"
+        )
     return True

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -6,7 +6,7 @@
 from typing import Optional, Any, List, Dict, Mapping
 from sqlalchemy import Table
 from pydantic import BaseModel
-from fastapi import HTTPException, Path
+from fastapi import HTTPException, Path, status
 
 from app.db import database
 
@@ -76,7 +76,10 @@ async def create_entry(table: Table, payload: BaseModel) -> Dict[str, Any]:
 async def get_entry(table: Table, entry_id: int = Path(..., gt=0)) -> Dict[str, Any]:
     entry = await get(entry_id, table)
     if entry is None:
-        raise HTTPException(status_code=404, detail="Entry not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Table {table.name} has no entry with id={entry_id}"
+        )
 
     return dict(entry)
 
@@ -93,7 +96,10 @@ async def update_entry(
     entry_id = await put(entry_id, payload_dict, table)
 
     if not isinstance(entry_id, int):
-        raise HTTPException(status_code=404, detail="Entry not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Table {table.name} has no entry with id={entry_id}"
+        )
 
     if only_specified:
         # Retrieve complete record values

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -93,9 +93,9 @@ async def update_entry(
         # Dont update columns for null fields
         payload_dict = {k: v for k, v in payload_dict.items() if v is not None}
 
-    entry_id = await put(entry_id, payload_dict, table)
+    _id = await put(entry_id, payload_dict, table)
 
-    if not isinstance(entry_id, int):
+    if not isinstance(_id, int):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Table {table.name} has no entry with id={entry_id}"

--- a/src/app/api/crud/groups.py
+++ b/src/app/api/crud/groups.py
@@ -5,12 +5,13 @@
 
 
 from sqlalchemy import Table
+from typing import Optional
 
 from app.api import crud
 from app.db import accesses, users, sites, events, devices, media, installations, alerts
 
 
-async def get_entity_group_id(table: Table, entry_id: int) -> int:
+async def get_entity_group_id(table: Table, entry_id: int) -> Optional[int]:
 
     if table == accesses:
         return await _get_access_group_id(entry_id)
@@ -29,31 +30,25 @@ async def get_entity_group_id(table: Table, entry_id: int) -> int:
     elif table == alerts:
         return await _get_alert_group_id(entry_id)
 
-    raise f"{table} is not an existing entity"
+    raise ValueError(f"Unknown table '{table.name}'")
 
 
 async def _get_access_group_id(entry_id: int) -> int:
     entry = await crud.base.get_entry(accesses, entry_id)
-    if entry is None:
-        return None
     return entry["group_id"]
 
 
 async def _get_user_group_id(entry_id: int) -> int:
     entry = await crud.base.get_entry(users, entry_id)
-    if entry is None:
-        return None
     return await _get_access_group_id(entry["access_id"])
 
 
 async def _get_site_group_id(entry_id: int) -> int:
     entry = await crud.base.get_entry(sites, entry_id)
-    if entry is None:
-        return None
     return entry["group_id"]
 
 
-async def _get_event_group_id(entry_id: int) -> int:
+async def _get_event_group_id(entry_id: int) -> Optional[int]:
     entry = await crud.base.fetch_one(alerts, {"event_id": entry_id})
     if entry is None:
         return None
@@ -62,27 +57,19 @@ async def _get_event_group_id(entry_id: int) -> int:
 
 async def _get_device_group_id(entry_id: int) -> int:
     entry = await crud.base.get_entry(devices, entry_id)
-    if entry is None:
-        return None
     return await _get_access_group_id(entry["access_id"])
 
 
 async def _get_media_group_id(entry_id: int) -> int:
     entry = await crud.base.get_entry(media, entry_id)
-    if entry is None:
-        return None
     return await _get_device_group_id(entry["device_id"])
 
 
 async def _get_installation_group_id(entry_id: int) -> int:
     entry = await crud.base.get_entry(installations, entry_id)
-    if entry is None:
-        return None
     return await _get_site_group_id(entry["site_id"])
 
 
 async def _get_alert_group_id(entry_id: int) -> int:
     entry = await crud.base.get_entry(alerts, entry_id)
-    if entry is None:
-        return None
     return await _get_device_group_id(entry["device_id"])

--- a/src/app/api/deps.py
+++ b/src/app/api/deps.py
@@ -63,7 +63,7 @@ async def get_current_access(security_scopes: SecurityScopes, token: str = Depen
     if set(token_data.scopes).isdisjoint(security_scopes.scopes):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Your access scope is not compatible with this operation.",
+            detail="Your access scope is not compatible with this operation.",
             headers={"WWW-Authenticate": authenticate_value},
         )
 

--- a/src/app/api/deps.py
+++ b/src/app/api/deps.py
@@ -25,14 +25,6 @@ oauth2_scheme = OAuth2PasswordBearer(
 )
 
 
-def unauthorized_exception(detail: str, authenticate_value: str) -> HTTPException:
-    return HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail=detail,
-        headers={"WWW-Authenticate": authenticate_value},
-    )
-
-
 async def get_current_access(security_scopes: SecurityScopes, token: str = Depends(oauth2_scheme)) -> AccessRead:
     """ Dependency to use as fastapi.security.Security with scopes.
 
@@ -48,22 +40,32 @@ async def get_current_access(security_scopes: SecurityScopes, token: str = Depen
 
     try:
         payload = jwt.decode(token, cfg.SECRET_KEY, algorithms=[cfg.JWT_ENCODING_ALGORITHM])
-        access_id = payload.get("sub")
-        if access_id is None:
-            raise unauthorized_exception("Invalid credentials", authenticate_value)
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired.",
+            headers={"WWW-Authenticate": authenticate_value},
+        )
+
+    try:
+        access_id = int(payload["sub"])
         token_scopes = payload.get("scopes", [])
-        token_data = TokenPayload(access_id=int(access_id), scopes=token_scopes)
+        token_data = TokenPayload(access_id=access_id, scopes=token_scopes)
+    except (KeyError, ValidationError):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid token payload.",
+            headers={"WWW-Authenticate": authenticate_value},
+        )
 
-    except (JWTError, ValidationError, KeyError):
-        raise unauthorized_exception("Invalid credentials", authenticate_value)
-
-    entry = await crud.get(table=accesses, entry_id=int(access_id))
-
-    if entry is None:
-        raise unauthorized_exception("Invalid credentials", authenticate_value)
+    entry = await crud.get_entry(table=accesses, entry_id=int(access_id))
 
     if set(token_data.scopes).isdisjoint(security_scopes.scopes):
-        raise unauthorized_exception("Permission denied", authenticate_value)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Your access scope is not compatible with this operation.",
+            headers={"WWW-Authenticate": authenticate_value},
+        )
 
     return AccessRead(**entry)
 
@@ -71,7 +73,10 @@ async def get_current_access(security_scopes: SecurityScopes, token: str = Depen
 async def get_current_user(access: AccessRead = Depends(get_current_access)) -> UserRead:
     user = await crud.fetch_one(users, {'access_id': access.id})
     if user is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Permission denied")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No matching user with this credentials.",
+        )
 
     return UserRead(**user)
 
@@ -79,6 +84,9 @@ async def get_current_user(access: AccessRead = Depends(get_current_access)) -> 
 async def get_current_device(access: AccessRead = Depends(get_current_access)) -> DeviceOut:
     device = await crud.fetch_one(devices, {'access_id': access.id})
     if device is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Permission denied")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No matching device with this credentials.",
+        )
 
     return DeviceOut(**device)

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -23,8 +23,8 @@ async def check_media_existence(media_id):
     existing_media = await crud.get(media_id, media)
     if existing_media is None:
         raise HTTPException(
-            status_code=404,
-            detail="Media does not exist"
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unable to find media with id={media_id}."
         )
 
 
@@ -35,7 +35,7 @@ async def alert_notification(payload: AlertOut):
     map(partial(post_request, payload=payload), webhook_urls)
 
 
-@router.post("/", response_model=AlertOut, status_code=201, summary="Create a new alert")
+@router.post("/", response_model=AlertOut, status_code=status.HTTP_201_CREATED, summary="Create a new alert")
 async def create_alert(
     payload: AlertIn,
     background_tasks: BackgroundTasks,
@@ -59,7 +59,7 @@ async def create_alert(
     return alert
 
 
-@router.post("/from-device", response_model=AlertOut, status_code=201,
+@router.post("/from-device", response_model=AlertOut, status_code=status.HTTP_201_CREATED,
              summary="Create an alert related to the authentified device")
 async def create_alert_from_device(
     payload: AlertBase,
@@ -145,8 +145,8 @@ async def link_media(
     existing_alert = await crud.fetch_one(alerts, {"id": alert_id, "device_id": current_device.id})
     if existing_alert is None:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Permission denied"
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unable to find alert with id={alert_id} & device_id={current_device.id}."
         )
 
     await check_media_existence(payload.media_id)

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -49,7 +49,7 @@ async def register_device(
     return await crud.accesses.create_accessed_entry(devices, accesses, payload, DeviceCreation)
 
 
-@router.post("/register", response_model=DeviceOut, status_code=status.HTTP_201_CREATED, summary="Reg   ister your device")
+@router.post("/register", response_model=DeviceOut, status_code=status.HTTP_201_CREATED, summary="Register your device")
 async def register_my_device(
     payload: MyDeviceAuth,
     me: UserRead = Security(get_current_user, scopes=[AccessType.admin, AccessType.user])
@@ -158,7 +158,7 @@ async def update_device_location(
     if device["owner_id"] != user.id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied to modify device with id={device_id}."
+            detail=f"Permission denied to modify device with id={device_id}."
         )
     # Update only the location
     device.update(payload.dict())

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -30,7 +30,7 @@ from app.api.crud.authorizations import is_admin_access
 router = APIRouter()
 
 
-@router.post("/", response_model=DeviceOut, status_code=201, summary="Create a new device")
+@router.post("/", response_model=DeviceOut, status_code=status.HTTP_201_CREATED, summary="Create a new device")
 async def register_device(
     payload: AdminDeviceAuth,
     _=Security(get_current_access, scopes=[AccessType.admin])
@@ -40,8 +40,8 @@ async def register_device(
     Below, click on "Schema" for more detailed information about arguments
     or "Example Value" to get a concrete idea of arguments
     """
-    if await crud.get(payload.owner_id, users) is None:
-        raise HTTPException(status_code=404, detail=f"Unknown user for owner_id={payload.owner_id}")
+    await crud.get_entry(users, payload.owner_id)
+
     if payload.group_id is None:
         payload = payload.dict()
         payload["group_id"] = await get_entity_group_id(users, payload["owner_id"])
@@ -49,7 +49,7 @@ async def register_device(
     return await crud.accesses.create_accessed_entry(devices, accesses, payload, DeviceCreation)
 
 
-@router.post("/register", response_model=DeviceOut, status_code=201, summary="Reg   ister your device")
+@router.post("/register", response_model=DeviceOut, status_code=status.HTTP_201_CREATED, summary="Reg   ister your device")
 async def register_my_device(
     payload: MyDeviceAuth,
     me: UserRead = Security(get_current_user, scopes=[AccessType.admin, AccessType.user])
@@ -156,7 +156,10 @@ async def update_device_location(
     # Check that device is accessible to this user
     device = await crud.get_entry(devices, device_id)
     if device["owner_id"] != user.id:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Permission denied")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied to modify device with id={device_id}."
+        )
     # Update only the location
     device.update(payload.dict())
     device = DeviceOut(**device)

--- a/src/app/api/routes/events.py
+++ b/src/app/api/routes/events.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from typing import List
-from fastapi import APIRouter, Path, Security, Depends
+from fastapi import APIRouter, Path, Security, Depends, status
 from sqlalchemy import and_
 from app.api import crud
 from app.db import events, get_session, models
@@ -16,7 +16,7 @@ from app.api.crud.groups import get_entity_group_id
 router = APIRouter()
 
 
-@router.post("/", response_model=EventOut, status_code=201, summary="Create a new event")
+@router.post("/", response_model=EventOut, status_code=status.HTTP_201_CREATED, summary="Create a new event")
 async def create_event(
     payload: EventIn,
     _=Security(get_current_access, scopes=[AccessType.admin, AccessType.device])

--- a/src/app/api/routes/groups.py
+++ b/src/app/api/routes/groups.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from typing import List
-from fastapi import APIRouter, Path, Security
+from fastapi import APIRouter, Path, Security, status
 from app.api import crud
 from app.db import groups
 from app.api.schemas import GroupIn, GroupOut, AccessType
@@ -14,7 +14,7 @@ from app.api.deps import get_current_access
 router = APIRouter()
 
 
-@router.post("/", response_model=GroupOut, status_code=201, summary="Create a new group")
+@router.post("/", response_model=GroupOut, status_code=status.HTTP_201_CREATED, summary="Create a new group")
 async def create_group(payload: GroupIn, _=Security(get_current_access, scopes=[AccessType.admin])):
     """Creates a new group based on the given information
 

--- a/src/app/api/routes/installations.py
+++ b/src/app/api/routes/installations.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from typing import List
-from fastapi import APIRouter, Path, Security, Depends
+from fastapi import APIRouter, Path, Security, Depends, status
 from sqlalchemy import and_, or_
 from datetime import datetime
 from app.api import crud
@@ -17,7 +17,8 @@ from app.api.crud.groups import get_entity_group_id
 router = APIRouter()
 
 
-@router.post("/", response_model=InstallationOut, status_code=201, summary="Create a new installation")
+@router.post("/", response_model=InstallationOut, status_code=status.HTTP_201_CREATED,
+             summary="Create a new installation")
 async def create_installation(
     payload: InstallationIn,
     _=Security(get_current_access, scopes=[AccessType.admin])

--- a/src/app/api/routes/login.py
+++ b/src/app/api/routes/login.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from datetime import timedelta
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from app.api import crud, security
@@ -28,14 +28,18 @@ async def create_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
     # Verify credentials
     entry = await crud.fetch_one(accesses, {'login': form_data.username})
     if entry is None or not await security.verify_password(form_data.password, entry['hashed_password']):
-        raise HTTPException(status_code=400, detail="Invalid credentials")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials."
+        )
     # create access token using user user_id/user_scopes
     token_data = {"sub": str(entry['id']), "scopes": entry['scope'].split()}
     if entry["scope"] == "device":
         token = await security.create_unlimited_access_token(token_data)
     else:
-        token = await security.create_access_token(token_data,
-                                                   expires_delta=timedelta(minutes=cfg.ACCESS_TOKEN_EXPIRE_MINUTES)
-                                                   )
+        token = await security.create_access_token(
+            token_data,
+            expires_delta=timedelta(minutes=cfg.ACCESS_TOKEN_EXPIRE_MINUTES)
+        )
 
     return {"access_token": token, "token_type": "bearer"}

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -21,16 +21,16 @@ router = APIRouter()
 
 async def check_media_registration(media_id: int, device_id: Optional[int] = None) -> MediaOut:
     """Checks whether the media is registered in the DB"""
-    filters = {"id": media_id}
-    if device_id is not None:
-        filters.update({"device_id": device_id})
-
-    existing_media = await crud.fetch_one(media, filters)
-    if existing_media is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Permission denied"
-        )
+    if device_id is None:
+        media_dict = await crud.get_entry(media, media_id)
+        existing_media = MediaOut(**media_dict)
+    else:
+        existing_media = await crud.fetch_one(media, {"id": media_id, "device_id": device_id})
+        if existing_media is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Unable to find media with id={media_id} & device_id={device_id}"
+            )
     return existing_media
 
 

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -34,7 +34,8 @@ async def check_media_registration(media_id: int, device_id: Optional[int] = Non
     return existing_media
 
 
-@router.post("/", response_model=MediaOut, status_code=201, summary="Create a media related to a specific device")
+@router.post("/", response_model=MediaOut, status_code=status.HTTP_201_CREATED,
+             summary="Create a media related to a specific device")
 async def create_media(
     payload: MediaIn,
     _=Security(get_current_access, scopes=[AccessType.admin])
@@ -48,7 +49,7 @@ async def create_media(
     return await crud.create_entry(media, payload)
 
 
-@router.post("/from-device", response_model=MediaOut, status_code=201,
+@router.post("/from-device", response_model=MediaOut, status_code=status.HTTP_201_CREATED,
              summary="Create a media related to the authentified device")
 async def create_media_from_device(
     payload: BaseMedia,
@@ -148,7 +149,7 @@ async def upload_media_from_device(
         # Failed upload
         if not await bucket_service.upload_file(bucket_key=bucket_key, file_binary=file.file):
             raise HTTPException(
-                status_code=500,
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed upload"
             )
         # Data integrity check
@@ -156,8 +157,8 @@ async def upload_media_from_device(
         # Failed download
         if uploaded_file is None:
             raise HTTPException(
-                status_code=500,
-                detail="The data integrity check failed (unable to download media form bucket)"
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="The data integrity check failed (unable to download media from bucket)"
             )
         # Remove temp local file
         background_tasks.add_task(bucket_service.flush_tmp_file, uploaded_file)
@@ -168,7 +169,7 @@ async def upload_media_from_device(
             # Delete corrupted file
             await bucket_service.delete_file(bucket_key)
             raise HTTPException(
-                status_code=500,
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Data was corrupted during upload"
             )
 

--- a/src/app/api/routes/sites.py
+++ b/src/app/api/routes/sites.py
@@ -15,7 +15,7 @@ from app.api.crud.groups import get_entity_group_id
 router = APIRouter()
 
 
-@router.post("/", response_model=SiteOut, status_code=201, summary="Create a new site")
+@router.post("/", response_model=SiteOut, status_code=status.HTTP_201_CREATED, summary="Create a new site")
 async def create_site(
     payload: SiteIn,
     _=Security(get_current_access, scopes=[AccessType.admin])
@@ -29,7 +29,7 @@ async def create_site(
     return await crud.create_entry(sites, payload)
 
 
-@router.post("/no-alert/", response_model=SiteOut, status_code=201, summary="Create a new no-alert site")
+@router.post("/no-alert/", response_model=SiteOut, status_code=status.HTTP_201_CREATED, summary="Create a new no-alert site")
 async def create_noalert_site(
     payload: SiteBase,
     requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user])

--- a/src/app/api/routes/sites.py
+++ b/src/app/api/routes/sites.py
@@ -29,7 +29,8 @@ async def create_site(
     return await crud.create_entry(sites, payload)
 
 
-@router.post("/no-alert/", response_model=SiteOut, status_code=status.HTTP_201_CREATED, summary="Create a new no-alert site")
+@router.post("/no-alert/", response_model=SiteOut, status_code=status.HTTP_201_CREATED,
+             summary="Create a new no-alert site")
 async def create_noalert_site(
     payload: SiteBase,
     requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user])

--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -49,7 +49,7 @@ async def update_my_password(
     return entry
 
 
-@router.post("/", response_model=UserRead, status_code=201, summary="Create a new user")
+@router.post("/", response_model=UserRead, status_code=status.HTTP_201_CREATED, summary="Create a new user")
 async def create_user(
     payload: UserAuth,
     _=Security(get_current_user, scopes=[AccessType.admin])

--- a/src/app/api/routes/webhooks.py
+++ b/src/app/api/routes/webhooks.py
@@ -5,7 +5,7 @@
 
 from typing import List
 
-from fastapi import APIRouter, Path, Security
+from fastapi import APIRouter, Path, Security, status
 
 from app.api import crud
 from app.db import webhooks
@@ -16,7 +16,7 @@ from app.api.deps import get_current_access
 router = APIRouter()
 
 
-@router.post("/", response_model=WebhookOut, status_code=201, summary="Create a new webhook")
+@router.post("/", response_model=WebhookOut, status_code=status.HTTP_201_CREATED, summary="Create a new webhook")
 async def create_webhook(payload: WebhookIn, _=Security(get_current_access, scopes=["admin"])):
     """
     Creates a new webhook with the specified information

--- a/src/tests/routes/test_login.py
+++ b/src/tests/routes/test_login.py
@@ -33,8 +33,8 @@ async def init_test_db(monkeypatch, test_db):
     [
         [{"username": "foo"}, 422, None],
         [{"password": "foo"}, 422, None],
-        [{"username": "unknown", "password": "foo"}, 400, "Invalid credentials"],  # unknown username
-        [{"username": "first", "password": "second"}, 400, "Invalid credentials"],  # wrong pwd
+        [{"username": "unknown", "password": "foo"}, 401, "Invalid credentials."],  # unknown username
+        [{"username": "first", "password": "second"}, 401, "Invalid credentials."],  # wrong pwd
         [{"username": "first_login", "password": "first_pwd"}, 200, None],  # valid
     ],
 )

--- a/src/tests/routes/test_sites.py
+++ b/src/tests/routes/test_sites.py
@@ -90,7 +90,7 @@ async def test_get_site(test_app_asyncio, init_test_db, access_idx,
 @pytest.mark.parametrize(
     "access_idx, status_code, status_details, expected_sites",
     [
-        [None, 1, 401, "Not authenticated"],
+        [None, 401, "Not authenticated", []],
         [0, 200, None, [SITE_TABLE[0]]],
         [1, 200, None, SITE_TABLE],
         [2, 403, "Your access scope is not compatible with this operation.", None],

--- a/src/tests/routes/test_sites.py
+++ b/src/tests/routes/test_sites.py
@@ -60,11 +60,12 @@ async def init_test_db(monkeypatch, test_db):
 @pytest.mark.parametrize(
     "access_idx, site_id, status_code, status_details",
     [
+        [None, 1, 401, "Not authenticated"],
         [0, 1, 200, None],
         [1, 1, 200, None],
-        [1, 999, 404, "Entry not found"],
+        [1, 999, 404, "Table sites has no entry with id=999"],
         [0, 0, 422, None],
-        [4, 1, 401, "You can't access this ressource"],
+        [4, 1, 403, "This access can't read resources from group_id=1"],
     ],
 )
 @pytest.mark.asyncio
@@ -72,7 +73,9 @@ async def test_get_site(test_app_asyncio, init_test_db, access_idx,
                         site_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
+    auth = None
+    if isinstance(access_idx, int):
+        auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get(f"/sites/{site_id}", headers=auth)
     response_json = response.json()
@@ -87,15 +90,18 @@ async def test_get_site(test_app_asyncio, init_test_db, access_idx,
 @pytest.mark.parametrize(
     "access_idx, status_code, status_details, expected_sites",
     [
+        [None, 1, 401, "Not authenticated"],
         [0, 200, None, [SITE_TABLE[0]]],
         [1, 200, None, SITE_TABLE],
-        [2, 401, "Permission denied", None],
+        [2, 403, "Your access scope is not compatible with this operation.", None],
     ],
 )
 @pytest.mark.asyncio
 async def test_fetch_sites(test_app_asyncio, init_test_db, access_idx, status_code, status_details, expected_sites):
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
+    auth = None
+    if isinstance(access_idx, int):
+        auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.get("/sites/", headers=auth)
     assert response.status_code == status_code
@@ -111,6 +117,7 @@ async def test_fetch_sites(test_app_asyncio, init_test_db, access_idx, status_co
 @pytest.mark.parametrize(
     "access_idx, payload, expected_group_id, no_alert, status_code, status_details",
     [
+        [None, {}, None, False, 401, "Not authenticated"],
         [1, {"name": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
              "type": "tower", "country": "FR", "geocode": "01"}, 1, False,
          201, None],
@@ -124,15 +131,15 @@ async def test_fetch_sites(test_app_asyncio, init_test_db, access_idx, status_co
              "country": "FR", "geocode": "01"}, 1, True, 201, None],
         [0, {"name": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
              "country": "FR", "geocode": "01"}, 1, False,
-         401, "Permission denied"],
+         403, "Your access scope is not compatible with this operation."],
         [0, {"name": "my_site", "group_id": 2, "lat": 0., "lon": 0.,
              "country": "FR", "geocode": "01"}, 1, True,
-         401, "You can't specify another group"],
+         403, "This access can't update resources for group_id=2"],
         [0, {"name": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
              "country": "FR", "geocode": "01"}, 1, True, 201, None],
         [2, {"name": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
              "country": "FR", "geocode": "01"}, 1, False,
-         401, "Permission denied"],
+         403, "Your access scope is not compatible with this operation."],
         [1, {"names": "my_site", "group_id": 1, "lat": 0., "lon": 0.,
              "country": "FR", "geocode": "01"}, 1, False, 422, None],
         [1, {"name": "my_site", "group_id": 1, "lat": 0.,
@@ -144,7 +151,9 @@ async def test_create_site(test_app_asyncio, init_test_db, test_db,
                            access_idx, payload, expected_group_id, no_alert, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
+    auth = None
+    if isinstance(access_idx, int):
+        auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     test_response = {"id": len(SITE_TABLE) + 1, "group_id": expected_group_id, **payload}
     subroute = ""
@@ -171,18 +180,19 @@ async def test_create_site(test_app_asyncio, init_test_db, test_db,
 @pytest.mark.parametrize(
     "access_idx, payload, site_id, status_code, status_details",
     [
+        [None, {}, 1, 401, "Not authenticated"],
         [1, {"name": "renamed_site", "lat": 0., "lon": 0., "country": "FR", "geocode": "01"}, 1, 200, None],
         [0, {"name": "renamed_site", "lat": 0., "lon": 0., "country": "FR", "geocode": "01"}, 1,
          200, None],
         [2, {"name": "renamed_site", "lat": 0., "lon": 0., "country": "FR", "geocode": "01"}, 1,
-         401, "Permission denied"],
+         403, "Your access scope is not compatible with this operation."],
         [1, {}, 1, 422, None],
         [1, {"site_name": "foo"}, 1, 422, None],
         [1, {"name": "foo", "lat": 0., "lon": 0., "type": "tower", "country": "FR", "geocode": "01"}, 999, 404, None],
         [1, {"name": "1", "lat": 0., "lon": 0., "type": "tower", "country": "FR", "geocode": "01"}, 1, 422, None],
         [1, {"name": "foo", "lat": 0., "lon": 0., "type": "tower", "country": "FR", "geocode": "01"}, 0, 422, None],
         [4, {"name": "renamed_site", "lat": 0., "lon": 0., "country": "FR", "geocode": "01"},
-         1, 401, "You can't specify another group"],
+         1, 403, "This access can't update resources for group_id=1"],
     ],
 )
 @pytest.mark.asyncio
@@ -190,7 +200,9 @@ async def test_update_site(test_app_asyncio, init_test_db, test_db,
                            access_idx, payload, site_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
+    auth = None
+    if isinstance(access_idx, int):
+        auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.put(f"/sites/{site_id}/", data=json.dumps(payload), headers=auth)
     assert response.status_code == status_code
@@ -208,9 +220,10 @@ async def test_update_site(test_app_asyncio, init_test_db, test_db,
 @pytest.mark.parametrize(
     "access_idx, site_id, status_code, status_details",
     [
+        [None, 1, 401, "Not authenticated"],
         [1, 1, 200, None],
-        [0, 1, 401, "Permission denied"],
-        [1, 999, 404, "Entry not found"],
+        [0, 1, 403, "Your access scope is not compatible with this operation."],
+        [1, 999, 404, "Table sites has no entry with id=999"],
         [1, 0, 422, None],
     ],
 )
@@ -218,7 +231,9 @@ async def test_update_site(test_app_asyncio, init_test_db, test_db,
 async def test_delete_site(test_app_asyncio, init_test_db, access_idx, site_id, status_code, status_details):
 
     # Create a custom access token
-    auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
+    auth = None
+    if isinstance(access_idx, int):
+        auth = await pytest.get_token(ACCESS_TABLE[access_idx]['id'], ACCESS_TABLE[access_idx]['scope'].split())
 
     response = await test_app_asyncio.delete(f"/sites/{site_id}/", headers=auth)
     assert response.status_code == status_code


### PR DESCRIPTION
Following up on #161, this PR introduces the following modifications:
- fixes the instruction to run the unittest in CONTRIBUTING
- Specified error codes (cf. https://kinsta.com/blog/http-status-codes/): 404 when an entry isn't found, 401 when token expires or creds aren't valid, 409 when there is a conflict, 403 when the authorization level doesn't allow an operation
- Added detailed error messages for each `HTTPException`
- updated unittest accordingly

Closes #161 

Any feedback is welcome!