### PR TITLE
fix: Fixed media registration inconsistency

### DIFF
--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -30,7 +30,7 @@ async def check_media_registration(media_id: int, device_id: Optional[int] = Non
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Unable to find media with id={media_id} & device_id={device_id}"
             )
-    return MediaOut(**_media)
+    return MediaOut(**media_dict)
 
 
 @router.post("/", response_model=MediaOut, status_code=status.HTTP_201_CREATED,


### PR DESCRIPTION
This PR fixes an inconsistency in `check_media_registration` which was either returning a dict or a `MediaOut`. I have no clue why the bug hasn't come up until now, but I deployed it on Heroku, created a device, a media, uploaded a media and fetched the URL without any issue with this PR :+1: 

Any feedback is welcome!