### PR TITLE
feat: Added max request response size for fetch routes

### DIFF
--- a/src/app/api/crud/alerts.py
+++ b/src/app/api/crud/alerts.py
@@ -30,7 +30,7 @@ async def fetch_ongoing_alerts(
             all_closed_events = all_closed_events.where(getattr(table.c, query_filter_key) == query_filter_value)
     query = query.where(~getattr(table.c, "event_id").in_(all_closed_events))
 
-    return await crud.base.database.fetch_all(query=query.limit(limit))[::-1]
+    return await crud.base.database.fetch_all(query=query.limit(limit))
 
 
 async def resolve_previous_alert(device_id: int) -> Optional[AlertOut]:

--- a/src/app/api/crud/alerts.py
+++ b/src/app/api/crud/alerts.py
@@ -16,7 +16,7 @@ from app.db import alerts
 
 
 async def fetch_ongoing_alerts(
-    table: Table, query_filters: Dict[str, Any], excluded_events_filter: Dict[str, Any], limit: int = 20,
+    table: Table, query_filters: Dict[str, Any], excluded_events_filter: Dict[str, Any], limit: int = 50,
 ) -> List[Mapping[str, Any]]:
     query = table.select().order_by(table.c.id.desc())
     if isinstance(query_filters, dict):

--- a/src/app/api/crud/alerts.py
+++ b/src/app/api/crud/alerts.py
@@ -30,7 +30,7 @@ async def fetch_ongoing_alerts(
             all_closed_events = all_closed_events.where(getattr(table.c, query_filter_key) == query_filter_value)
     query = query.where(~getattr(table.c, "event_id").in_(all_closed_events))
 
-    return await crud.base.database.fetch_all(query=query.limit(limit).order_by(table.c.id))
+    return await crud.base.database.fetch_all(query=query.limit(limit).order_by(table.c.id.asc()))
 
 
 async def resolve_previous_alert(device_id: int) -> Optional[AlertOut]:

--- a/src/app/api/crud/alerts.py
+++ b/src/app/api/crud/alerts.py
@@ -16,9 +16,9 @@ from app.db import alerts
 
 
 async def fetch_ongoing_alerts(
-    table: Table, query_filters: Dict[str, Any], excluded_events_filter: Dict[str, Any]
+    table: Table, query_filters: Dict[str, Any], excluded_events_filter: Dict[str, Any], limit: int = 20,
 ) -> List[Mapping[str, Any]]:
-    query = table.select()
+    query = table.select().order_by(table.c.id.desc())
     if isinstance(query_filters, dict):
         for query_filter_key, query_filter_value in query_filters.items():
             query = query.where(getattr(table.c, query_filter_key) == query_filter_value)
@@ -30,7 +30,7 @@ async def fetch_ongoing_alerts(
             all_closed_events = all_closed_events.where(getattr(table.c, query_filter_key) == query_filter_value)
     query = query.where(~getattr(table.c, "event_id").in_(all_closed_events))
 
-    return await crud.base.database.fetch_all(query=query)
+    return await crud.base.database.fetch_all(query=query.limit(limit).order_by(table.c.id))
 
 
 async def resolve_previous_alert(device_id: int) -> Optional[AlertOut]:

--- a/src/app/api/crud/alerts.py
+++ b/src/app/api/crud/alerts.py
@@ -30,7 +30,7 @@ async def fetch_ongoing_alerts(
             all_closed_events = all_closed_events.where(getattr(table.c, query_filter_key) == query_filter_value)
     query = query.where(~getattr(table.c, "event_id").in_(all_closed_events))
 
-    return await crud.base.database.fetch_all(query=query.limit(limit))
+    return await crud.base.database.fetch_all(query=query.limit(limit).order_by(table.c.id.desc()))
 
 
 async def resolve_previous_alert(device_id: int) -> Optional[AlertOut]:

--- a/src/app/api/crud/alerts.py
+++ b/src/app/api/crud/alerts.py
@@ -30,7 +30,7 @@ async def fetch_ongoing_alerts(
             all_closed_events = all_closed_events.where(getattr(table.c, query_filter_key) == query_filter_value)
     query = query.where(~getattr(table.c, "event_id").in_(all_closed_events))
 
-    return await crud.base.database.fetch_all(query=query.limit(limit).order_by(table.c.id.desc()))
+    return (await crud.base.database.fetch_all(query=query.limit(limit)))[::-1]
 
 
 async def resolve_previous_alert(device_id: int) -> Optional[AlertOut]:

--- a/src/app/api/crud/alerts.py
+++ b/src/app/api/crud/alerts.py
@@ -4,33 +4,15 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Optional
 
-from sqlalchemy import Table, and_
+from sqlalchemy import and_
 
 import app.config as cfg
 from app.api import crud
 from app.api.routes.events import create_event
 from app.api.schemas import AlertIn, AlertOut, EventIn
 from app.db import alerts
-
-
-async def fetch_ongoing_alerts(
-    table: Table, query_filters: Dict[str, Any], excluded_events_filter: Dict[str, Any], limit: int = 50,
-) -> List[Mapping[str, Any]]:
-    query = table.select().order_by(table.c.id.desc())
-    if isinstance(query_filters, dict):
-        for query_filter_key, query_filter_value in query_filters.items():
-            query = query.where(getattr(table.c, query_filter_key) == query_filter_value)
-
-    #  TODO Should be performed using a sqlalchemy accessor. E.g: alert_event_end_ts is None
-    all_closed_events = table.select().with_only_columns([table.c.event_id])
-    if isinstance(excluded_events_filter, dict):
-        for query_filter_key, query_filter_value in excluded_events_filter.items():
-            all_closed_events = all_closed_events.where(getattr(table.c, query_filter_key) == query_filter_value)
-    query = query.where(~getattr(table.c, "event_id").in_(all_closed_events))
-
-    return (await crud.base.database.fetch_all(query=query.limit(limit)))[::-1]
 
 
 async def resolve_previous_alert(device_id: int) -> Optional[AlertOut]:

--- a/src/app/api/crud/alerts.py
+++ b/src/app/api/crud/alerts.py
@@ -30,7 +30,7 @@ async def fetch_ongoing_alerts(
             all_closed_events = all_closed_events.where(getattr(table.c, query_filter_key) == query_filter_value)
     query = query.where(~getattr(table.c, "event_id").in_(all_closed_events))
 
-    return await crud.base.database.fetch_all(query=query.limit(limit).order_by(table.c.id.asc()))
+    return await crud.base.database.fetch_all(query=query.limit(limit))[::-1]
 
 
 async def resolve_previous_alert(device_id: int) -> Optional[AlertOut]:

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -49,7 +49,7 @@ async def fetch_all(
     if isinstance(exclusions, dict):
         for key, value in exclusions.items():
             query = query.where(getattr(table.c, key) != value)
-    return await database.fetch_all(query=query.limit(limit).order_by(table.c.id.asc()))
+    return await database.fetch_all(query=query.limit(limit))[::-1]
 
 
 async def fetch_one(table: Table, query_filters: Dict[str, Any]) -> Mapping[str, Any]:

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -49,7 +49,7 @@ async def fetch_all(
     if isinstance(exclusions, dict):
         for key, value in exclusions.items():
             query = query.where(getattr(table.c, key) != value)
-    return await database.fetch_all(query=query.limit(limit))
+    return await database.fetch_all(query=query.limit(limit).order_by(table.c.id.desc()))
 
 
 async def fetch_one(table: Table, query_filters: Dict[str, Any]) -> Mapping[str, Any]:

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -49,7 +49,7 @@ async def fetch_all(
     if isinstance(exclusions, dict):
         for key, value in exclusions.items():
             query = query.where(getattr(table.c, key) != value)
-    return await database.fetch_all(query=query.limit(limit))[::-1]
+    return await database.fetch_all(query=query.limit(limit))
 
 
 async def fetch_one(table: Table, query_filters: Dict[str, Any]) -> Mapping[str, Any]:

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -39,7 +39,7 @@ async def fetch_all(
     table: Table,
     query_filters: Optional[Dict[str, Any]] = None,
     exclusions: Optional[Dict[str, Any]] = None,
-    limit: int = 20,
+    limit: int = 50,
 ) -> List[Mapping[str, Any]]:
     query = table.select().order_by(table.c.id.desc())
     if isinstance(query_filters, dict):

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -49,7 +49,7 @@ async def fetch_all(
     if isinstance(exclusions, dict):
         for key, value in exclusions.items():
             query = query.where(getattr(table.c, key) != value)
-    return await database.fetch_all(query=query.limit(limit).order_by(table.c.id.desc()))
+    return (await database.fetch_all(query=query.limit(limit)))[::-1]
 
 
 async def fetch_one(table: Table, query_filters: Dict[str, Any]) -> Mapping[str, Any]:

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -49,7 +49,7 @@ async def fetch_all(
     if isinstance(exclusions, dict):
         for key, value in exclusions.items():
             query = query.where(getattr(table.c, key) != value)
-    return await database.fetch_all(query=query.limit(limit).order_by(table.c.id))
+    return await database.fetch_all(query=query.limit(limit).order_by(table.c.id.asc()))
 
 
 async def fetch_one(table: Table, query_filters: Dict[str, Any]) -> Mapping[str, Any]:

--- a/src/app/api/crud/base.py
+++ b/src/app/api/crud/base.py
@@ -39,8 +39,9 @@ async def fetch_all(
     table: Table,
     query_filters: Optional[Dict[str, Any]] = None,
     exclusions: Optional[Dict[str, Any]] = None,
+    limit: int = 20,
 ) -> List[Mapping[str, Any]]:
-    query = table.select()
+    query = table.select().order_by(table.c.id.desc())
     if isinstance(query_filters, dict):
         for key, value in query_filters.items():
             query = query.where(getattr(table.c, key) == value)
@@ -48,7 +49,7 @@ async def fetch_all(
     if isinstance(exclusions, dict):
         for key, value in exclusions.items():
             query = query.where(getattr(table.c, key) != value)
-    return await database.fetch_all(query=query)
+    return await database.fetch_all(query=query.limit(limit).order_by(table.c.id))
 
 
 async def fetch_one(table: Table, query_filters: Dict[str, Any]) -> Mapping[str, Any]:

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -173,7 +173,7 @@ async def fetch_ongoing_alerts(
                     .where(events.c.end_ts.is_(None))
                 ))).order_by(alerts.c.id.desc())
 
-        return await crud.base.database.fetch_all(query=query.limit(50))
+        return await crud.base.database.fetch_all(query=query.limit(50).order_by(alerts.c.id.desc()))
     else:
         retrieved_alerts = (session.query(models.Alerts)
                             .join(models.Events)

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -171,9 +171,9 @@ async def fetch_ongoing_alerts(
                 alerts.c.event_id.in_(
                     select([events.c.id])
                     .where(events.c.end_ts.is_(None))
-                )))
+                ))).order_by(alerts.c.id.desc())
 
-        return await crud.base.database.fetch_all(query=query)
+        return await crud.base.database.fetch_all(query=query.limit(20).order_by(alerts.c.id))
     else:
         retrieved_alerts = (session.query(models.Alerts)
                             .join(models.Events)

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -173,7 +173,7 @@ async def fetch_ongoing_alerts(
                     .where(events.c.end_ts.is_(None))
                 ))).order_by(alerts.c.id.desc())
 
-        return await crud.base.database.fetch_all(query=query.limit(20).order_by(alerts.c.id))
+        return await crud.base.database.fetch_all(query=query.limit(50).order_by(alerts.c.id))
     else:
         retrieved_alerts = (session.query(models.Alerts)
                             .join(models.Events)

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -173,7 +173,7 @@ async def fetch_ongoing_alerts(
                     .where(events.c.end_ts.is_(None))
                 ))).order_by(alerts.c.id.desc())
 
-        return await crud.base.database.fetch_all(query=query.limit(50).order_by(alerts.c.id))
+        return await crud.base.database.fetch_all(query=query.limit(50).order_by(alerts.c.id.asc()))
     else:
         retrieved_alerts = (session.query(models.Alerts)
                             .join(models.Events)

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -173,7 +173,7 @@ async def fetch_ongoing_alerts(
                     .where(events.c.end_ts.is_(None))
                 ))).order_by(alerts.c.id.desc())
 
-        return await crud.base.database.fetch_all(query=query.limit(50))[::-1]
+        return await crud.base.database.fetch_all(query=query.limit(50))
     else:
         retrieved_alerts = (session.query(models.Alerts)
                             .join(models.Events)

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -173,7 +173,7 @@ async def fetch_ongoing_alerts(
                     .where(events.c.end_ts.is_(None))
                 ))).order_by(alerts.c.id.desc())
 
-        return await crud.base.database.fetch_all(query=query.limit(50).order_by(alerts.c.id.desc()))
+        return (await crud.base.database.fetch_all(query=query.limit(50)))[::-1]
     else:
         retrieved_alerts = (session.query(models.Alerts)
                             .join(models.Events)

--- a/src/app/api/routes/alerts.py
+++ b/src/app/api/routes/alerts.py
@@ -173,7 +173,7 @@ async def fetch_ongoing_alerts(
                     .where(events.c.end_ts.is_(None))
                 ))).order_by(alerts.c.id.desc())
 
-        return await crud.base.database.fetch_all(query=query.limit(50).order_by(alerts.c.id.asc()))
+        return await crud.base.database.fetch_all(query=query.limit(50))[::-1]
     else:
         retrieved_alerts = (session.query(models.Alerts)
                             .join(models.Events)

--- a/src/tests/routes/test_groups.py
+++ b/src/tests/routes/test_groups.py
@@ -12,7 +12,6 @@ from app.api import crud
 from tests.db_utils import TestSessionLocal, fill_table, get_entry
 from tests.utils import update_only_datetime
 
-
 # Have more groups than max request (20)
 GROUP_TABLE = [{"id": idx + 1, "name": f"group_{idx}"} for idx in range(51)]
 

--- a/src/tests/routes/test_groups.py
+++ b/src/tests/routes/test_groups.py
@@ -14,7 +14,7 @@ from tests.utils import update_only_datetime
 
 
 # Have more groups than max request (20)
-GROUP_TABLE = [{"id": idx + 1, "name": f"group_{idx}"} for idx in range(21)]
+GROUP_TABLE = [{"id": idx + 1, "name": f"group_{idx}"} for idx in range(51)]
 
 
 USER_TABLE = [

--- a/src/tests/routes/test_groups.py
+++ b/src/tests/routes/test_groups.py
@@ -12,10 +12,9 @@ from app.api import crud
 from tests.db_utils import TestSessionLocal, fill_table, get_entry
 from tests.utils import update_only_datetime
 
-GROUP_TABLE = [
-    {"id": 1, "name": "first_group"},
-    {"id": 2, "name": "second_group"}
-]
+
+# Have more groups than max request (20)
+GROUP_TABLE = [{"id": idx + 1, "name": f"group_{idx}"} for idx in range(21)]
 
 
 USER_TABLE = [
@@ -86,7 +85,7 @@ async def test_fetch_groups(test_app_asyncio, init_test_db):
     response = await test_app_asyncio.get("/groups/")
     assert response.status_code == 200
     response_json = response.json()
-    assert all(result == entry for result, entry in zip(response_json, GROUP_TABLE))
+    assert all(result == entry for result, entry in zip(response_json, GROUP_TABLE[-20:]))
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_groups.py
+++ b/src/tests/routes/test_groups.py
@@ -84,7 +84,7 @@ async def test_fetch_groups(test_app_asyncio, init_test_db):
     response = await test_app_asyncio.get("/groups/")
     assert response.status_code == 200
     response_json = response.json()
-    assert all(result == entry for result, entry in zip(response_json, GROUP_TABLE[-20:]))
+    assert all(result == entry for result, entry in zip(response_json, GROUP_TABLE[-50:]))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR introduces the following modifications:
- added a configurable limit to the size of the return response (set to 50 for now)
- adds a dedicated test case

For table with large number of entries, this will considerably speed it up. This PR makes it so that the limit is embedded in the SQL request (not done a posteriori).

That should help a lot with ongoing_alerts @Akilditu !


Any feedback is welcome!