### PR TITLE
add timeout arg

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -3,7 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
-from typing import Dict
+from typing import Dict, Optional
 from urllib.parse import urljoin
 
 import requests
@@ -71,17 +71,21 @@ class Client:
         return {"Authorization": f"Bearer {self.token}"}
 
     # CAMERAS
-    def heartbeat(self) -> Response:
+    def heartbeat(self, timeout: Optional[float] = None) -> Response:
         """Update the last ping of the camera
 
         >>> from pyroclient import Client
         >>> api_client = Client("MY_CAM_TOKEN")
         >>> response = api_client.heartbeat()
 
+        Args:
+            timeout: Optional timeout value for the request. If not provided, defaults to self.timeout.
+
         Returns:
-            HTTP response containing the update device info
+            HTTP response containing the updated device info
         """
-        return requests.patch(self.routes["cameras-heartbeat"], headers=self.headers, timeout=self.timeout)
+        request_timeout = timeout if timeout is not None else self.timeout
+        return requests.patch(self.routes["cameras-heartbeat"], headers=self.headers, timeout=request_timeout)
 
     # DETECTIONS
     def create_detection(


### PR DESCRIPTION
My internet router is very buggy at the moment and the connection jumps very frequently. It's very unpleasant, but I practically live on one of our stations, which allows me to pick up bugs that can happen in the field. 
For example, I had relatively variable prediction times without much reason, so I looked at the details and the main thing that changed was the call to the api due to the bad connection:
```

2024-06-06 17:06:27,504 | INFO: Camera '169.254.40.2' - No wildfire (confidence: 3.18%)
2024-06-06 17:06:27,504 | INFO: Heartbeat time: 4.098053 seconds
2024-06-06 17:06:27,504 | INFO: Resize time: 0.137569 seconds
2024-06-06 17:06:27,505 | INFO: Inference time: 2.505296 seconds
2024-06-06 17:06:27,505 | INFO: Update states time: 0.000756 seconds
2024-06-06 17:06:27,505 | INFO: Alert time: 0.000002 seconds
2024-06-06 17:06:27,505 | INFO: Total prediction time: 6.742037 seconds
2024-06-06 17:06:27,505 | INFO: Time taken to analyze stream from camera 169.254.40.2: 6.74 seconds
169.254.40.1 (3840, 2160)
2024-06-06 17:06:31,112 | INFO: Camera '169.254.40.1' - No wildfire (confidence: 27.97%)
2024-06-06 17:06:31,113 | INFO: Heartbeat time: 0.223382 seconds
2024-06-06 17:06:31,113 | INFO: Resize time: 0.112550 seconds
2024-06-06 17:06:31,114 | INFO: Inference time: 3.079912 seconds
2024-06-06 17:06:31,114 | INFO: Update states time: 0.001111 seconds
2024-06-06 17:06:31,114 | INFO: Alert time: 0.000003 seconds
2024-06-06 17:06:31,114 | INFO: Total prediction time: 3.417658 seconds
2024-06-06 17:06:31,114 | INFO: Time taken to analyze stream from camera 169.254.40.1: 3.42 seconds
```

I propose this PR to be able to change the heartbeat timeout by passing an argument. It's not really a problem if the heartbeat fails from time to time, but it mustn't block our loop. I'll probably even change the way I call it in engine