### PR TITLE
fix(client): handle the final slash sensitivity on core routers

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -25,7 +25,12 @@ jobs:
           poetry-version: "1.6.1"
       - name: Resolve dependencies
         run: poetry export -f requirements.txt --without-hashes --output src/app/requirements.txt
-      - name: Build & run docker
+      - name: Cache python modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-scripts-deps-${{ matrix.python }}-${{ hashFiles('scripts/requirements.txt') }}
+      - name: Run the backend & the test
         env:
           BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
           BUCKET_MEDIA_FOLDER: ${{ secrets.BUCKET_MEDIA_FOLDER }}
@@ -42,20 +47,7 @@ jobs:
           docker volume prune -f
           docker compose up -d --build
           docker ps
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-scripts-deps-${{ matrix.python }}-${{ hashFiles('scripts/requirements.txt') }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r scripts/requirements.txt
-
-      - name: End-to-End test
-        env:
-          SUPERUSER_LOGIN: dummy_login
-          SUPERUSER_PWD: dummy&P@ssw0rd!
-        run: |
+          python -m pip install --upgrade uv
+          uv pip install --system -r scripts/requirements.txt
           sleep 5
           python scripts/api_e2e.py 8080

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -25,11 +25,6 @@ jobs:
           poetry-version: "1.6.1"
       - name: Resolve dependencies
         run: poetry export -f requirements.txt --without-hashes --output src/app/requirements.txt
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-scripts-deps-${{ matrix.python }}-${{ hashFiles('scripts/requirements.txt') }}
       - name: Run the backend & the test
         env:
           BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
@@ -47,6 +42,16 @@ jobs:
           docker volume prune -f
           docker compose up -d --build
           docker ps
+      - name: Cache python modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-scripts-deps-${{ matrix.python }}-${{ hashFiles('scripts/requirements.txt') }}
+      - name: Run end-to-end integration test
+        env:
+          SUPERUSER_LOGIN: dummy_login
+          SUPERUSER_PWD: dummy&P@ssw0rd!
+        run: |
           python -m pip install --upgrade uv
           uv pip install --system -r scripts/requirements.txt
           sleep 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,9 @@ jobs:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_TEST_CHAT_ID: ${{ secrets.TELEGRAM_TEST_CHAT_ID }}
         run: |
-          docker compose -f docker-compose.test.yml up -d --build
-          docker compose exec localstack awslocal s3 mb s3://sample-bucket
-          docker compose exec localstack awslocal s3api put-object --bucket sample-bucket --key media-folder
+          docker compose -f docker-compose.test.yml up -d --build --wait
+          docker compose -f docker-compose.test.yml exec localstack awslocal s3 mb s3://sample-bucket
+          docker compose -f docker-compose.test.yml exec localstack awslocal s3api put-object --bucket sample-bucket --key media-folder
           docker compose -f docker-compose.test.yml exec -T backend pytest --cov=app --cov-report xml tests/
           docker compose -f docker-compose.test.yml cp backend:/app/coverage.xml ./coverage-src.xml
       - name: Upload coverage to Codecov
@@ -69,7 +69,7 @@ jobs:
           POSTGRES_DB: dummy_pg_db
         run: |
           docker volume prune -f
-          docker compose up -d --build
+          docker compose up -d --build --wait
           docker ps
       - name: Cache python modules
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,17 +19,14 @@ jobs:
           poetry-version: "1.6.1"
       - name: Resolve dependencies
         run: poetry export -f requirements.txt --without-hashes --with dev --output src/app/requirements.txt
-      - name: Build & run docker
+      - name: Run the backend & the tests
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_TEST_CHAT_ID: ${{ secrets.TELEGRAM_TEST_CHAT_ID }}
-        run: docker compose -f docker-compose.test.yml up -d --build
-      - name: "Create local AWS environment"
         run: |
+          docker compose -f docker-compose.test.yml up -d --build
           docker compose exec localstack awslocal s3 mb s3://sample-bucket
           docker compose exec localstack awslocal s3api put-object --bucket sample-bucket --key media-folder
-      - name: Run docker test
-        run: |
           docker compose -f docker-compose.test.yml exec -T backend pytest --cov=app --cov-report xml tests/
           docker compose -f docker-compose.test.yml cp backend:/app/coverage.xml ./coverage-src.xml
       - name: Upload coverage to Codecov
@@ -57,7 +54,19 @@ jobs:
           poetry-version: "1.6.1"
       - name: Resolve dependencies
         run: poetry export -f requirements.txt --without-hashes --output src/app/requirements.txt
-      - name: Build & run API server
+      - name: Run backend
+        env:
+          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+          BUCKET_MEDIA_FOLDER: ${{ secrets.BUCKET_MEDIA_FOLDER }}
+          S3_ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_REGION: ${{ secrets.S3_REGION }}
+          SUPERUSER_LOGIN: dummy_login
+          SUPERUSER_PWD: dummy&P@ssw0rd!
+          POSTGRES_USER: dummy_pg_user
+          POSTGRES_PASSWORD: dummy_pg_pwd
+          POSTGRES_DB: dummy_pg_db
         run: |
           docker volume prune -f
           docker compose up -d --build
@@ -67,12 +76,13 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('client/pyproject.toml') }}
-      - name: Install dependencies
+      - name: Run client tests
+        env:
+          SUPERUSER_LOGIN: dummy_login
+          SUPERUSER_PWD: dummy&P@ssw0rd!
         run: |
