### PR TITLE
fix: Fixes media deletion route by checking bucket file existence

### DIFF
--- a/src/app/api/endpoints/media.py
+++ b/src/app/api/endpoints/media.py
@@ -110,8 +110,9 @@ async def delete_media(media_id: int = Path(..., gt=0), _=Security(get_current_a
     """
     # Delete entry
     entry = await crud.delete_entry(media, media_id)
-    # Delete media file
-    await bucket_service.delete_file(entry["bucket_key"])
+    # Delete media file if one exists
+    if isinstance(entry["bucket_key"], str) and len(entry["bucket_key"]) > 0:
+        await bucket_service.delete_file(entry["bucket_key"])
     return entry
 
 


### PR DESCRIPTION
This PR ensures that we only try to remove a bucket file if the media has one that was set. I tested on my environment, this PR fixes the script issues in #245.

Closes #259