### PR TITLE
feat: Added support of alternative S3 storage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           docker-compose -f docker-compose-dev.yml exec -T backend coverage --version
           docker-compose -f docker-compose-dev.yml exec -T backend coverage run -m pytest tests/
           docker-compose -f docker-compose-dev.yml exec -T backend coverage xml
-          docker cp pyro-api_pyroapi_1:/app/coverage.xml .
+          docker cp pyro-api_backend_1:/app/coverage.xml .
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,9 @@ jobs:
           docker-compose -f docker-compose-dev.yml up -d --build
       - name: Run docker test
         run: |
-          docker-compose -f docker-compose-dev.yml exec -T pyroapi coverage --version
-          docker-compose -f docker-compose-dev.yml exec -T pyroapi coverage run -m pytest tests/
-          docker-compose -f docker-compose-dev.yml exec -T pyroapi coverage xml
+          docker-compose -f docker-compose-dev.yml exec -T backend coverage --version
+          docker-compose -f docker-compose-dev.yml exec -T backend coverage run -m pytest tests/
+          docker-compose -f docker-compose-dev.yml exec -T backend coverage xml
           docker cp pyro-api_pyroapi_1:/app/coverage.xml .
 
       - uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ stop-dev:
 test:
 	docker build src/. -t pyroapi:python3.8-alpine3.10
 	docker-compose -f docker-compose-dev.yml up -d --build
-	docker-compose exec -T pyroapi coverage run -m pytest tests/
+	docker-compose exec -T backend coverage run -m pytest tests/
 	docker-compose -f docker-compose-dev.yml down
 
 # Run tests for the Python client

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 services:
-  pyroapi:
+  backend:
     build:
       context: src
       dockerfile: Dockerfile-dev
@@ -20,15 +20,19 @@ services:
       - QARNOT_TOKEN=${QARNOT_TOKEN}
       - BUCKET_NAME=${BUCKET_NAME}
       - BUCKET_MEDIA_FOLDER=${BUCKET_MEDIA_FOLDER}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
+      - S3_ACCESS_KEY=${S3_ACCESS_KEY}
+      - S3_SECRET_KEY=${S3_SECRET_KEY}
+      - S3_REGION=${S3_REGION}
     depends_on:
       - db
-  nginx:
+  proxy:
     build: nginx
     ports:
       - 80:80
       - 443:443
     depends_on:
-      - pyroapi
+      - backend
   db:
     image: postgres:12.1-alpine
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 services:
-  pyroapi:
+  backend:
     build: src
     restart: always
     command: uvicorn app.main:app --reload --workers 1 --host 0.0.0.0 --port 8080
@@ -29,13 +29,13 @@ services:
       - POSTGRES_USER=dummy_pg_user
       - POSTGRES_PASSWORD=dummy_pg_pwd
       - POSTGRES_DB=dummy_pg_db
-  nginx:
+  proxy:
     build: nginx
     ports:
       - 80:80
       - 443:443
     depends_on:
-      - pyroapi
+      - backend
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       - QARNOT_TOKEN=${QARNOT_TOKEN}
       - BUCKET_NAME=${BUCKET_NAME}
       - BUCKET_MEDIA_FOLDER=${BUCKET_MEDIA_FOLDER}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
