### PR TITLE
fix(apm): Disable posthog events when there is a heartbeat

### DIFF
--- a/src/app/api/endpoints/devices.py
+++ b/src/app/api/endpoints/devices.py
@@ -146,9 +146,9 @@ async def heartbeat(device: DeviceOut = Security(get_current_device, scopes=[Acc
     """
     Updates the last ping of the current device with the current datetime
     """
-    telemetry_client.capture(
-        device.id, event="devices-hearbeat", properties={"device_name": device.login, "owner_id": device.owner_id}
-    )
+    # telemetry_client.capture(
+    #     device.id, event="devices-hearbeat", properties={"device_name": device.login, "owner_id": device.owner_id}
+    # )
     device.last_ping = datetime.utcnow()
     await crud.update_entry(devices, device, device.id)
     return device


### PR DESCRIPTION
This PR modifies the feature introduced in #307 for product analytics by disabling tracking of the most frequent signal (heartbeat). There are too many not to hit the free quota limit (we get more than 1/sec)

Any feedback is welcome!