### PR TITLE
test: Simplifies testing procedure by using unbinded Docker

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -71,7 +71,7 @@
 
 'topic: docker':
 - docker-compose.yml
-- docker-compose-dev.yml
+- docker-compose.test.yml
 - src/Dockerfile
 - src/Dockerfile-dev
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,12 +33,12 @@ jobs:
           TELEGRAM_TEST_CHAT_ID: ${{ secrets.TELEGRAM_TEST_CHAT_ID }}
         run: |
           docker build src/. -t pyroapi:python3.8-alpine3.10
-          docker-compose -f docker-compose-dev.yml up -d --build
+          docker-compose -f docker-compose.test.yml up -d --build
       - name: Run docker test
         run: |
-          docker-compose -f docker-compose-dev.yml exec -T backend coverage --version
-          docker-compose -f docker-compose-dev.yml exec -T backend coverage run -m pytest tests/
-          docker-compose -f docker-compose-dev.yml exec -T backend coverage xml -o coverage-src.xml
+          docker-compose -f docker-compose.test.yml exec -T backend coverage --version
+          docker-compose -f docker-compose.test.yml exec -T backend coverage run -m pytest tests/
+          docker-compose -f docker-compose.test.yml exec -T backend coverage xml -o coverage-src.xml
           docker cp pyro-api_backend_1:/app/coverage-src.xml .
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -149,5 +149,6 @@ _build/
 *.sql
 
 # Poetry
+src/requirements.txt
 src/app/requirements.txt
 src/requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -32,19 +32,19 @@ run-dev:
 	poetry export -f requirements.txt --without-hashes --output src/app/requirements.txt
 	docker build src/. -t pyronear/pyro-api:python3.8-alpine3.10
 	poetry export -f requirements.txt --without-hashes --with dev --output src/requirements-dev.txt
-	docker-compose -f docker-compose-dev.yml up -d --build
+	docker-compose -f docker-compose.test.yml up -d --build
 
 stop-dev:
-	docker-compose -f docker-compose-dev.yml down
+	docker-compose -f docker-compose.test.yml down
 
 # Run tests for the library
 test:
 	poetry export -f requirements.txt --without-hashes --output src/app/requirements.txt
 	docker build src/. -t pyronear/pyro-api:python3.8-alpine3.10
 	poetry export -f requirements.txt --without-hashes --with dev --output src/requirements-dev.txt
-	docker-compose -f docker-compose-dev.yml up -d --build
+	docker-compose -f docker-compose.test.yml up -d --build
 	docker-compose exec -T backend coverage run -m pytest tests/
-	docker-compose -f docker-compose-dev.yml down
+	docker-compose -f docker-compose.test.yml down
 
 # Run tests for the Python client
 test-client:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,7 +14,6 @@ services:
     environment:
       - DEBUG=true
       - DATABASE_URL=postgresql://dummy_pg_user:dummy_pg_pwd@db/dummy_pg_db
-      - TEST_DATABASE_URL=postgresql://dummy_pg_tuser:dummy_pg_tpwd@db_test/dummy_pg_tdb
       - SQLALCHEMY_SILENCE_UBER_WARNING=1
       - SUPERUSER_LOGIN=dummy_login
       - SUPERUSER_PWD=dummy&P@ssw0rd!
@@ -37,9 +36,3 @@ services:
       - POSTGRES_USER=dummy_pg_user
       - POSTGRES_PASSWORD=dummy_pg_pwd
       - POSTGRES_DB=dummy_pg_db
-  db_test:
-    image: postgres:12.1-alpine
-    environment:
-      - POSTGRES_USER=dummy_pg_tuser
-      - POSTGRES_PASSWORD=dummy_pg_tpwd
-      - POSTGRES_DB=dummy_pg_tdb

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -31,8 +31,6 @@ services:
       - db
   db:
     image: postgres:12.1-alpine
-    volumes:
-      - postgres_data:/var/lib/postgresql/data/
     ports:
       - 5432:5432
     environment:
@@ -41,13 +39,7 @@ services:
       - POSTGRES_DB=dummy_pg_db
   db_test:
     image: postgres:12.1-alpine
-    volumes:
-      - postgres_data_test:/var/lib/postgresql/data_test/
     environment:
       - POSTGRES_USER=dummy_pg_tuser
       - POSTGRES_PASSWORD=dummy_pg_tpwd
       - POSTGRES_DB=dummy_pg_tdb
-
-volumes:
-  postgres_data:
-  postgres_data_test:

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -22,7 +22,6 @@ DATABASE_URL: str = os.environ["DATABASE_URL"]
 if DATABASE_URL.startswith("postgres://"):
     DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
 
-TEST_DATABASE_URL: str = os.getenv("TEST_DATABASE_URL", "")
 LOGO_URL: str = "https://pyronear.org/img/logo_letters.png"
 
 ALERT_RELAXATION_SECONDS: int = 30 * 60

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -40,11 +40,11 @@ async def test_app_asyncio():
 
 @pytest_asyncio.fixture(scope="function")
 async def test_db():
+    await reset_test_db()
     try:
         await test_database.connect()
         yield test_database
     finally:
-        await reset_test_db()
         await test_database.disconnect()
 
 

--- a/src/tests/db_utils.py
+++ b/src/tests/db_utils.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import sessionmaker
 import app.config as cfg
 from app.db import metadata
 
-SQLALCHEMY_DATABASE_URL = cfg.TEST_DATABASE_URL
+SQLALCHEMY_DATABASE_URL = cfg.DATABASE_URL
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 metadata.create_all(bind=engine)
 database = Database(SQLALCHEMY_DATABASE_URL)


### PR DESCRIPTION
This PR simplifies the testing procedure by:
- removing the volume binding for the docker orchestration of test (making sure we don't alter local prod database, and no point keeping test data)
- removing the test_db to instead clear & populate the main database. Because it's now unbinded, the volume is fresh on each test procedure and doesn't affect the potential local volume that holds the database

The advantage is that it reduces the number of docker containers to handle, and removes some config variables.
Additionally, "docker-compose-dev.yml" was renamed to "docker-compose.test.yml" to reflect common practices.

Any feedback is welcome!