### PR TITLE
Fix :the admin behavior for bucket requests

### DIFF
--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -130,8 +130,14 @@ async def get_detection_url(
     detection = cast(Detection, await detections.get(detection_id, strict=True))
 
     if UserRole.ADMIN in token_payload.scopes:
-        return DetectionUrl(
-            url=await s3_bucket.get_public_url(detection.bucket_key, get_bucket_name(token_payload.organization_id))
+        camera = await cameras.get(detection.camera_id)
+        if camera is not None:
+            return DetectionUrl(
+                url=await s3_bucket.get_public_url(detection.bucket_key, get_bucket_name(camera.organization_id))
+            )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="No Camera found",
         )
 
     camera = await cameras.get(detection.camera_id, strict=True)

--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -59,7 +59,10 @@ class S3Bucket:
     async def get_public_url(self, bucket_key: str, bucket_name: str, url_expiration: int = 3600) -> str:
         """Generate a temporary public URL for a bucket file"""
         if not (await self.check_file_existence(bucket_key, bucket_name)):
-            raise HTTPException(status_code=404, detail="File cannot be found on the bucket storage")
+            raise HTTPException(
+                status_code=404,
+                detail=f"File cannot be found on the bucket storage : bucket_key : {bucket_key}, bucket_name : {bucket_name}",
+            )
 
         # Point to the bucket file
         file_params = {"Bucket": bucket_name, "Key": bucket_key}


### PR DESCRIPTION
If you are connected as an admin, the bucket par defaut is "admin" but the endpoint Detection was using the "alert-api-1" name.

Anyway we should not use any of this two solutions when requesting for an URL, we need to use the Detection_id instead