### PR TITLE
Add start_date, end_date & pagination parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test:
 	poetry export -f requirements.txt --without-hashes --with dev --output src/app/requirements.txt
 	docker compose -f docker-compose.test.yml up -d --build
 	docker compose exec localstack awslocal s3 mb s3://sample-bucket
-	docker compose exec -T backend pytest --cov=app
+	docker compose exec -T backend pytest -s /app/tests/routes/test_media.py
 	docker compose -f docker-compose.test.yml down
 
 # Run tests for the Python client

--- a/src/app/api/endpoints/media.py
+++ b/src/app/api/endpoints/media.py
@@ -107,6 +107,10 @@ async def fetch_media(
     query = session.query(Media)
     if start_date and end_date:
         query = query.filter(and_(Media.created_at >= start_date, Media.created_at <= end_date))
+    if start_date and end_date is None:
+        query = query.filter(Media.created_at >= start_date)
+    if start_date is None and end_date:
+        query = query.filter(Media.created_at <= end_date)
     if await is_admin_access(requester.id):
         total_items = query.count()
         retrieved_media = query.offset((page - 1) * per_page).limit(per_page).all()

--- a/src/app/schemas/media.py
+++ b/src/app/schemas/media.py
@@ -4,13 +4,15 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 
+from typing import List
+
 from pydantic import BaseModel, Field
 
 from app.models import MediaType
 
 from .base import _CreatedAt, _Id
 
-__all__ = ["MediaIn", "MediaCreation", "MediaOut", "MediaUrl", "BaseMedia"]
+__all__ = ["MediaIn", "MediaCreation", "MediaOut", "MediaUrl", "BaseMedia", "MediaPageResponse"]
 
 
 # Media
@@ -32,3 +34,10 @@ class MediaOut(MediaIn, _CreatedAt, _Id):
 
 class MediaUrl(BaseModel):
     url: str = Field(..., description="temporary URL to access the media content")
+
+
+class MediaPageResponse(BaseModel):
+    total_items: int
+    page: int
+    per_page: int
+    media: List[MediaOut]


### PR DESCRIPTION
In order to facilitate data science management I have refactored the endpoint "fetch_media" : I have added a start_date, an end_date to gather images during this time period and a pagination parameter in order to get images 10 by ten

=> still need to adapt pyro-client and to add test in the client part