### PR TITLE
fix: Fixed media duplication

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -122,14 +122,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.24.19"
+version = "1.24.20"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.27.19,<1.28.0"
+botocore = ">=1.27.20,<1.28.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -138,7 +138,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.27.19"
+version = "1.27.20"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -661,6 +661,14 @@ pycrypto = ["pycrypto (>=2.6.0,<2.7.0)", "pyasn1"]
 pycryptodome = ["pycryptodome (>=3.3.1,<4.0.0)", "pyasn1"]
 
 [[package]]
+name = "python-magic"
+version = "0.4.27"
+description = "File type identification using libmagic"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "python-multipart"
 version = "0.0.5"
 description = "A streaming multipart parser for Python"
@@ -908,7 +916,7 @@ quality = ["flake8", "isort", "mypy", "pydocstyle", "black"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "402d5c05eb994237264c0ac2e7c5c7265221ec078fe08d0492f43128d904f13b"
+content-hash = "dae8b836eebd5bb967ce1d3bcc69db89328dec39f3fcfc9069f1693fcd03683a"
 
 [metadata.files]
 aiofiles = [
@@ -1002,12 +1010,12 @@ black = [
     {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
 ]
 boto3 = [
-    {file = "boto3-1.24.19-py3-none-any.whl", hash = "sha256:882091279f4520bf6b8b535e02dbef4fe14280404035a93ea5396821f10b4f4b"},
-    {file = "boto3-1.24.19.tar.gz", hash = "sha256:cc01e513a54914b2a8b5515cade3bc359f9001b108416664053f02882f85050f"},
+    {file = "boto3-1.24.20-py3-none-any.whl", hash = "sha256:7033d3a351171b85647405eb70c4c9ae0d75c085dd987d7674557607acbcd459"},
+    {file = "boto3-1.24.20.tar.gz", hash = "sha256:e87dbc67475b0ea7564b17b6686995fd3a120312a95a625e6db61490fa0a3fed"},
 ]
 botocore = [
-    {file = "botocore-1.27.19-py3-none-any.whl", hash = "sha256:e52c77fb349ae5d2a36ba0c2d1dc1416d963f987139dc2e036d2d8d697e4b4c7"},
-    {file = "botocore-1.27.19.tar.gz", hash = "sha256:850bec9363e10c56b2678c3742a48150f6201d7184695326a380fe7341075484"},
+    {file = "botocore-1.27.20-py3-none-any.whl", hash = "sha256:bb80a2204ccd51c1611e562d3d0511dc2a156257f87edeb59e99d7cef24b75d6"},
+    {file = "botocore-1.27.20.tar.gz", hash = "sha256:d3445a382711b58b4ec29e42267f074aa743ac7a5ddc50a08e0aae2b8309e3a5"},
 ]
 certifi = [
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
@@ -1435,6 +1443,10 @@ python-editor = [
 python-jose = [
     {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
     {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
+]
+python-magic = [
+    {file = "python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b"},
+    {file = "python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"},
 ]
 python-multipart = [
     {file = "python-multipart-0.0.5.tar.gz", hash = "sha256:f7bb5f611fc600d15fa47b3974c8aa16e93724513b49b5f95c81e6624c83fa43"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ aiofiles = "==0.6.0"
 requests = "^2.22.0"
 sentry-sdk = "^1.5.12"
 qarnot = "^2.2.1"
+python-magic = "^0.4.17"
 
 flake8 = { version = ">=3.9.0,<5.0.0", optional = true }
 isort = { version = "^5.7.0", optional = true }

--- a/src/app/requirements.txt
+++ b/src/app/requirements.txt
@@ -2,8 +2,8 @@ aiofiles==0.6.0
 anyio==3.6.1; python_version >= "3.6" and python_full_version >= "3.6.2"
 asyncpg==0.25.0; python_full_version >= "3.6.0"
 bcrypt==3.2.2; python_version >= "3.6"
-boto3==1.24.19; python_version >= "3.7"
-botocore==1.27.19; python_version >= "3.7"
+boto3==1.24.20; python_version >= "3.7"
+botocore==1.27.20; python_version >= "3.7"
 certifi==2022.6.15; python_version >= "3.7" and python_version < "4"
 cffi==1.15.0; python_version >= "3.6"
 charset-normalizer==2.1.0; python_version >= "3.7" and python_version < "4" and python_full_version >= "3.6.0"
@@ -26,6 +26,7 @@ pydantic==1.9.1; python_full_version >= "3.6.1"
 pyparsing==3.0.9; python_full_version >= "3.6.8" and python_version >= "3.6"
 python-dateutil==2.8.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7"
 python-jose==3.3.0
+python-magic==0.4.27; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 python-multipart==0.0.5
 qarnot==2.10.0; python_version >= "3.6"
 requests==2.28.1; python_version >= "3.7" and python_version < "4"

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -6,8 +6,8 @@ asyncpg==0.25.0; python_full_version >= "3.6.0"
 atomicwrites==1.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.4.0"
 attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 bcrypt==3.2.2; python_version >= "3.6"
-boto3==1.24.19; python_version >= "3.7"
-botocore==1.27.19; python_version >= "3.7"
+boto3==1.24.20; python_version >= "3.7"
+botocore==1.27.20; python_version >= "3.7"
 certifi==2022.6.15; python_version >= "3.7" and python_version < "4"
 cffi==1.15.0; python_version >= "3.6"
 charset-normalizer==2.1.0; python_version >= "3.7" and python_version < "4" and python_full_version >= "3.6.0"
@@ -41,6 +41,7 @@ pytest==7.1.2; python_version >= "3.7"
 python-dateutil==2.8.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 python-editor==1.0.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 python-jose==3.3.0
+python-magic==0.4.27; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 python-multipart==0.0.5
 qarnot==2.10.0; python_version >= "3.6"
 requests==2.28.1; python_version >= "3.7" and python_version < "4"

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -274,12 +274,19 @@ async def test_update_media(
     ],
 )
 @pytest.mark.asyncio
-async def test_delete_media(test_app_asyncio, init_test_db, access_idx, media_id, status_code, status_details):
+async def test_delete_media(
+    test_app_asyncio, init_test_db, monkeypatch, access_idx, media_id, status_code, status_details
+):
 
     # Create a custom access token
     auth = None
     if isinstance(access_idx, int):
         auth = await pytest.get_token(ACCESS_TABLE[access_idx]["id"], ACCESS_TABLE[access_idx]["scope"].split())
+
+    async def mock_delete_file(filename):
+        return True
+
+    monkeypatch.setattr(bucket_service, "delete_file", mock_delete_file)
 
     response = await test_app_asyncio.delete(f"/media/{media_id}/", headers=auth)
     assert response.status_code == status_code


### PR DESCRIPTION
This PR introduces the following modifications:
- updates bucket name resolution: formerly hash first 32 characters + ".file", now timestamp + fash first 8 characters + extension (using mimetype guessing)
- delete the previous file from bucket when a media is assigned a new file via upload
- deletes file when media is deleted
- updates test accordingly

Closes #94