### PR TITLE
ci(push): fix workflow syntax for push job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,7 +44,7 @@ jobs:
           docker push $IMAGE_ID:latest
 
   deploy-dev:
-    needs: dockerhub
+    needs: docker
     runs-on: ubuntu-latest
     steps:
       - uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
This PR fixes a small problem introduced in #322 as the CI workflow job was renamed but the depending job didn't update the reference to it. This will now push again the latest version of the docker image to Dockerhub & GitHub container registry