### PR TITLE
feat: Adds possibility to specify secret key

### DIFF
--- a/src/app/config.py
+++ b/src/app/config.py
@@ -23,7 +23,7 @@ LOGO_URL: str = "https://pyronear.org/img/logo_letters.png"
 ALERT_RELAXATION_SECONDS: int = 5 * 60
 
 
-SECRET_KEY: str = secrets.token_urlsafe(32)
+SECRET_KEY: str = os.environ.get("SECRET_KEY", secrets.token_urlsafe(32))
 if DEBUG:
     # To keep the same Auth at every app loading in debug mode and not having to redo the auth.
     debug_secret_key = "000000000000000000000000000000000000"  # nosec B105


### PR DESCRIPTION
This PR allows the docker compose to specify the secret key as env parameters. The nice part is that this prevents the expiration of tokens when restarting the container (thus heartbeat won't expire all the time).