### PR TITLE
fix: Fixes access ID resolution on media URL resolution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
     image: postgres:12.1-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data/
-    ports:
-      - 5432:5432
+    expose:
+      - 5432
     environment:
       - POSTGRES_USER=dummy_pg_user
       - POSTGRES_PASSWORD=dummy_pg_pwd

--- a/src/app/api/endpoints/media.py
+++ b/src/app/api/endpoints/media.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Pa
 from app.api import crud
 from app.api.crud.authorizations import check_group_read, is_admin_access
 from app.api.crud.groups import get_entity_group_id
-from app.api.deps import get_current_access, get_current_device, get_current_user, get_db
+from app.api.deps import get_current_access, get_current_device, get_db
 from app.api.security import hash_content_file
 from app.db import devices, media
 from app.models import Access, AccessType, Device, Media
@@ -174,7 +174,7 @@ async def upload_media_from_device(
 
 @router.get("/{media_id}/url", response_model=MediaUrl, status_code=200)
 async def get_media_url(
-    media_id: int = Path(..., gt=0), requester=Security(get_current_user, scopes=[AccessType.admin, AccessType.user])
+    media_id: int = Path(..., gt=0), requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user])
 ):
     """Resolve the temporary media image URL"""
     requested_group_id = await get_entity_group_id(media, media_id)


### PR DESCRIPTION
This PR introduces the following modifications:
- fixes the access check on media URL resolution. Interesting fact about why this wasn't spotted earlier: we were using the user ID as access ID, which is not a problem when you create all the users before any device (because then access ID = user ID). Hence the problem @MateoLostanlen (I got the idea because I didn't encounter the problem when using the superadmin which is the first access that gets created, but had the problem with other admins, where the user ID != access ID)
- avoids DB direct exposition for external HTTP requests