### PR TITLE
ci: Makes script job independent form tests

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: [3.7, 3.8]
+        python: [3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Build & run docker

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,13 +1,13 @@
 name: scripts
 
 on:
-  workflow_run:
-    workflows: ["tests"]
-    types: [completed]
+  push:
+    branches: main
+  pull_request:
+    branches: main
 
 jobs:
   end-to-end:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
I noticed, the CI job for E2E script wasn't running anymore. This needs to be addressed so here it is!