### PR TITLE
chore: Bumps PG version to 15 to avoid deprecation

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -30,11 +30,16 @@ jobs:
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
           S3_REGION: ${{ secrets.S3_REGION }}
-        run: docker-compose up -d --build
+          SUPERUSER_LOGIN: dummy_login
+          SUPERUSER_PWD: dummy&P@ssw0rd!
+          POSTGRES_USER: dummy_pg_user
+          POSTGRES_PASSWORD: dummy_pg_pwd
+          POSTGRES_DB: dummy_pg_db
+        run: docker compose up -d --build
       - name: Docker sanity check
         run: sleep 20 && nc -vz localhost 8080
       - name: Debug
-        run: docker-compose logs
+        run: docker compose logs
       - name: Ping server
         run: curl http://localhost:8080/docs
 

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -33,8 +33,13 @@ jobs:
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
           S3_REGION: ${{ secrets.S3_REGION }}
+          SUPERUSER_LOGIN: dummy_login
+          SUPERUSER_PWD: dummy&P@ssw0rd!
+          POSTGRES_USER: dummy_pg_user
+          POSTGRES_PASSWORD: dummy_pg_pwd
+          POSTGRES_DB: dummy_pg_db
         run: |
-          docker-compose up -d --build
+          docker compose up -d --build
           docker ps
       - name: Cache python modules
         uses: actions/cache@v2

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -39,6 +39,7 @@ jobs:
           POSTGRES_PASSWORD: dummy_pg_pwd
           POSTGRES_DB: dummy_pg_db
         run: |
+          docker volume prune -f
           docker compose up -d --build
           docker ps
       - name: Cache python modules
@@ -52,6 +53,9 @@ jobs:
           pip install -r scripts/requirements.txt
 
       - name: End-to-End test
+        env:
+          SUPERUSER_LOGIN: dummy_login
+          SUPERUSER_PWD: dummy&P@ssw0rd!
         run: |
           sleep 5
           python scripts/api_e2e.py 8080

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,11 @@ jobs:
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
           S3_REGION: ${{ secrets.S3_REGION }}
+          SUPERUSER_LOGIN: dummy_login
+          SUPERUSER_PWD: dummy&P@ssw0rd!
+          POSTGRES_USER: dummy_pg_user
+          POSTGRES_PASSWORD: dummy_pg_pwd
+          POSTGRES_DB: dummy_pg_db
         run: |
           docker volume prune -f
           docker compose up -d --build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           docker compose -f docker-compose.test.yml exec -T backend coverage --version
           docker compose -f docker-compose.test.yml exec -T backend coverage run -m pytest tests/
           docker compose -f docker-compose.test.yml exec -T backend coverage xml -o coverage-src.xml
-          docker cp pyro-api_backend_1:/app/coverage-src.xml .
+          docker compose -f docker-compose.test.yml cp backend:/app/coverage-src.xml .
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,12 +33,12 @@ jobs:
           TELEGRAM_TEST_CHAT_ID: ${{ secrets.TELEGRAM_TEST_CHAT_ID }}
         run: |
           docker build src/. -t pyroapi:python3.8-alpine3.10
-          docker-compose -f docker-compose.test.yml up -d --build
+          docker compose -f docker-compose.test.yml up -d --build
       - name: Run docker test
         run: |
-          docker-compose -f docker-compose.test.yml exec -T backend coverage --version
-          docker-compose -f docker-compose.test.yml exec -T backend coverage run -m pytest tests/
-          docker-compose -f docker-compose.test.yml exec -T backend coverage xml -o coverage-src.xml
+          docker compose -f docker-compose.test.yml exec -T backend coverage --version
+          docker compose -f docker-compose.test.yml exec -T backend coverage run -m pytest tests/
+          docker compose -f docker-compose.test.yml exec -T backend coverage xml -o coverage-src.xml
           docker cp pyro-api_backend_1:/app/coverage-src.xml .
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
@@ -74,7 +74,7 @@ jobs:
           S3_REGION: ${{ secrets.S3_REGION }}
         run: |
           docker volume prune -f
-          docker-compose up -d --build
+          docker compose up -d --build
           docker ps
       - name: Cache python modules
         uses: actions/cache@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,28 @@ git push -u origin a-short-description
 Then [open a Pull Request](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) from your fork's branch. Follow the instructions of the Pull Request template and then click on "Create a pull request".
 
 
