### PR TITLE
test: Adds extensive test for the client and fixed alert endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,27 @@ repos:
     rev: v4.3.0
     hooks:
       - id: check-yaml
-        exclude: client/.conda
+        exclude: .conda
       - id: check-toml
+      - id: check-added-large-files
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: check-ast
+      - id: debug-statements
+      - id: check-json
+      - id: check-merge-conflict
+      - id: no-commit-to-branch
+      - id: debug-statements
+        language_version: python3
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
-    - id: black
+      - id: black
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
-    - id: isort
+      - id: isort
   - repo: https://github.com/PyCQA/autoflake
     rev: v1.7.7
     hooks:
-    - id: autoflake
+      - id: autoflake

--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -24,20 +24,16 @@ ROUTES: Dict[str, str] = {
     #################
     # Device-logged
     "heartbeat": "/devices/heartbeat",
-    "update-my-location": "/devices/update-my-location",
-    "get-my-device": "/devices/me",
-    "update-my-hash": "/devices/hash",
+    "get-self-device": "/devices/me",
     # User-logged
-    "get-my-devices": "/devices/my-devices",
+    "get-user-devices": "/devices/my-devices",
     #################
     # SITES
     #################
     "get-sites": "/sites",
-    "no-alert-site": "/sites/no-alert",
     #################
     # EVENTS
     #################
-    "create-event": "/events",
     "get-unacknowledged-events": "/events/unacknowledged",
     "get-past-events": "/events/past",
     "acknowledge-event": "/events/{event_id}/acknowledge",
@@ -48,14 +44,12 @@ ROUTES: Dict[str, str] = {
     #################
     # MEDIA
     #################
-    "create-media": "/media",
     "create-media-from-device": "/media/from-device",
     "upload-media": "/media/{media_id}/upload",
     "get-media-url": "/media/{media_id}/url",
     #################
     # ALERTS
     #################
-    "send-alert": "/alerts",
     "send-alert-from-device": "/alerts/from-device",
     "get-alerts": "/alerts",
     "get-ongoing-alerts": "/alerts/ongoing",
@@ -188,7 +182,7 @@ class Client:
         Returns:
             HTTP response containing the list of owned devices
         """
-        return requests.get(self.routes["get-my-devices"], headers=self.headers)
+        return requests.get(self.routes["get-user-devices"], headers=self.headers)
 
     def get_sites(self) -> Response:
         """Get all the existing sites in the DB
@@ -305,9 +299,9 @@ class Client:
 
         >>> from pyroclient import client
         >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
-        >>> response = api_client.get_my_device()
+        >>> response = api_client.get_self_device()
 
         Returns:
             HTTP response containing the device information
         """
-        return requests.get(self.routes["get-my-device"], headers=self.headers)
+        return requests.get(self.routes["get-self-device"], headers=self.headers)

--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -109,101 +109,6 @@ class Client:
         """
         return requests.put(self.routes["heartbeat"], headers=self.headers)
 
-    def update_my_location(
-        self,
-        lat: float,
-        lon: float,
-        elevation: float,
-        azimuth: float,
-        pitch: float,
-    ) -> Response:
-        """Updates the location of the device
-
-        >>> from pyroclient import client
-        >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "DEVICE_LOGIN", "MY_PWD")
-        >>> response = api_client.update_my_location(lat=10., lon=-5.45)
-
-        Returns:
-            HTTP response containing the update device info
-        """
-        payload = {"lat": lat, "lon": lon, "elevation": elevation, "azimuth": azimuth, "pitch": pitch}
-        return requests.put(self.routes["update-my-location"], headers=self.headers, json=payload)
-
-    def create_event(self, lat: float, lon: float) -> Response:
-        """Register an event (e.g wildfire).
-
-        >>> from pyroclient import client
-        >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
-        >>> response = api_client.create_event(lat=10., lon=-5.45)
-
-        Args:
-            lat: the latitude of the event
-            lon: the longitude of the event
-
-        Returns:
-            HTTP response containing the created event
-        """
-        payload = {"lat": lat, "lon": lon}
-        return requests.post(self.routes["create-event"], headers=self.headers, json=payload)
-
-    def create_no_alert_site(
-        self, lat: float, lon: float, name: str, country: str, geocode: str, group_id: Union[int, None] = None
-    ) -> Response:
-        """Create a site that is not supposed to generate alerts.
-
-        >>> from pyroclient import client
-        >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
-        >>> response = api_client.create_no_alert_site(lat=10., lon=-5.45, name="farm", country="FR", geocode="01")
-
-        Args:
-            lat: the latitude of the site
-            lon: the longitude of the site
-            name: the name of the site
-            country: the country where the site is located
-            geocode: the geocode of the site
-
-        Returns:
-            HTTP response containing the created site
-        """
-        payload = {"lat": lat, "lon": lon, "name": name, "country": country, "geocode": geocode}
-        if group_id is not None:
-            payload["group_id"] = group_id
-        return requests.post(self.routes["no-alert-site"], headers=self.headers, json=payload)
-
-    def send_alert(
-        self,
-        lat: float,
-        lon: float,
-        device_id: int,
-        media_id: int,
-        azimuth: Union[float, None] = None,
-        event_id: Union[int, None] = None,
-    ) -> Response:
-        """Raise an alert to the API.
-
-        >>> from pyroclient import client
-        >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
-        >>> response = api_client.send_alert(lat=10., lon=-5.45, device_id=3, azimuth=2.)
-
-        Args:
-            lat: the latitude of the alert
-            lon: the longitude of the alert
-            device_id: ID of the device that sent this alert
-            media_id: media ID linked to this alert
-            azimuth: the azimuth of the alert
-            event_id: the ID of the event this alerts relates to
-
-        Returns:
-            HTTP response containing the created alert
-        """
-        payload = {"lat": lat, "lon": lon, "event_id": event_id, "device_id": device_id}
-        if isinstance(media_id, int):
-            payload["media_id"] = media_id
-        if isinstance(azimuth, float):
-            payload["azimuth"] = azimuth
-
-        return requests.post(self.routes["send-alert"], headers=self.headers, json=payload)
-
     def send_alert_from_device(
         self,
         lat: float,
@@ -236,22 +141,6 @@ class Client:
             payload["azimuth"] = azimuth
 
         return requests.post(self.routes["send-alert-from-device"], headers=self.headers, json=payload)
-
-    def create_media(self, device_id: int) -> Response:
-        """Create a media entry
-
-        >>> from pyroclient import client
-        >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
-        >>> response = api_client.create_media(device_id=3)
-
-        Args:
-            device_id: ID of the device that created that media
-
-        Returns:
-            HTTP response containing the created media
-        """
-
-        return requests.post(self.routes["create-media"], headers=self.headers, json={"device_id": device_id})
 
     def create_media_from_device(self):
         """Create a media entry from a device (no need to specify device ID).
@@ -289,12 +178,12 @@ class Client:
         )
 
     # User functions
-    def get_my_devices(self) -> Response:
+    def get_user_devices(self) -> Response:
         """Get the devices who are owned by the logged user
 
         >>> from pyroclient import client
         >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
-        >>> response = api_client.get_my_devices()
+        >>> response = api_client.get_user_devices()
 
         Returns:
             HTTP response containing the list of owned devices
@@ -384,9 +273,11 @@ class Client:
     def get_media_url(self, media_id: int) -> Response:
         """Get the image as a URL
 
+        >>> import requests
         >>> from pyroclient import client
         >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
         >>> response = api_client.get_media_url(1)
+        >>> file_response = requests.get(response.json()["url"])
 
         Args:
             media_id: the identifier of the media entry
@@ -396,22 +287,6 @@ class Client:
         """
 
         return requests.get(self.routes["get-media-url"].format(media_id=media_id), headers=self.headers)
-
-    def get_media_url_and_read(self, media_id: int) -> Response:
-        """Get the image as a url and read it
-
-        >>> from pyroclient import client
-        >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
-        >>> response = api_client.get_media_url_and_read(1)
-
-        Args:
-            media_id: the identifier of the media entry
-
-        Returns:
-            HTTP response containing the media content
-        """
-        image_url = requests.get(self.routes["get-media-url"].format(media_id=media_id), headers=self.headers)
-        return requests.get(image_url.json()["url"])
 
     def get_past_events(self) -> Response:
         """Get all past events
@@ -425,7 +300,7 @@ class Client:
         """
         return requests.get(self.routes["get-past-events"], headers=self.headers)
 
-    def get_my_device(self) -> Response:
+    def get_self_device(self) -> Response:
         """Get information about the current device
 
         >>> from pyroclient import client
@@ -436,17 +311,3 @@ class Client:
             HTTP response containing the device information
         """
         return requests.get(self.routes["get-my-device"], headers=self.headers)
-
-    def update_my_hash(self, software_hash: str) -> Response:
-        """Updates the software hash of the current device
-
-        >>> from pyroclient import client
-        >>> api_client = client.Client("http://pyronear-api.herokuapp.com", "MY_LOGIN", "MY_PWD")
-        >>> response = api_client.update_my_hash()
-
-        Returns:
-            HTTP response containing the updated device information
-        """
-        payload = {"software_hash": software_hash}
-
-        return requests.put(self.routes["update-my-hash"], headers=self.headers, json=payload)

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -1,0 +1,82 @@
+from urllib.parse import urljoin
+
+import pytest
+import requests
+
+from pyroclient.client import Client
+from pyroclient.exceptions import HTTPRequestException
+
+API_URL = "http://localhost:8080"
+
+
+@pytest.fixture(scope="session")
+def mock_img():
+    # Get Pyronear logo
+    URL = "https://avatars.githubusercontent.com/u/61667887?s=200&v=4"
+    return requests.get(URL).content
+
+
+@pytest.fixture(scope="function")
+def admin_client():
+    return Client(API_URL, "dummy_login", "dummy&P@ssw0rd!")
+
+
+@pytest.fixture(scope="function")
+def user_client(admin_client):
+    user_creds = ("dummy_user", "dummy_pwd")
+    try:
+        client = Client(API_URL, *user_creds)
+    except HTTPRequestException:
+        # Log as admin & create a user
+        payload = {"login": user_creds[0], "password": user_creds[1], "group_id": 1}
+        response = requests.post(urljoin(API_URL, "users"), json=payload, headers=admin_client.headers)
+        assert response.status_code == 201
+        # Log as that device
+        client = Client(API_URL, *user_creds)
+
+    return client
+
+
+@pytest.fixture(scope="function")
+def device_client(admin_client):
+    device_creds = ("dummy_device", "dummy_pwd")
+    try:
+        client = Client(API_URL, *device_creds)
+    except HTTPRequestException:
+        # Log as admin & create a device
+        payload = {
+            "login": device_creds[0],
+            "password": device_creds[1],
+            "owner_id": 1,
+            "specs": "dummy",
+            "angle_of_view": 68.0,
+            "group_id": 1,
+        }
+        response = requests.post(urljoin(API_URL, "devices"), json=payload, headers=admin_client.headers)
+        assert response.status_code == 201
+        # Log as that device
+        client = Client(API_URL, *device_creds)
+
+    return client
+
+
+@pytest.fixture(scope="function")
+def setup(admin_client):
+    # Create a site
+    payload = {"name": "dummy_site", "lat": 0.0, "lon": 0.0, "country": "FR", "geocode": "code", "group_id": 1}
+    response = requests.post(urljoin(API_URL, "sites"), json=payload, headers=admin_client.headers)
+    assert response.status_code == 201, print(response.text)
+    # Event
+    payload = {"lat": 0.0, "lon": 0.0}
+    response = requests.post(urljoin(API_URL, "events"), json=payload, headers=admin_client.headers)
+    assert response.status_code == 201
+    event_id = response.json()["id"]
+    # Media
+    payload = {"device_id": 1}
+    response = requests.post(urljoin(API_URL, "media"), json=payload, headers=admin_client.headers)
+    assert response.status_code == 201
+    media_id = response.json()["id"]
+    # Alert
+    payload = {"lat": 0.0, "lon": 0.0, "event_id": event_id, "media_id": media_id, "device_id": 1, "azimuth": 0}
+    response = requests.post(urljoin(API_URL, "alerts"), json=payload, headers=admin_client.headers)
+    assert response.status_code == 201

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -1,69 +1,87 @@
 import time
 from copy import deepcopy
+from urllib.parse import urljoin
 
 import pytest
+import requests
 from requests import ConnectionError
 
-from pyroclient import client
+from pyroclient.client import Client
 from pyroclient.exceptions import HTTPRequestException
 
 
 def _test_route_return(response, return_type, status_code=200):
-    assert response.status_code == status_code
+    assert response.status_code == status_code, print(response.text)
     assert isinstance(response.json(), return_type)
 
     return response.json()
 
 
-def test_client():
+@pytest.mark.parametrize(
+    "url, login, pwd, expected_error",
+    [
+        # Wrong credentials
+        ["http://localhost:8080", "invalid_login", "invalid_pwd", HTTPRequestException],
+        # Incorrect URL port
+        ["http://localhost:8003", "dummy_login", "dummy&P@ssw0rd!", ConnectionError],
+        # Correct
+        ["http://localhost:8080", "dummy_login", "dummy&P@ssw0rd!", None],
+    ],
+)
+def test_client_constructor(url, login, pwd, expected_error):
+    if expected_error is None:
+        api_client = Client(url, login, pwd)
+        assert isinstance(api_client.headers, dict)
+    else:
+        with pytest.raises(expected_error):
+            Client(url, login, pwd)
 
-    # Wrong credentials
-    with pytest.raises(HTTPRequestException):
-        client.Client("http://localhost:8080", "invalid_login", "invalid_pwd")
 
-    # Incorrect URL port
-    with pytest.raises(ConnectionError):
-        client.Client("http://localhost:8003", "dummy_login", "dummy&P@ssw0rd!")
-
-    api_client = client.Client("http://localhost:8080", "dummy_login", "dummy&P@ssw0rd!")
-
-    # Sites
-    site_id = _test_route_return(
-        api_client.create_no_alert_site(lat=44.870959, lon=4.395387, name="dummy_tower", country="FR", geocode="07"),
-        dict,
-        201,
-    )["id"]
-    sites = _test_route_return(api_client.get_sites(), list)
-    assert sites[-1]["id"] == site_id
-
-    # Devices
-    all_devices = _test_route_return(api_client.get_my_devices(), list)
-    _test_route_return(api_client.get_site_devices(site_id), list)
-
-    # Alerts
-    _test_route_return(api_client.get_all_alerts(), list)
-    _test_route_return(api_client.get_ongoing_alerts(), list)
-    # Events
-    _test_route_return(api_client.get_unacknowledged_events(), list)
-    _test_route_return(api_client.get_past_events(), list)
-
-    if len(all_devices) > 0:
-        # Media
-        media_id = _test_route_return(api_client.create_media(all_devices[0]["id"]), dict, 201)["id"]
-        # Create event
-        event_id = _test_route_return(api_client.create_event(0.0, 0.0), dict, 201)["id"]
-        # Create an alert
-        _ = _test_route_return(
-            api_client.send_alert(0.0, 0.0, event_id, all_devices[0]["id"], media_id=media_id), dict, 201
-        )
-        # Acknowledge it
-        updated_event = _test_route_return(api_client.acknowledge_event(event_id), dict)
-        assert updated_event["is_acknowledged"]
-
+def test_client_refresh_token(admin_client):
     # Check token refresh
-    prev_headers = deepcopy(api_client.headers)
+    prev_headers = deepcopy(admin_client.headers)
     # In case the 2nd token creation request is done in the same second, since the expiration is truncated to the
     # second, it returns the same token
     time.sleep(1)
-    api_client.refresh_token("dummy_login", "dummy&P@ssw0rd!")
-    assert prev_headers != api_client.headers
+    admin_client.refresh_token("dummy_login", "dummy&P@ssw0rd!")
+    assert prev_headers != admin_client.headers
+
+
+def test_client_device(admin_client, device_client, mock_img):
+    # Every on-site interactions (critical priority)
+
+    # Get self
+    device = _test_route_return(device_client.get_self_device(), dict)
+    # Heartbeat
+    last_ping = device["last_ping"]
+    updated_device = _test_route_return(device_client.heartbeat(), dict)
+    assert isinstance(updated_device["last_ping"], str)
+    if isinstance(last_ping, str):
+        assert updated_device["last_ping"] > last_ping
+
+    # Alert
+    media_id = _test_route_return(device_client.create_media_from_device(), dict, 201)["id"]
+    _test_route_return(device_client.send_alert_from_device(1.0, 2.0, media_id, 0.0), dict, 201)
+    response = device_client.upload_media(media_id, mock_img)
+    if response.status_code == 200:
+        media = _test_route_return(response, dict)
+        assert isinstance(media["bucket_key"], str)
+        _test_route_return(admin_client.get_media_url(media_id), str)
+        # Delete media
+        response = requests.delete(urljoin("http://localhost:8080", f"media/{media_id}"), headers=admin_client.headers)
+        assert response.status_code == 200
+
+
+def test_client_user(setup, user_client, mock_img):
+    # Every platform interaction (medium priority)
+
+    _test_route_return(user_client.get_user_devices(), list)
+    sites = _test_route_return(user_client.get_sites(), list)
+    _test_route_return(user_client.get_site_devices(sites[0]["id"]), list)
+    events = _test_route_return(user_client.get_past_events(), list)
+    events = _test_route_return(user_client.get_unacknowledged_events(), list)
+    event = _test_route_return(user_client.acknowledge_event(events[0]["id"]), dict)
+    assert event["is_acknowledged"]
+    _test_route_return(user_client.get_all_alerts(), list)
+    _test_route_return(user_client.get_ongoing_alerts(), list)
+    assert user_client.get_media_url(1).status_code == 404

--- a/client/tests/test_exceptions.py
+++ b/client/tests/test_exceptions.py
@@ -1,0 +1,15 @@
+import pytest
+
+from pyroclient.exceptions import HTTPRequestException
+
+
+@pytest.mark.parametrize(
+    "status_code, response_msg, expected_repr",
+    [
+        [404, "not found", "HTTPRequestException(status_code=404, response_message='not found')"],
+        [502, "internal error", "HTTPRequestException(status_code=502, response_message='internal error')"],
+    ],
+)
+def test_httprequestexception(status_code, response_msg, expected_repr):
+    exception = HTTPRequestException(status_code, response_msg)
+    assert repr(exception) == expected_repr

--- a/src/app/api/endpoints/alerts.py
+++ b/src/app/api/endpoints/alerts.py
@@ -78,6 +78,11 @@ async def create_alert_from_device(
     payload_dict = payload.dict()
     # If no azimuth is specified, use the one from the device
     payload_dict["azimuth"] = payload_dict["azimuth"] if isinstance(payload_dict["azimuth"], float) else device.azimuth
+    if payload_dict["azimuth"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Please specify a value for 'azimuth' in the payload, since this device's azimuth is not set.",
+        )
     return await create_alert(AlertIn(**payload_dict, device_id=device.id), background_tasks)
 
 


### PR DESCRIPTION
This PR introduces the following modifications:
- adds extensive tests for the client
- fixes a rare case on the alert endpoint (when azimuth is not specified, it defaults to the value of the device that created the alert, but if for some reason, the device azimuth is None, that creates an internal error)
- deprecates the following client methods: `update_my_location`, `create_event`, `create_no_alert_site`, `send_alert`, `create_media`, `get_media_url_and_read`
- renamed the following client methods: `get_my_devices` --> `get_user_devices`, `get_my_device` -> `get_self_device`
- updates precommit hooks

Closes #224 