+      - S3_ACCESS_KEY=${S3_ACCESS_KEY}
+      - S3_SECRET_KEY=${S3_SECRET_KEY}
+      - S3_REGION=${S3_REGION}
     depends_on:
       - db
   db:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,7 +18,7 @@ http {
     # to return a good HTTP response
 
     # for a TCP configuration
-    server pyroapi:8080 fail_timeout=0;
+    server backend:8080 fail_timeout=0;
   }
 
   server {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ module = [
     "sqlalchemy.*",
     "app.*",
     "boto3.*",
+    "botocore.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ module = [
     "qarnot.*",
     "sqlalchemy.*",
     "app.*",
+    "boto3.*",
 ]
 ignore_missing_imports = true
 

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -154,9 +154,9 @@ async def upload_media_from_device(
         if not (await bucket_service.upload_file(bucket_key=bucket_key, file_binary=file.file)):
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed upload")
         # Data integrity check
-        file_meta = bucket_service.get_file_metadata(bucket_key)
+        file_meta = await bucket_service.get_file_metadata(bucket_key)
         # Corrupted file
-        if md5_hash != file_meta["ETag"]:
+        if md5_hash != file_meta["ETag"].replace('"', ''):
             # Delete the corrupted upload
             await bucket_service.delete_file(bucket_key)
             # Raise the exception

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -156,7 +156,7 @@ async def upload_media_from_device(
         # Data integrity check
         file_meta = await bucket_service.get_file_metadata(bucket_key)
         # Corrupted file
-        if md5_hash != file_meta["ETag"].replace('"', ''):
+        if md5_hash != file_meta["ETag"].replace('"', ""):
             # Delete the corrupted upload
             await bucket_service.delete_file(bucket_key)
             # Raise the exception

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -161,7 +161,8 @@ async def upload_media_from_device(
             await bucket_service.delete_file(bucket_key)
             # Raise the exception
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Data was corrupted during upload",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Data was corrupted during upload",
             )
         # If a file was previously uploaded, delete it
         if isinstance(entry["bucket_key"], str):

--- a/src/app/api/routes/media.py
+++ b/src/app/api/routes/media.py
@@ -132,12 +132,15 @@ async def upload_media_from_device(
     entry = await check_media_registration(media_id, current_device.id)
 
     # Concatenate the first 8 chars (to avoid system interactions issues) of SHA256 hash with file extension
-    file_hash = hash_content_file(file.file.read())
+    sha_hash = hash_content_file(file.file.read())
+    await file.seek(0)
+    # Use MD5 to verify upload
+    md5_hash = hash_content_file(file.file.read(), use_md5=True)
     await file.seek(0)
     # guess_extension will return none if this fails
     extension = guess_extension(magic.from_buffer(file.file.read(), mime=True)) or ""
     # Concatenate timestamp & hash
-    file_name = f"{datetime.utcnow().strftime('%Y%m%d%H%M%S')}-{file_hash[:8]}{extension}"
+    file_name = f"{datetime.utcnow().strftime('%Y%m%d%H%M%S')}-{sha_hash[:8]}{extension}"
     # Reset byte position of the file (cf. https://fastapi.tiangolo.com/tutorial/request-files/#uploadfile)
     await file.seek(0)
     # If files are in a subfolder of the bucket, prepend the folder path
@@ -151,23 +154,14 @@ async def upload_media_from_device(
         if not (await bucket_service.upload_file(bucket_key=bucket_key, file_binary=file.file)):
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed upload")
         # Data integrity check
-        uploaded_file = await bucket_service.get_file(bucket_key=bucket_key)
-        # Failed download
-        if uploaded_file is None:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="The data integrity check failed (unable to download media from bucket)",
-            )
-        # Remove temp local file
-        background_tasks.add_task(bucket_service.flush_tmp_file, uploaded_file)
-        # Check the hash
-        with open(uploaded_file, "rb") as f:
-            upload_hash = hash_content_file(f.read())
-        if upload_hash != file_hash:
-            # Delete corrupted file
+        file_meta = bucket_service.get_file_metadata(bucket_key)
+        # Corrupted file
+        if md5_hash != file_meta["ETag"]:
+            # Delete the corrupted upload
             await bucket_service.delete_file(bucket_key)
+            # Raise the exception
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Data was corrupted during upload"
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Data was corrupted during upload",
             )
         # If a file was previously uploaded, delete it
         if isinstance(entry["bucket_key"], str):

--- a/src/app/api/security.py
+++ b/src/app/api/security.py
@@ -36,5 +36,6 @@ async def hash_password(password: str) -> str:
     return pwd_context.hash(password)
 
 
-def hash_content_file(content: bytes) -> str:
-    return hashlib.sha256(content).hexdigest()
+def hash_content_file(content: bytes, use_md5: bool = False) -> str:
+    hash_fn = hashlib.md5 else hashlib.sha256
+    return hash_fn(content).hexdigest()

--- a/src/app/api/security.py
+++ b/src/app/api/security.py
@@ -37,5 +37,5 @@ async def hash_password(password: str) -> str:
 
 
 def hash_content_file(content: bytes, use_md5: bool = False) -> str:
-    hash_fn = hashlib.md5 else hashlib.sha256
+    hash_fn = hashlib.md5 if use_md5 else hashlib.sha256
     return hash_fn(content).hexdigest()

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -44,6 +44,10 @@ if SUPERUSER_LOGIN is None or SUPERUSER_PWD is None:
 QARNOT_TOKEN: str = os.getenv("QARNOT_TOKEN", "")
 BUCKET_NAME: str = os.getenv("BUCKET_NAME", "")
 BUCKET_MEDIA_FOLDER: Optional[str] = os.getenv("BUCKET_MEDIA_FOLDER")
+S3_ACCESS_KEY: str = os.getenv("S3_ACCESS_KEY", "")
+S3_SECRET_KEY: str = os.getenv("S3_SECRET_KEY", "")
+S3_REGION: str = os.getenv("S3_REGION", "")
+S3_ENDPOINT_URL: str = os.getenv("S3_ENDPOINT_URL", "")
 DUMMY_BUCKET_FILE = (
     "https://ec.europa.eu/jrc/sites/jrcsh/files/styles/normal-responsive/"
     + "public/growing-risk-future-wildfires_adobestock_199370851.jpeg"

--- a/src/app/services/bucket/__init__.py
+++ b/src/app/services/bucket/__init__.py
@@ -1,1 +1,2 @@
 from .qarnot import *
+from .s3 import *

--- a/src/app/services/bucket/qarnot.py
+++ b/src/app/services/bucket/qarnot.py
@@ -8,6 +8,7 @@ import logging
 from qarnot.connection import Connection
 
 from app import config as cfg
+
 from .s3 import S3Bucket
 
 __all__ = ["QarnotBucket"]

--- a/src/app/services/bucket/qarnot.py
+++ b/src/app/services/bucket/qarnot.py
@@ -4,14 +4,11 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import logging
-import os
-from typing import List, Optional
 
-from fastapi import HTTPException
-from qarnot.bucket import Bucket
 from qarnot.connection import Connection
 
 from app import config as cfg
+from .s3 import S3Bucket
 
 __all__ = ["QarnotBucket"]
 
@@ -19,81 +16,11 @@ __all__ = ["QarnotBucket"]
 logger = logging.getLogger("uvicorn.warning")
 
 
-class QarnotBucket:
+class QarnotBucket(S3Bucket):
     """Storage bucket manipulation object on Qarnot computing"""
 
-    _bucket: Optional[Bucket] = None
-    _media_folder: Optional[str] = None
-
-    def __init__(self) -> None:
-        self._connect_to_bucket()
-
-    def _connect_to_bucket(self) -> None:
+    def _connect_to_storage(self) -> None:
         """Connect to the CSP bucket"""
-        self._conn = Connection(client_token=cfg.QARNOT_TOKEN)
-        self._bucket = Bucket(self._conn, cfg.BUCKET_NAME)
+        self._s3 = Connection(client_token=cfg.QARNOT_TOKEN)._s3client
         if isinstance(cfg.BUCKET_MEDIA_FOLDER, str):
             self._media_folder = cfg.BUCKET_MEDIA_FOLDER
-
-    @property
-    def bucket(self) -> Bucket:
-        if self._bucket is None:
-            self._connect_to_bucket()
-        return self._bucket
-
-    async def get_file(self, bucket_key: str) -> Optional[str]:
-        """Download a file locally and returns the local temp path"""
-        try:
-            return self.bucket.get_file(bucket_key)
-        except Exception as e:
-            logger.warning(e)
-            return None
-
-    async def check_file_existence(self, bucket_key: str) -> bool:
-        """Check whether a file exists on the bucket"""
-        try:
-            # Use boto3 head_object method using the Qarnot private connection attribute
-            # cf. https://github.com/qarnot/qarnot-sdk-python/blob/master/qarnot/connection.py#L188
-            head_object = self._conn._s3client.head_object(Bucket=cfg.BUCKET_NAME, Key=bucket_key)
-            return head_object["ResponseMetadata"]["HTTPStatusCode"] == 200
-        except Exception as e:
-            logger.warning(e)
-            return False
-
-    async def get_public_url(self, bucket_key: str, url_expiration: int = 3600) -> str:
-        """Generate a temporary public URL for a bucket file"""
-        if not await self.check_file_existence(bucket_key):
-            raise HTTPException(status_code=404, detail="File cannot be found on the bucket storage")
-
-        # Point to the bucket file
-        file_params = {"Bucket": cfg.BUCKET_NAME, "Key": bucket_key}
-        # Generate a public URL for it using boto3 presign URL generation
-        return self._conn._s3client.generate_presigned_url("get_object", Params=file_params, ExpiresIn=url_expiration)
-
-    async def upload_file(self, bucket_key: str, file_binary: bytes) -> bool:
-        """Upload a file to bucket and return whether the upload succeeded"""
-        try:
-            self.bucket.add_file(file_binary, bucket_key)
-        except Exception as e:
-            logger.warning(e)
-            return False
-        return True
-
-    async def fetch_bucket_filenames(self) -> List[str]:
-        """List all bucket files"""
-
-        if isinstance(self._media_folder, str):
-            obj_summary = self.bucket.directory(self._media_folder)
-        else:
-            obj_summary = self.bucket.list_files()
-
-        return [file.key for file in list(obj_summary)]
-
-    async def flush_tmp_file(self, filename: str) -> None:
-        """Remove temporary file"""
-        if os.path.exists(filename):
-            os.remove(filename)
-
-    async def delete_file(self, bucket_key: str) -> None:
-        """Remove bucket file and return whether the deletion succeeded"""
-        self.bucket.delete_file(bucket_key)

--- a/src/app/services/bucket/s3.py
+++ b/src/app/services/bucket/s3.py
@@ -4,11 +4,10 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import logging
-import os
-from typing import List, Optional
+from typing import Any, Dict, Optional
 
-from fastapi import HTTPException
 import boto3
+from fastapi import HTTPException
 
 from app import config as cfg
 

--- a/src/app/services/bucket/s3.py
+++ b/src/app/services/bucket/s3.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2022, Pyronear.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import logging
+import os
+from typing import List, Optional
+
+from fastapi import HTTPException
+import boto3
+
+from app import config as cfg
+
+__all__ = ["S3Bucket"]
+
+
+logger = logging.getLogger("uvicorn.warning")
+
+
+class S3Bucket:
+    """Storage bucket manipulation object on S3 storage"""
+
+    _s3: Optional[boto3.client.S3] = None
+    _media_folder: Optional[str] = None
+
+    def __init__(self) -> None:
+        self._connect_to_storage()
+
+    def _connect_to_storage(self) -> None:
+        """Connect to the CSP bucket"""
+        _session = boto3.Session(cfg.S3_ACCESS_KEY, cfg.S3_SECRET_KEY, region_name=cfg.S3_REGION)
+        self._s3 = _session.client("s3", endpoint_url=cfg.S3_ENDPOINT_URL)
+        if isinstance(cfg.BUCKET_MEDIA_FOLDER, str):
+            self._media_folder = cfg.BUCKET_MEDIA_FOLDER
+
+    @property
+    def s3(self) -> boto3.client.S3:
+        if self._s3 is None:
+            self._connect_to_storage()
+        return self._s3
+
+    async def get_file_metadata(self, bucket_key: str) -> Dict[str, Any]:
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.head_object
+        return self.s3.head_object(Bucket=cfg.BUCKET_NAME, Key=bucket_key)
+
+    async def check_file_existence(self, bucket_key: str) -> bool:
+        """Check whether a file exists on the bucket"""
+        try:
+            # Use boto3 head_object method using the Qarnot private connection attribute
+            head_object = self.s3.get_file_metadata(bucket_key)
+            return head_object["ResponseMetadata"]["HTTPStatusCode"] == 200
+        except Exception as e:
+            logger.warning(e)
+            return False
+
+    async def get_public_url(self, bucket_key: str, url_expiration: int = 3600) -> str:
+        """Generate a temporary public URL for a bucket file"""
+        if not await self.check_file_existence(bucket_key):
+            raise HTTPException(status_code=404, detail="File cannot be found on the bucket storage")
+
+        # Point to the bucket file
+        file_params = {"Bucket": cfg.BUCKET_NAME, "Key": bucket_key}
+        # Generate a public URL for it using boto3 presign URL generation
+        return self.s3.generate_presigned_url("get_object", Params=file_params, ExpiresIn=url_expiration)
+
+    async def upload_file(self, bucket_key: str, file_binary: bytes) -> bool:
+        """Upload a file to bucket and return whether the upload succeeded"""
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Bucket.upload_fileobj
+        try:
+            self.s3.upload_fileobj(file_binary, cfg.BUCKET_NAME, bucket_key)
+        except Exception as e:
+            logger.warning(e)
+            return False
+        return True
+
+    async def delete_file(self, bucket_key: str) -> None:
+        """Remove bucket file and return whether the deletion succeeded"""
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.delete_object
+        self.s3.delete_object(Bucket=cfg.BUCKET_NAME, Key=bucket_key)

--- a/src/app/services/bucket/s3.py
+++ b/src/app/services/bucket/s3.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any, Dict, Optional
 
 import boto3
+import botocore
 from fastapi import HTTPException
 
 from app import config as cfg
@@ -20,7 +21,7 @@ logger = logging.getLogger("uvicorn.warning")
 class S3Bucket:
     """Storage bucket manipulation object on S3 storage"""
 
-    _s3: Optional[boto3.client.S3] = None
+    _s3: Optional[botocore.client.BaseClient] = None
     _media_folder: Optional[str] = None
 
     def __init__(self) -> None:
@@ -34,7 +35,7 @@ class S3Bucket:
             self._media_folder = cfg.BUCKET_MEDIA_FOLDER
 
     @property
-    def s3(self) -> boto3.client.S3:
+    def s3(self) -> botocore.client.BaseClient:
         if self._s3 is None:
             self._connect_to_storage()
         return self._s3

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -299,7 +299,7 @@ async def test_upload_media(test_app_asyncio, init_test_db, test_db, monkeypatch
     async def mock_get_file_metadata(bucket_key):
         return {"ETag": md5_hash}
 
-    monkeypatch.setattr(bucket_service, "mock_get_file_metadata", mock_get_file_metadata)
+    monkeypatch.setattr(bucket_service, "get_file_metadata", mock_get_file_metadata)
 
     async def mock_delete_file(filename):
         return True
@@ -326,7 +326,7 @@ async def test_upload_media(test_app_asyncio, init_test_db, test_db, monkeypatch
     async def mock_get_wrong_metadata(bucket_key):
         return {"ETag": "wronghash"}
 
-    monkeypatch.setattr(bucket_service, "mock_get_file_metadata", mock_get_wrong_metadata)
+    monkeypatch.setattr(bucket_service, "get_file_metadata", mock_get_wrong_metadata)
     response = await test_app_asyncio.post(
         f"/media/{new_media_id}/upload", files=dict(file=img_content), headers=device_auth
     )

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -321,7 +321,19 @@ async def test_upload_media(test_app_asyncio, init_test_db, test_db, monkeypatch
     assert {k: v for k, v in updated_media.items() if k not in ("created_at", "bucket_key")} == response_json
     assert updated_media["bucket_key"] is not None
 
+    # Same file
+    response = await test_app_asyncio.post(
+        f"/media/{new_media_id}/upload", files=dict(file=img_content), headers=device_auth
+    )
+    assert response.status_code == 200, print(response.json()["detail"])
+
     # Broken test
+    # Take a different file to avoid the shortcut
+    img_content = requests.get("https://pyronear.org/pyro-vision/_static/logo.png").content
+    with open(local_tmp_path, "wb") as f:
+        f.write(img_content)
+
+    md5_hash = hash_content_file(img_content, use_md5=True)
     # Corrupted payload
     async def mock_get_wrong_metadata(bucket_key):
         return {"ETag": "wronghash"}

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -335,6 +335,7 @@ async def test_upload_media(test_app_asyncio, init_test_db, test_db, monkeypatch
 
     md5_hash = hash_content_file(img_content, use_md5=True)
     # Corrupted payload
+
     async def mock_get_wrong_metadata(bucket_key):
         return {"ETag": "wronghash"}
 

--- a/src/tests/routes/test_media.py
+++ b/src/tests/routes/test_media.py
@@ -294,7 +294,7 @@ async def test_upload_media(test_app_asyncio, init_test_db, test_db, monkeypatch
     with open(local_tmp_path, "wb") as f:
         f.write(img_content)
 
-    md5_hash = await hash_content_file(img_content, use_md5=True)
+    md5_hash = hash_content_file(img_content, use_md5=True)
 
     async def mock_get_file_metadata(bucket_key):
         return {"ETag": md5_hash}


### PR DESCRIPTION
This PR adds support for alternative S3 storage interfaces, and refactors QarnotBucket as an S3Bucket. Additionally, this PR improves the media upload route:
- previously, we uploaded the file, then downloaded it to check that the hash is identical (1 upload + 1 download)
- with this PR, we upload the file, then only read the MD5 hash computed by S3 file system (1 upload)
This should speed up the route while decreasing bandwidth requirements.

Any feedback is welcome!