-## Database migration
+## Database
+
+### Schema evolution
 
 See [Alembic](https://github.com/pyronear/pyro-api/blob/main/src/alembic) guide to create revision and run it locally.
+
+
+### Postgres upgrade
+
+With your current PG version, we first make a data extract:
+```shell
+make run
+docker compose exec -it db pg_dumpall -U mybdsuperuserpyro > my_local_dump.sql
+./scripts/pg_extract.sh my_local_dump.sql pyro_api_prod >> upgrade_dump.sql
+```
+We stop the container and remove the volume to prevent it from repopulating the new database
+```shell
+make stop
+docker volume rm pyro-api_postgres_data
+```
+Now update the Postgres version on your docker. We then run the DB only (to prevent the backend from initializing it) and restore the data:
+```shell
+docker compose up db -d
+cat upgrade_dump.sql| docker compose exec -T db psql -U mybdsuperuserpyro
+```

--- a/Makefile
+++ b/Makefile
@@ -22,29 +22,29 @@ build:
 # Run the docker
 run:
 	poetry export -f requirements.txt --without-hashes --output src/app/requirements.txt
-	docker-compose up -d --build
+	docker compose up -d --build
 
 # Run the docker
 stop:
-	docker-compose down
+	docker compose down
 
 run-dev:
 	poetry export -f requirements.txt --without-hashes --output src/app/requirements.txt
 	docker build src/. -t pyronear/pyro-api:python3.8-alpine3.10
 	poetry export -f requirements.txt --without-hashes --with dev --output src/requirements-dev.txt
-	docker-compose -f docker-compose.test.yml up -d --build
+	docker compose -f docker-compose.test.yml up -d --build
 
 stop-dev:
-	docker-compose -f docker-compose.test.yml down
+	docker compose -f docker-compose.test.yml down
 
 # Run tests for the library
 test:
 	poetry export -f requirements.txt --without-hashes --output src/app/requirements.txt
 	docker build src/. -t pyronear/pyro-api:python3.8-alpine3.10
 	poetry export -f requirements.txt --without-hashes --with dev --output src/requirements-dev.txt
-	docker-compose -f docker-compose.test.yml up -d --build
-	docker-compose exec -T backend coverage run -m pytest tests/
-	docker-compose -f docker-compose.test.yml down
+	docker compose -f docker-compose.test.yml up -d --build
+	docker compose exec -T backend coverage run -m pytest tests/
+	docker compose -f docker-compose.test.yml down
 
 # Run tests for the Python client
 test-client:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ This file will have to hold the following information:
 - `S3_REGION`: your S3 bucket is geographically identified by its location's region
 - `S3_ENDPOINT_URL`: the URL providing a S3 endpoint by your cloud provider
 - `BUCKET_NAME`: the name of the storage bucket
+- `POSTGRES_DB`: name of postgres database
+- `POSTGRES_USER`: user of postgres database
+- `POSTGRES_PASSWORD`: user password of postgres database
 - `S3_PROXY_URL`: the url of the proxy to hide the real s3 url behind, do not use proxy if ""
 Optionally, the following information can be added:
 - `SENTRY_DSN`: the URL of the [Sentry](https://sentry.io/) project, which monitors back-end errors and report them back.
@@ -126,6 +129,9 @@ S3_SECRET_KEY=YOUR_SECRET_KEY
 S3_REGION=bucket-region
 S3_ENDPOINT_URL='https://s3.mydomain.com/'
 BUCKET_NAME=my_storage_bucket_name
+POSTGRES_USER=dummy_pg_user
+POSTGRES_PASSWORD=dummy_pg_pwd
+POSTGRES_DB=dummy_pg_db
 SENTRY_DSN='https://replace.with.you.sentry.dsn/'
 SENTRY_SERVER_NAME=my_storage_bucket_name
 ```

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,12 +27,18 @@ services:
       - TELEGRAM_TOKEN=${TELEGRAM_TOKEN}
       - TELEGRAM_TEST_CHAT_ID=${TELEGRAM_TEST_CHAT_ID}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
   db:
-    image: postgres:12.1-alpine
-    ports:
-      - 5432:5432
+    image: postgres:15-alpine
+    expose:
+      - 5432
     environment:
       - POSTGRES_USER=dummy_pg_user
       - POSTGRES_PASSWORD=dummy_pg_pwd
       - POSTGRES_DB=dummy_pg_db
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U dummy_pg_user -d dummy_pg_db'"]
+      interval: 10s
+      timeout: 3s
+      retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,10 @@ services:
       - 8080:8080
     environment:
       - DEBUG=false
-      - DATABASE_URL=postgresql://dummy_pg_user:dummy_pg_pwd@db/dummy_pg_db
       - SQLALCHEMY_SILENCE_UBER_WARNING=1
-      - SUPERUSER_LOGIN=dummy_login
-      - SUPERUSER_PWD=dummy&P@ssw0rd!
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+      - SUPERUSER_LOGIN=${SUPERUSER_LOGIN}
+      - SUPERUSER_PWD=${SUPERUSER_PWD}
       - QARNOT_TOKEN=${QARNOT_TOKEN}
       - BUCKET_NAME=${BUCKET_NAME}
       - BUCKET_MEDIA_FOLDER=${BUCKET_MEDIA_FOLDER}
@@ -27,17 +27,23 @@ services:
       - SENTRY_SERVER_NAME=${SENTRY_SERVER_NAME}
       - TELEGRAM_TOKEN=${TELEGRAM_TOKEN}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
   db:
-    image: postgres:12.1-alpine
+    image: postgres:15-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     expose:
       - 5432
     environment:
-      - POSTGRES_USER=dummy_pg_user
-      - POSTGRES_PASSWORD=dummy_pg_pwd
-      - POSTGRES_DB=dummy_pg_db
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
 
 volumes:
   postgres_data:

--- a/scripts/api_e2e.py
+++ b/scripts/api_e2e.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 import argparse
+import os
 import time
 from getpass import getpass
 from typing import Any, Dict, Optional
@@ -38,8 +39,8 @@ def main(args):
     api_url = f"http://localhost:{args.port}"
 
     # Log as superuser
-    superuser_login = getpass("Login: ") if args.creds else "dummy_login"
-    superuser_pwd = getpass() if args.creds else "dummy&P@ssw0rd!"
+    superuser_login = input("Login: ") if args.creds else os.environ["SUPERUSER_LOGIN"]
+    superuser_pwd = getpass() if args.creds else os.environ["SUPERUSER_PWD"]
 
     start_ts = time.time()
     # Retrieve superuser token

--- a/scripts/pg_extract.sh
+++ b/scripts/pg_extract.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+[ $# -lt 2 ] && { echo "Usage: $0 <postgresql dump> <dbname>"; exit 1; }
+sed  "/connect.*$2/,\$!d" $1 | sed "/PostgreSQL database dump complete/,\$d"

--- a/src/app/api/endpoints/alerts.py
+++ b/src/app/api/endpoints/alerts.py
@@ -132,7 +132,12 @@ async def fetch_alerts(
         return await crud.fetch_all(alerts)
     else:
         retrieved_alerts = (
-            session.query(Alert).join(Device).join(Access).filter(Access.group_id == requester.group_id).all()
+            session.query(Alert)
+            .join(Device)
+            .join(Access)
+            .filter(Access.group_id == requester.group_id)
+            .order_by(Alert.id)
+            .all()
         )
         retrieved_alerts = [x.__dict__ for x in retrieved_alerts]
         return retrieved_alerts


### PR DESCRIPTION
This PR introduces the following modifications:
- updates to postgres 15 to avoid upcoming deprecation (and it happens to be faster)
- fixes a minor issue with alert ordering (seems like this didn't happen on PG 12)
- switches to new docker syntax (docker-compose --> docker compose)
- moves prod env var to .env
- adds health checks in the docker compose

To upgrade existing DB, I tried locally, you just need to:

on the PG 12.1 (dump only the data, removing the PG version specific aspects, then delete the volume)
```shell
docker compose exec -it db pg_dumpall -U mybdsuperuserpyro > my_local_dump.sql
./scripts/pg_extract.sh my_local_dump.sql pyro_api_prod >> upgrade_dump.sql
docker compose down
docker volume rm pyro-api_postgres_data
```

On the PG 15 (we only run the db so that it stays empty, then we restore the data):
```shell
docker compose up db -d
cat upgrade_dump.sql| docker compose exec -T db psql -U mybdsuperuserpyro
```

This has been added in the CONTRIBUTING (adapted from https://thomasbandt.com/postgres-docker-major-version-upgrade)
