### PR TITLE
build(deps): bump requests & idna to security compliant versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -676,13 +676,13 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
-    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
+    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
+    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1429,13 +1429,13 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.31.0"
+version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [package.dependencies]
@@ -1856,4 +1856,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "cbb4605c1477d7af1e97e418b4c92eeafed198c7609e68d7d06b1ce99285e335"
+content-hash = "f9ea4765bb8b061670dc18744a748ec756333865e079ca810370caf74cfdd2a1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ fastapi = ">=0.109.1,<1.0.0"
 sqlmodel = "^0.0.16"
 pydantic = ">=2.0.0,<3.0.0"
 pydantic-settings = ">=2.0.0,<3.0.0"
-requests = "^2.31.0"
+requests = "^2.32.0"
 PyJWT = "^2.8.0"
 passlib = { version = "^1.7.4", extras = ["bcrypt"] }
 uvicorn = ">=0.11.1,<1.0.0"


### PR DESCRIPTION
This PR bumps requests from 2.31.0 to 2.32.0 and idna from 3.4 to 3.7.

cf. https://github.com/pyronear/pyro-api/security/dependabot/41
cf. https://github.com/pyronear/pyro-api/security/dependabot/38