### PR TITLE
ci: Removed version update for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: pip
-    directory: "/"
-    schedule:
-      interval: daily
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
This PR removes the version update of the dependabot (alerts and security updates will still work)

Any feedback is welcome!