### PR TITLE
feat: fields and methods to set event type (wildfire or something else)

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -37,6 +37,7 @@ ROUTES: Dict[str, str] = {
     "get-unacknowledged-events": "/events/unacknowledged",
     "get-past-events": "/events/past",
     "acknowledge-event": "/events/{event_id}/acknowledge",
+    "set-event-type": "/events/{event_id}/type?event_type={event_type}",
     "get-alerts-for-event": "/events/{event_id}/alerts",
     #################
     # INSTALLATIONS
@@ -272,6 +273,22 @@ class Client:
         """
         return requests.put(
             self.routes["acknowledge-event"].format(event_id=event_id), headers=self.headers, timeout=self.timeout
+        )
+
+    def set_event_type(self, event_id: int, event_type: str):
+        """Set the event type field value
+
+        Args:
+            event_id: ID of the associated event entry
+            event_type: event type ("wildfire" or other)
+
+        Returns:
+            HTTP response containing the updated event
+        """
+        return requests.put(
+            self.routes["set-event-type"].format(event_id=event_id, event_type=event_type),
+            headers=self.headers,
+            timeout=self.timeout,
         )
 
     def get_site_devices(self, site_id: int) -> Response:

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -86,6 +86,8 @@ def test_client_user(setup, user_client, mock_img):
     events = _test_route_return(user_client.get_unacknowledged_events(), list)
     event = _test_route_return(user_client.acknowledge_event(events[0]["id"]), dict)
     assert event["is_acknowledged"]
+    type_info = _test_route_return(user_client.set_event_type(events[0]["id"], "wildfire"), dict)
+    assert type_info["type"] == "wildfire"
     _test_route_return(user_client.get_all_alerts(), list)
     _test_route_return(user_client.get_ongoing_alerts(), list)
     _test_route_return(user_client.get_alerts_for_event(events[0]["id"]), list)

--- a/src/app/models/event.py
+++ b/src/app/models/event.py
@@ -5,7 +5,7 @@
 
 import enum
 
-from sqlalchemy import Boolean, Column, DateTime, Enum, Float, Integer
+from sqlalchemy import Boolean, Column, DateTime, Enum, Float, ForeignKey, Integer
 from sqlalchemy.orm import RelationshipProperty, relationship
 from sqlalchemy.sql import func
 
@@ -16,6 +16,11 @@ __all__ = ["EventType", "Event"]
 
 class EventType(str, enum.Enum):
     wildfire: str = "wildfire"
+    domestic_fire: str = "domestic fire"
+    chimney: str = "chimney"
+    cloud: str = "cloud"
+    other: str = "other"
+    undefined: str = "undefined"
 
 
 class Event(Base):
@@ -24,13 +29,16 @@ class Event(Base):
     id = Column(Integer, primary_key=True)
     lat = Column(Float(4, asdecimal=True))
     lon = Column(Float(4, asdecimal=True))
-    type = Column(Enum(EventType), default=EventType.wildfire)
+    type = Column(Enum(EventType), default=EventType.undefined)
     start_ts = Column(DateTime, default=func.now())
     end_ts = Column(DateTime, default=None, nullable=True)
     is_acknowledged = Column(Boolean, default=False)
     created_at = Column(DateTime, default=func.now())
+    type_set_by = Column(Integer, ForeignKey("users.id"))
+    type_set_ts = Column(DateTime, default=None, nullable=True)
 
     alerts: RelationshipProperty = relationship("Alert", back_populates="event")
+    type_setter: RelationshipProperty = relationship("User", back_populates="type_set_events")
 
     def __repr__(self):
         return (

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -23,6 +23,7 @@ class User(Base):
 
     access: RelationshipProperty = relationship("Access", uselist=False, back_populates="user")
     device: RelationshipProperty = relationship("Device", uselist=False, back_populates="owner")
+    type_set_events: RelationshipProperty = relationship("Event", back_populates="type_setter")
 
     def __repr__(self):
         return f"<User(login='{self.login}', created_at='{self.created_at}'>"

--- a/src/app/schemas/events.py
+++ b/src/app/schemas/events.py
@@ -12,7 +12,15 @@ from app.models import EventType
 
 from .base import _CreatedAt, _FlatLocation, _Id, validate_datetime_none
 
-__all__ = ["EventIn", "EventOut", "EventUpdate", "Acknowledgement", "AcknowledgementOut"]
+__all__ = [
+    "EventIn",
+    "EventOut",
+    "EventUpdate",
+    "Acknowledgement",
+    "AcknowledgementOut",
+    "EventTypeSetting",
+    "EventTypeSettingOut",
+]
 
 
 # Events
@@ -25,9 +33,12 @@ class EventIn(_FlatLocation):
         None, description="timestamp of event end", example=datetime.utcnow().replace(tzinfo=None)
     )
     is_acknowledged: bool = Field(False, description="whether the event has been acknowledged")
+    type_set_by: Optional[int] = Field(None, description="id of the user who defined the event type")
+    type_set_ts: Optional[datetime] = Field(None, description="event type definition timestamp")
 
     _validate_start_ts = validator("start_ts", pre=True, always=True, allow_reuse=True)(validate_datetime_none)
     _validate_end_ts = validator("end_ts", pre=True, always=True, allow_reuse=True)(validate_datetime_none)
+    _validate_type_ts = validator("type_set_ts", pre=True, always=True, allow_reuse=True)(validate_datetime_none)
 
 
 class EventOut(EventIn, _CreatedAt, _Id):
@@ -39,6 +50,18 @@ class Acknowledgement(BaseModel):
 
 
 class AcknowledgementOut(Acknowledgement, _Id):
+    pass
+
+
+class EventTypeSetting(BaseModel):
+    type: EventType = Field(..., description="event type")
+    type_set_by: Optional[int] = Field(None, description="id of the user who defined the event type")
+    type_set_ts: Optional[datetime] = Field(None, description="event type definition timestamp")
+
+    _validate_type_ts = validator("type_set_ts", pre=True, always=True, allow_reuse=True)(validate_datetime_none)
+
+
+class EventTypeSettingOut(EventTypeSetting, _Id):
     pass
 
 

--- a/src/tests/routes/test_events.py
+++ b/src/tests/routes/test_events.py
@@ -606,4 +606,3 @@ async def test_update_event_type(
         else:
             assert updated_event["type_set_by"] is None
             assert updated_event["type_set_ts"] is None
-

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -6,7 +6,9 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 
 def update_only_datetime(entity_as_dict: Dict[str, Any]):
     return {
-        k: parse_time(v) if isinstance(v, str) and k in ("created_at", "start_ts", "end_ts", "last_ping") else v
+        k: parse_time(v)
+        if isinstance(v, str) and k in ("created_at", "start_ts", "end_ts", "last_ping", "type_set_ts")
+        else v
         for k, v in entity_as_dict.items()
     }
 


### PR DESCRIPTION
This PR adds the possibility to set an event type, different than wildfire. This event assessment is currently done via `pyro-platform` but this information is only stored locally (in the machine running it).

- add options to EventType enum: domestic fire, chimney, cloud, other, undefined (default)
- add type_set_by and type_set_ts to events table
- add PUT /events/{event_id}/type endpoint and `set_event_type` method to client