### PR TITLE
Raise an exception for sentry log

### DIFF
--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -70,8 +70,8 @@ class S3Bucket:
         try:
             self._s3.upload_fileobj(file_binary, self.bucket_name, bucket_key)
         except Exception as e:
-            logger.warning(e)
-            return False
+            logger.error(e)
+            raise
         return True
 
     async def delete_file(self, bucket_key: str) -> None:


### PR DESCRIPTION
The following exception is not raised : 
`botocore.errorfactory.NoSuchBucket: An error occurred (NoSuchBucket) when calling the PutObject operation: The specified bucket does not exist`