-          python -m pip install --upgrade pip
-          pip install -e "client/.[test]"
-      - name: Run client unittests
-        run: |
+          python -m pip install --upgrade uv
+          uv pip install --system -e "client/.[test]"
           sleep 15
           cd client && pytest --cov=pyroclient --cov-report xml tests/ -n auto
       - name: Upload coverage to Codecov

--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -30,7 +30,7 @@ ROUTES: Dict[str, str] = {
     #################
     # SITES
     #################
-    "get-sites": "/sites",
+    "get-sites": "/sites/",
     #################
     # EVENTS
     #################
@@ -52,7 +52,7 @@ ROUTES: Dict[str, str] = {
     # ALERTS
     #################
     "send-alert-from-device": "/alerts/from-device",
-    "get-alerts": "/alerts",
+    "get-alerts": "/alerts/",
     "get-ongoing-alerts": "/alerts/ongoing",
 }
 

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -71,12 +71,21 @@ def setup(admin_client):
     response = requests.post(urljoin(API_URL, "events"), json=payload, headers=admin_client.headers, timeout=5)
     assert response.status_code == 201
     event_id = response.json()["id"]
+    # User
+    response = requests.get(urljoin(API_URL, "users/me"), headers=admin_client.headers, timeout=5)
+    assert response.status_code == 200
+    user_id = response.json()["id"]
     # Media
-    payload = {"device_id": 1}
+    payload = {"owner_id": user_id, "login": "pyrodevice", "password": "my_pwd", "specs": "V0.1", "angle_of_view": 68.0}
+    response = requests.post(urljoin(API_URL, "devices"), json=payload, headers=admin_client.headers, timeout=5)
+    assert response.status_code == 201
+    device_id = response.json()["id"]
+    # Media
+    payload = {"device_id": device_id}
     response = requests.post(urljoin(API_URL, "media"), json=payload, headers=admin_client.headers, timeout=5)
     assert response.status_code == 201
     media_id = response.json()["id"]
     # Alert
-    payload = {"lat": 0.0, "lon": 0.0, "event_id": event_id, "media_id": media_id, "device_id": 1, "azimuth": 0}
+    payload = {"lat": 0.0, "lon": 0.0, "event_id": event_id, "media_id": media_id, "device_id": device_id, "azimuth": 0}
     response = requests.post(urljoin(API_URL, "alerts"), json=payload, headers=admin_client.headers, timeout=5)
     assert response.status_code == 201

--- a/scripts/api_e2e.py
+++ b/scripts/api_e2e.py
@@ -28,11 +28,7 @@ def api_request(method_type: str, route: str, headers=Dict[str, str], payload: O
     kwargs = {"json": payload} if isinstance(payload, dict) else {}
 
     response = getattr(requests, method_type)(route, headers=headers, **kwargs)
-    try:
-        detail = response.json()["detail"]
-    except (requests.exceptions.JSONDecodeError, KeyError):
-        detail = response.text
-    assert response.status_code // 100 == 2, print(detail)
+    assert response.status_code // 100 == 2, print(response.text)
     return response.json()
 
 

--- a/scripts/api_e2e.py
+++ b/scripts/api_e2e.py
@@ -67,6 +67,9 @@ def main(args):
     # Create a site
     payload = {"name": "first_site", "country": "FR", "geocode": "01", "lat": 44.1, "lon": 3.9, "group_id": 1}
     site_id = api_request("post", f"{api_url}/sites/", superuser_auth, payload)["id"]
+    # Check internal redirect of slashes
+    api_request("get", f"{api_url}/sites/", superuser_auth)
+    api_request("get", f"{api_url}/sites", superuser_auth)
 
     # Update the user password
     payload = {"password": "my_second_pwd"}  # nosec B106

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -13,7 +13,8 @@ COPY app/requirements.txt /app/requirements.txt
 # install dependencies
 RUN set -eux \
     && apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev libmagic \
-    && pip install -r /app/requirements.txt \
+    && pip install --no-cache-dir uv \
+    && uv pip install --no-cache --system -r /app/requirements.txt \
     && apk del --purge gcc musl-dev postgresql-dev \
     && rm -rf /root/.cache/pip
 

--- a/src/Dockerfile-dev
+++ b/src/Dockerfile-dev
@@ -13,7 +13,8 @@ COPY app/requirements.txt /app/requirements.txt
 # install dependencies
 RUN set -eux \
     && apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev libmagic \
-    && pip install -r /app/requirements.txt \
+    && pip install --no-cache-dir uv \
+    && uv pip install --no-cache --system -r /app/requirements.txt \
     && apk del --purge gcc musl-dev postgresql-dev \
     && rm -rf /root/.cache/pip
 

--- a/src/app/api/endpoints/accesses.py
+++ b/src/app/api/endpoints/accesses.py
@@ -13,7 +13,7 @@ from app.db import accesses
 from app.models import AccessType
 from app.schemas.accesses import AccessRead
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 @router.get("/{access_id}/", response_model=AccessRead, summary="Get information about a specific access")

--- a/src/app/api/endpoints/alerts.py
+++ b/src/app/api/endpoints/alerts.py
@@ -22,7 +22,7 @@ from app.models import Access, AccessType, Alert, Device, Event
 from app.schemas import AlertBase, AlertIn, AlertOut, DeviceOut, NotificationIn, RecipientOut, UserRead
 from app.services.telemetry import telemetry_client
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 async def check_media_existence(media_id):

--- a/src/app/api/endpoints/devices.py
+++ b/src/app/api/endpoints/devices.py
@@ -28,7 +28,7 @@ from app.schemas import (
 )
 from app.services.telemetry import telemetry_client
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 @router.post("/", response_model=DeviceOut, status_code=status.HTTP_201_CREATED, summary="Create a new device")

--- a/src/app/api/endpoints/events.py
+++ b/src/app/api/endpoints/events.py
@@ -18,7 +18,7 @@ from app.models import Access, AccessType, Alert, Device, Event
 from app.schemas import AccessRead, Acknowledgement, AcknowledgementOut, AlertOut, EventIn, EventOut, EventUpdate
 from app.services.telemetry import telemetry_client
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 @router.post("/", status_code=status.HTTP_201_CREATED, summary="Create a new event")

--- a/src/app/api/endpoints/groups.py
+++ b/src/app/api/endpoints/groups.py
@@ -13,7 +13,7 @@ from app.db import groups
 from app.models import AccessType
 from app.schemas import GroupIn, GroupOut
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 @router.post("/", response_model=GroupOut, status_code=status.HTTP_201_CREATED, summary="Create a new group")

--- a/src/app/api/endpoints/installations.py
+++ b/src/app/api/endpoints/installations.py
@@ -18,7 +18,7 @@ from app.models import AccessType, Installation, Site
 from app.schemas import InstallationIn, InstallationOut, InstallationUpdate
 from app.services.telemetry import telemetry_client
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 @router.post(

--- a/src/app/api/endpoints/login.py
+++ b/src/app/api/endpoints/login.py
@@ -13,7 +13,7 @@ from app.api import crud, security
 from app.db import accesses
 from app.schemas import Token
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 @router.post("/access-token", response_model=Token)

--- a/src/app/api/endpoints/media.py
+++ b/src/app/api/endpoints/media.py
@@ -21,7 +21,7 @@ from app.schemas import BaseMedia, DeviceOut, MediaCreation, MediaIn, MediaOut, 
 from app.services import resolve_bucket_key, s3_bucket
 from app.services.telemetry import telemetry_client
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 async def check_media_registration(media_id: int, device_id: Optional[int] = None) -> Dict[str, Any]:

--- a/src/app/api/endpoints/notifications.py
+++ b/src/app/api/endpoints/notifications.py
@@ -16,7 +16,7 @@ from app.schemas import NotificationIn, NotificationOut, RecipientOut, UserRead
 from app.services import send_telegram_msg
 from app.services.telemetry import telemetry_client
 
-router = APIRouter(dependencies=[Security(get_current_access, scopes=[AccessType.admin])])
+router = APIRouter(dependencies=[Security(get_current_access, scopes=[AccessType.admin])], redirect_slashes=True)
 
 
 async def _send_notification(payload: NotificationIn) -> NotificationOut:

--- a/src/app/api/endpoints/recipients.py
+++ b/src/app/api/endpoints/recipients.py
@@ -13,7 +13,7 @@ from app.db import recipients
 from app.models import AccessType
 from app.schemas import RecipientIn, RecipientOut
 
-router = APIRouter(dependencies=[Security(get_current_access, scopes=[AccessType.admin])])
+router = APIRouter(dependencies=[Security(get_current_access, scopes=[AccessType.admin])], redirect_slashes=True)
 
 
 @router.post("/", response_model=RecipientOut, status_code=status.HTTP_201_CREATED, summary="Create a new recipient")

--- a/src/app/api/endpoints/sites.py
+++ b/src/app/api/endpoints/sites.py
@@ -16,7 +16,7 @@ from app.models import AccessType, SiteType
 from app.schemas import SiteBase, SiteIn, SiteOut, SiteUpdate
 from app.services.telemetry import telemetry_client
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 @router.post("/", response_model=SiteOut, status_code=status.HTTP_201_CREATED, summary="Create a new site")

--- a/src/app/api/endpoints/users.py
+++ b/src/app/api/endpoints/users.py
@@ -15,7 +15,7 @@ from app.models import Access, AccessType, User
 from app.schemas import Cred, Login, UserAuth, UserCreation, UserRead
 from app.services.telemetry import telemetry_client
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 @router.get("/me", response_model=UserRead, summary="Get information about the current user")

--- a/src/app/api/endpoints/webhooks.py
+++ b/src/app/api/endpoints/webhooks.py
@@ -12,7 +12,7 @@ from app.api.deps import get_current_access
 from app.db import webhooks
 from app.schemas import WebhookIn, WebhookOut
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=True)
 
 
 @router.post("/", response_model=WebhookOut, status_code=status.HTTP_201_CREATED, summary="Create a new webhook")


### PR DESCRIPTION
This PR introduces the following modifications:
- reflects the final slash in the endpoint of base router (cf. https://github.com/pyronear/pyro-api/blob/main/src/app/api/endpoints/sites.py#L22) by modifying the client routes
- make sure the API is redirecting to the trailing slash endpoint in the backend to avoid problems later
- add a test case in the integration test script
- speeds up the dependencies installation in the Docker images

Any feedback is welcome!
cc @MateoLostanlen 