### PR TITLE
refactor: Moved azimuth angle from (-180, +180) to (0, 360)

### DIFF
--- a/client/test/test_client.py
+++ b/client/test/test_client.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import unittest
+import time
 from copy import deepcopy
 from requests import ConnectionError
 
@@ -68,6 +69,9 @@ class ClientTester(unittest.TestCase):
 
         # Check token refresh
         prev_headers = deepcopy(api_client.headers)
+        # In case the 2nd token creation request is done in the same second, since the expiration is truncated to the
+        # second, it returns the same token
+        time.sleep(1)
         api_client.refresh_token("dummy_login", "dummy_pwd")
         self.assertNotEqual(prev_headers, api_client.headers)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,3 +11,23 @@ ignore_missing_imports = True
 [mypy-qarnot.*]
 
 ignore_missing_imports = True
+
+[mypy-databases.*]
+
+ignore_missing_imports = True
+
+[mypy-jose.*]
+
+ignore_missing_imports = True
+
+[mypy-passlib.*]
+
+ignore_missing_imports = True
+
+[mypy-requests.*]
+
+ignore_missing_imports = True
+
+[mypy-app.*]
+
+ignore_missing_imports = True

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -115,13 +115,13 @@ class DefaultLocation(BaseModel):
 
 
 class _Rotation(BaseModel):
-    yaw: float = Field(..., gt=-180, lt=180, example=110)
-    pitch: float = Field(..., gt=-90, lt=90, example=-5)
+    yaw: float = Field(..., ge=0, le=360, example=110)
+    pitch: float = Field(..., ge=-90, le=90, example=-5)
 
 
 class _DefaultRotation(BaseModel):
-    yaw: Optional[float] = Field(None, gt=-180, lt=180, example=110)
-    pitch: Optional[float] = Field(None, gt=-90, lt=90, example=-5)
+    yaw: Optional[float] = Field(None, ge=0, le=360, example=110)
+    pitch: Optional[float] = Field(None, ge=-90, le=90, example=-5)
 
 
 class DefaultPosition(DefaultLocation, _DefaultRotation):
@@ -164,7 +164,7 @@ class SoftwareHash(BaseModel):
 class MyDeviceIn(Login, DefaultPosition):
     specs: str = Field(..., min_length=3, max_length=100, example="systemV0.1")
     last_ping: Optional[datetime] = Field(default=None, example=datetime.utcnow())
-    angle_of_view: float = Field(..., gt=0, lt=360, example=10)
+    angle_of_view: float = Field(..., ge=0, le=360, example=10)
     software_hash: Optional[str] = Field(None, min_length=8, max_length=16, example="0123456789ABCDEF")
 
 

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -3,5 +3,5 @@ pytest-asyncio>=0.14.0
 asyncpg>=0.20.0
 coverage>=4.5.4
 aiosqlite>=0.16.0
-httpx>=0.16.1
+httpx>=0.16.1,<0.19.0
 alembic==1.5.4


### PR DESCRIPTION
The azimuth was wrongly constrained between -180 and +180, while it should have been 0 and 360.
This PR fixes that, pinned the `httpx` version which caused problems during testing, and I fixed the client unittests which were failing on a very rare edge case

