### PR TITLE
fix: Fixes the parsing of datetime

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r src/app/requirements.txt --upgrade
-          pip install "mypy==1.2.0" types-requests
+          pip install "mypy==1.2.0" types-requests types-python-dateutil
       - name: Run mypy
         run: |
           mypy --version

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -20,16 +20,15 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dynamic = ["version"]
 dependencies = [
-    "requests>=2.24.0,<3.0.0",
+    "requests>=2.31.0,<3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,10 @@ boto3 = "^1.26.0"
 
 flake8 = { version = ">=3.9.0,<5.0.0", optional = true }
 isort = { version = "^5.7.0", optional = true }
-mypy = {version = "1.2.0", optional = true}
-black = {version = "22.3.0", optional = true}
+mypy = {version = "==1.2.0", optional = true}
+types-requests = {version = "^2.31.0", optional = true}
+types-python-dateutil = {version = "^2.8.0", optional = true}
+black = {version = "==22.3.0", optional = true}
 pydocstyle = { version = "^6.0.0", extras = ["toml"], optional = true }
 autoflake = { version = "^1.5.0", optional = true }
 bandit = { version = "^1.7.0", extras = ["toml"], optional = true }
@@ -44,7 +46,7 @@ alembic = "==1.5.4"
 asyncpg = ">=0.20.0,<1.0.0"
 
 [tool.poetry.extras]
-quality = ["flake8", "isort", "mypy", "pydocstyle", "black", "autoflake", "bandit", "pre-commit"]
+quality = ["flake8", "isort", "mypy", "types-requests", "types-python-dateutil", "pydocstyle", "black", "autoflake", "bandit", "pre-commit"]
 
 [tool.mypy]
 mypy_path = "src/"
@@ -62,8 +64,6 @@ explicit_package_bases = true
 module = [
     "jose.*",
     "passlib.*",
-    "requests.*",
-    "qarnot.*",
     "sqlalchemy.*",
     "app.*",
     "boto3.*",

--- a/src/app/schemas/base.py
+++ b/src/app/schemas/base.py
@@ -6,17 +6,20 @@
 from datetime import datetime
 from typing import Optional
 
+from dateutil.parser import isoparse
 from pydantic import BaseModel, Field, validator
 
 __all__ = ["Cred", "CredHash", "Login", "Position"]
 
 
 class _CreatedAt(BaseModel):
-    created_at: Optional[datetime] = Field(None, description="timestamp of entry creation")
+    created_at: Optional[datetime] = Field(
+        None, description="timestamp of entry creation", example=datetime.utcnow().replace(tzinfo=None)
+    )
 
     @validator("created_at", pre=True, always=True)
-    def default_ts_created(v):
-        return v or datetime.utcnow()
+    def validate_created_at(v):
+        return datetime.utcnow() if v is None else (isoparse(v) if isinstance(v, str) else v).replace(tzinfo=None)
 
 
 class _Id(BaseModel):

--- a/src/tests/routes/test_installations.py
+++ b/src/tests/routes/test_installations.py
@@ -193,6 +193,29 @@ async def test_fetch_installations(
         ],
         [1, {"device_id": 1, "site_id": 1, "start_ts": "2020-10-13T08:18:45.447773"}, 201, None],
         [
+            1,
+            {
+                "device_id": 1,
+                "site_id": 1,
+                "start_ts": "2020-10-13T08:18:45.447773",
+                "end_ts": "2020-10-13T08:18:45.447773",
+            },
+            201,
+            None,
+        ],
+        [1, {"device_id": 1, "site_id": 1, "start_ts": "2020-10-13T08:18:45.447773Z"}, 201, None],
+        [
+            1,
+            {
+                "device_id": 1,
+                "site_id": 1,
+                "start_ts": "2020-10-13T08:18:45.447773Z",
+                "end_ts": "2020-10-13T08:18:45.447773Z",
+            },
+            201,
+            None,
+        ],
+        [
             2,
             {"device_id": 1, "site_id": 1, "start_ts": "2020-10-13T08:18:45.447773"},
             403,
@@ -221,7 +244,9 @@ async def test_create_installation(
 
     if response.status_code // 100 == 2:
         json_response = response.json()
-        test_response = {"id": len(INSTALLATION_TABLE) + 1, **payload, "end_ts": None, "is_trustworthy": True}
+        test_response = {"id": len(INSTALLATION_TABLE) + 1, **payload, "is_trustworthy": True}
+        test_response["start_ts"] = test_response["start_ts"].replace("Z", "")
+        test_response["end_ts"] = payload["end_ts"].replace("Z", "") if payload.get("end_ts") is not None else None
         assert {k: v for k, v in json_response.items() if k != "created_at"} == test_response
 
         new_installation = await get_entry(test_db, db.installations, json_response["id"])


### PR DESCRIPTION
This PR handles the tedious datetime & timezone issues by sanitizing all of them:
- removes tzinfo from datetime when relevant
- parses datetime information that have "Z"
- specifies swagger examples to avoid Z (which indicate UTC timezone --> we want ISO format independent on TZ, thus UTC, but as a convention and not being specifying UTC as if we could pass UTC+2)
- adds test cases
- updates version specifiers of the API & client

Closes #261