### PR TITLE
feat: add limit and offset parameters to routes that fetch lists from db

### DIFF
--- a/src/Dockerfile-dev
+++ b/src/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM pyroapi:python3.8-alpine3.10
+FROM pyronear/pyro-api:python3.8-alpine3.10
 
 # copy requirements file
 COPY requirements-dev.txt requirements-dev.txt

--- a/src/app/api/endpoints/accesses.py
+++ b/src/app/api/endpoints/accesses.py
@@ -3,9 +3,10 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import List
+from typing import List, Optional
 
-from fastapi import APIRouter, Path, Security
+from fastapi import APIRouter, Path, Query, Security
+from typing_extensions import Annotated
 
 from app.api import crud
 from app.api.deps import get_current_access
@@ -25,8 +26,12 @@ async def get_access(access_id: int = Path(..., gt=0), _=Security(get_current_ac
 
 
 @router.get("/", response_model=List[AccessRead], summary="Get the list of all accesses")
-async def fetch_accesses(_=Security(get_current_access, scopes=[AccessType.admin])):
+async def fetch_accesses(
+    limit: Annotated[int, Query(description="maximum number of items", ge=1, le=1000)] = 50,
+    offset: Annotated[Optional[int], Query(description="number of items to skip", ge=0)] = None,
+    _=Security(get_current_access, scopes=[AccessType.admin]),
+):
     """
     Retrieves the list of all accesses and their information
     """
-    return await crud.fetch_all(accesses)
+    return await crud.fetch_all(accesses, limit=limit, offset=offset)

--- a/src/app/api/endpoints/devices.py
+++ b/src/app/api/endpoints/devices.py
@@ -4,9 +4,10 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 from datetime import datetime
-from typing import List, cast
+from typing import List, Optional, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Security, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Security, status
+from typing_extensions import Annotated
 
 from app.api import crud
 from app.api.crud.authorizations import is_admin_access
@@ -80,18 +81,22 @@ async def get_my_device(me: DeviceOut = Security(get_current_device, scopes=["de
 
 @router.get("/", response_model=List[DeviceOut], summary="Get the list of all devices")
 async def fetch_devices(
-    requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]), session=Depends(get_db)
+    limit: Annotated[int, Query(description="maximum number of items", ge=1, le=1000)] = 50,
+    offset: Annotated[Optional[int], Query(description="number of items to skip", ge=0)] = None,
+    requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+    session=Depends(get_db),
 ):
     """
     Retrieves the list of all devices and their information
     """
-    if await is_admin_access(requester.id):
-        return await crud.fetch_all(devices)
-    else:
-        retrieved_devices = session.query(Device).join(Access).filter(Access.group_id == requester.group_id).all()
-        retrieved_devices = [x.__dict__ for x in retrieved_devices]
-
-        return retrieved_devices
+    return await crud.fetch_all(
+        devices,
+        query=None
+        if await is_admin_access(requester.id)
+        else session.query(Device).join(Access).filter(Access.group_id == requester.group_id),
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.put("/{device_id}/", response_model=DeviceOut, summary="Update information about a specific device")
@@ -115,11 +120,15 @@ async def delete_device(device_id: int = Path(..., gt=0), _=Security(get_current
 @router.get(
     "/my-devices", response_model=List[DeviceOut], summary="Get the list of all devices belonging to the current user"
 )
-async def fetch_my_devices(me: UserRead = Security(get_current_user, scopes=[AccessType.admin, AccessType.user])):
+async def fetch_my_devices(
+    limit: Annotated[int, Query(description="maximum number of items", ge=1, le=1000)] = 50,
+    offset: Annotated[Optional[int], Query(description="number of items to skip", ge=0)] = None,
+    me: UserRead = Security(get_current_user, scopes=[AccessType.admin, AccessType.user]),
+):
     """
     Retrieves the list of all devices and the information which are owned by the current user
     """
-    return await crud.fetch_all(devices, {"owner_id": me.id})
+    return await crud.fetch_all(devices, {"owner_id": me.id}, limit=limit, offset=offset)
 
 
 @router.put("/heartbeat", response_model=DeviceOut, summary="Update the last ping of the current device")

--- a/src/app/api/endpoints/groups.py
+++ b/src/app/api/endpoints/groups.py
@@ -3,9 +3,10 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import List
+from typing import List, Optional
 
-from fastapi import APIRouter, Path, Security, status
+from fastapi import APIRouter, Path, Query, Security, status
+from typing_extensions import Annotated
 
 from app.api import crud
 from app.api.deps import get_current_access
@@ -35,11 +36,14 @@ async def get_group(group_id: int = Path(..., gt=0)):
 
 
 @router.get("/", response_model=List[GroupOut], summary="Get the list of all groups")
-async def fetch_groups():
+async def fetch_groups(
+    limit: Annotated[int, Query(description="maximum number of items", ge=1, le=1000)] = 50,
+    offset: Annotated[Optional[int], Query(description="number of items to skip", ge=0)] = None,
+):
     """
     Retrieves the list of all groups and their information
     """
-    return await crud.fetch_all(groups)
+    return await crud.fetch_all(groups, limit=limit, offset=offset)
 
 
 @router.put("/{group_id}/", response_model=GroupOut, summary="Update information about a specific group")

--- a/src/app/api/endpoints/installations.py
+++ b/src/app/api/endpoints/installations.py
@@ -4,16 +4,17 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 from datetime import datetime
-from typing import List, cast
+from typing import List, Optional, cast
 
-from fastapi import APIRouter, Depends, Path, Security, status
+from fastapi import APIRouter, Depends, Path, Query, Security, status
 from sqlalchemy import and_, or_
+from typing_extensions import Annotated
 
 from app.api import crud
 from app.api.crud.authorizations import check_group_read, check_group_update, is_admin_access
 from app.api.crud.groups import get_entity_group_id
 from app.api.deps import get_current_access, get_db
-from app.db import installations
+from app.db import installations, sites
 from app.models import AccessType, Installation, Site
 from app.schemas import InstallationIn, InstallationOut, InstallationUpdate
 
@@ -49,19 +50,22 @@ async def get_installation(
 
 @router.get("/", response_model=List[InstallationOut], summary="Get the list of all installations")
 async def fetch_installations(
-    requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]), session=Depends(get_db)
+    limit: Annotated[int, Query(description="maximum number of items", ge=1, le=1000)] = 50,
+    offset: Annotated[Optional[int], Query(description="number of items to skip", ge=0)] = None,
+    requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
+    session=Depends(get_db),
 ):
     """
     Retrieves the list of all installations and their information
     """
-    if await is_admin_access(requester.id):
-        return await crud.fetch_all(installations)
-    else:
-        retrieved_installations = (
-            session.query(Installation).join(Site).filter(Site.group_id == requester.group_id).all()
-        )
-        retrieved_installations = [x.__dict__ for x in retrieved_installations]
-        return retrieved_installations
+    return await crud.fetch_all(
+        installations,
+        query=None
+        if await is_admin_access(requester.id)
+        else session.query(Installation).join(Site).filter(Site.group_id == requester.group_id),
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.put(
@@ -93,29 +97,33 @@ async def delete_installation(
 @router.get("/site-devices/{site_id}", response_model=List[int], summary="Get all devices related to a specific site")
 async def get_active_devices_on_site(
     site_id: int = Path(..., gt=0),
+    limit: Annotated[int, Query(description="maximum number of items", ge=1, le=1000)] = 50,
+    offset: Annotated[Optional[int], Query(description="number of items to skip", ge=0)] = None,
     requester=Security(get_current_access, scopes=[AccessType.admin, AccessType.user]),
     session=Depends(get_db),
 ):
     """
     Based on a site_id, retrieves the list of all the related devices and their information
     """
+    requested_group_id = await get_entity_group_id(sites, site_id)
+    await check_group_read(requester.id, cast(int, requested_group_id))
     current_ts = datetime.utcnow()
-
-    query = (
-        session.query(Installation)
-        .join(Site)
-        .filter(
-            and_(
-                Site.id == site_id,
-                Installation.start_ts <= current_ts,
-                or_(Installation.end_ts.is_(None), Installation.end_ts >= current_ts),
-            )
+    return [
+        item["device_id"]
+        for item in await crud.fetch_all(
+            installations,
+            query=(
+                session.query(Installation)
+                .join(Site)
+                .filter(
+                    and_(
+                        Site.id == site_id,
+                        Installation.start_ts <= current_ts,
+                        or_(Installation.end_ts.is_(None), Installation.end_ts >= current_ts),
+                    )
+                )
+            ),
+            limit=limit,
+            offset=offset,
         )
-    )
-
-    if not await is_admin_access(requester.id):
-        # Restrict on the group_id of the requester
-        query = query.filter(Site.group_id == requester.group_id)
-
-    retrieved_device_ids = [x.__dict__["device_id"] for x in query.all()]
-    return retrieved_device_ids
+    ]

--- a/src/app/api/endpoints/notifications.py
+++ b/src/app/api/endpoints/notifications.py
@@ -3,9 +3,10 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import List
+from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException, Path, Security, status
+from fastapi import APIRouter, HTTPException, Path, Query, Security, status
+from typing_extensions import Annotated
 
 from app.api import crud
 from app.api.deps import get_current_access
@@ -49,11 +50,14 @@ async def get_notification(notification_id: int = Path(..., gt=0)):
 
 
 @router.get("/", response_model=List[NotificationOut], summary="Get the list of all notifications")
-async def fetch_notifications():
+async def fetch_notifications(
+    limit: Annotated[int, Query(description="maximum number of items", ge=1, le=1000)] = 50,
+    offset: Annotated[Optional[int], Query(description="number of items to skip", ge=0)] = None,
+):
     """
     Retrieves the list of all notifications and their information
     """
-    return await crud.fetch_all(notifications)
+    return await crud.fetch_all(notifications, limit=limit, offset=offset)
 
 
 @router.delete("/{notification_id}/", response_model=NotificationOut, summary="Delete a specific notification")

--- a/src/app/api/endpoints/recipients.py
+++ b/src/app/api/endpoints/recipients.py
@@ -3,10 +3,11 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import List
+from typing import List, Optional
 
-from fastapi import APIRouter, Security, status
+from fastapi import APIRouter, Query, Security, status
 from pydantic import PositiveInt
+from typing_extensions import Annotated
 
 from app.api import crud
 from app.api.deps import get_current_access
@@ -39,11 +40,14 @@ async def get_recipient(recipient_id: PositiveInt):
 
 
 @router.get("/", response_model=List[RecipientOut], summary="Get the list of all recipients")
-async def fetch_recipients():
+async def fetch_recipients(
+    limit: Annotated[int, Query(description="maximum number of items", ge=1, le=1000)] = 50,
+    offset: Annotated[Optional[int], Query(description="number of items to skip", ge=0)] = None,
+):
     """
     Retrieves the list of all recipients and their information
     """
-    return await crud.fetch_all(recipients)
+    return await crud.fetch_all(recipients, limit=limit, offset=offset)
 
 
 @router.get(
@@ -51,11 +55,15 @@ async def fetch_recipients():
     response_model=List[RecipientOut],
     summary="Get the list of all recipients for the given group",
 )
-async def fetch_recipients_for_group(group_id: PositiveInt):
+async def fetch_recipients_for_group(
+    group_id: PositiveInt,
+    limit: Annotated[int, Query(description="maximum number of items", ge=1, le=1000)] = 50,
+    offset: Annotated[Optional[int], Query(description="number of items to skip", ge=0)] = None,
+):
     """
     Retrieves the list of all recipients for the given group and their information
     """
-    return await crud.fetch_all(recipients, {"group_id": group_id})
+    return await crud.fetch_all(recipients, {"group_id": group_id}, limit=limit, offset=offset)
 
 
 @router.put("/{recipient_id}/", response_model=RecipientOut, summary="Update information about a specific recipient")

--- a/src/app/api/endpoints/webhooks.py
+++ b/src/app/api/endpoints/webhooks.py
@@ -3,9 +3,10 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import List
+from typing import List, Optional
 
-from fastapi import APIRouter, Path, Security, status
+from fastapi import APIRouter, Path, Query, Security, status
+from typing_extensions import Annotated
 
 from app.api import crud
 from app.api.deps import get_current_access
@@ -35,11 +36,15 @@ async def get_webhook(webhook_id: int = Path(..., gt=0), _=Security(get_current_
 
 
 @router.get("/", response_model=List[WebhookOut], summary="Get the list of all webhooks")
-async def fetch_webhooks(_=Security(get_current_access, scopes=["admin"])):
+async def fetch_webhooks(
+    limit: Annotated[int, Query(description="maximum number of items", ge=1, le=1000)] = 50,
+    offset: Annotated[Optional[int], Query(description="number of items to skip", ge=0)] = None,
+    _=Security(get_current_access, scopes=["admin"]),
+):
     """
     Retrieves the list of all webhooks and their information
     """
-    return await crud.fetch_all(webhooks)
+    return await crud.fetch_all(webhooks, limit=limit, offset=offset)
 
 
 @router.put("/{webhook_id}/", response_model=WebhookOut, summary="Update information about a specific webhook")

--- a/src/tests/routes/test_groups.py
+++ b/src/tests/routes/test_groups.py
@@ -97,12 +97,30 @@ async def test_get_group(test_app_asyncio, init_test_db, group_id, status_code, 
         assert response_json == GROUP_TABLE[group_id - 1]
 
 
+@pytest.mark.parametrize(
+    "limit, offset, expected",
+    [
+        (None, None, GROUP_TABLE[-50:]),
+        (50, None, GROUP_TABLE[-50:]),
+        (None, 0, GROUP_TABLE[-50:]),
+        (50, 0, GROUP_TABLE[-50:]),
+        (10, 0, GROUP_TABLE[-10:]),
+        (10, 10, GROUP_TABLE[-20:-10]),
+    ],
+)
 @pytest.mark.asyncio
-async def test_fetch_groups(test_app_asyncio, init_test_db):
-    response = await test_app_asyncio.get("/groups/")
+async def test_fetch_groups(test_app_asyncio, init_test_db, limit, offset, expected):
+    query = []
+    if limit is not None:
+        query.append(f"limit={limit}")
+    if offset is not None:
+        query.append(f"offset={offset}")
+    if not query:
+        response = await test_app_asyncio.get("/groups/")
+    else:
+        response = await test_app_asyncio.get("/groups/?" + "&".join(query))
     assert response.status_code == 200
-    response_json = response.json()
-    assert all(result == entry for result, entry in zip(response_json, GROUP_TABLE[-50:]))
+    assert response.json() == expected
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routes/test_installations.py
+++ b/src/tests/routes/test_installations.py
@@ -425,9 +425,10 @@ async def test_delete_installation(
         [0, 1, [1], 200, None],
         [1, 1, [1], 200, None],
         [4, 2, [2], 200, None],
-        [1, 999, [], 200, None],  # TODO: this should fail since the site doesn't exist
+        [1, 999, [], 404, "Table sites has no entry with id=999"],
         [1, 0, [], 422, None],
         [2, 1, [], 403, "Your access scope is not compatible with this operation."],
+        [4, 1, [], 403, "This access can't read resources from group_id=1"]
     ],
 )
 @pytest.mark.asyncio

--- a/src/tests/routes/test_installations.py
+++ b/src/tests/routes/test_installations.py
@@ -428,7 +428,7 @@ async def test_delete_installation(
         [1, 999, [], 404, "Table sites has no entry with id=999"],
         [1, 0, [], 422, None],
         [2, 1, [], 403, "Your access scope is not compatible with this operation."],
-        [4, 1, [], 403, "This access can't read resources from group_id=1"]
+        [4, 1, [], 403, "This access can't read resources from group_id=1"],
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR adds limit and offset parameters with descriptions, to all routes that fetch lists from db (fix #243, fix #250). Also:

- use crud.fetch_all in all the routes above, to limit the number of items returned for non-admin users (fix #276)
- forbid /installation/site-devices to access site outside of group, instead of filtering devices
- improve test_installations.py (test_get_active_devices_on_site)
- Dockerfile-dev: update FROM image name