### PR TITLE
refactor: change alert relaxation from 5 to 30 minutes

### DIFF
--- a/src/app/api/crud/alerts.py
+++ b/src/app/api/crud/alerts.py
@@ -16,7 +16,7 @@ from app.schemas import AlertIn, AlertOut, EventIn
 
 
 async def resolve_previous_alert(device_id: int) -> Optional[AlertOut]:
-    # check whether there is an alert in the last 5 min by the same device
+    # check whether there is an alert in the last 30 min by the same device
     max_ts = datetime.utcnow() - timedelta(seconds=cfg.ALERT_RELAXATION_SECONDS)
     query = (
         alerts.select()
@@ -31,7 +31,7 @@ async def resolve_previous_alert(device_id: int) -> Optional[AlertOut]:
 
 
 async def create_event_if_inexistant(payload: AlertIn) -> int:
-    # check whether there is an alert in the last 5 min by the same device
+    # check whether there is an alert in the last 30 min by the same device
     previous_alert = await resolve_previous_alert(payload.device_id)
     if previous_alert is None:
         # Create an event & get the ID

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -20,7 +20,7 @@ if DATABASE_URL.startswith("postgres://"):
 TEST_DATABASE_URL: str = os.getenv("TEST_DATABASE_URL", "")
 LOGO_URL: str = "https://pyronear.org/img/logo_letters.png"
 
-ALERT_RELAXATION_SECONDS: int = 5 * 60
+ALERT_RELAXATION_SECONDS: int = 30 * 60
 
 
 SECRET_KEY: str = os.environ.get("SECRET_KEY", secrets.token_urlsafe(32))


### PR DESCRIPTION
When a device issues multiple alerts, it is associated to an existing event if it is within "relaxation time". This PR increases the relaxation time from 5 to 30 minutes to avoid creating multiple events for the same fire detection. The risk to miss another fire within the relaxation time is considered small at this point.