### PR TITLE
Fix fetch unlabeled detections endpoint

### DIFF
--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -19,10 +19,13 @@ from fastapi import (
     UploadFile,
     status,
 )
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import dispatch_webhook, get_camera_crud, get_detection_crud, get_jwt, get_webhook_crud
 from app.core.config import settings
 from app.crud import CameraCRUD, DetectionCRUD, WebhookCRUD
+from app.db import get_session
 from app.models import Camera, Detection, Role, UserRole
 from app.schemas.detections import (
     BOXES_PATTERN,
@@ -143,41 +146,39 @@ async def fetch_unlabeled_detections(
     limit: Optional[int] = Query(15, description="Maximum number of detections to fetch"),
     offset: Optional[int] = Query(0, description="Number of detections to skip before starting to fetch"),
     detections: DetectionCRUD = Depends(get_detection_crud),
-    cameras: CameraCRUD = Depends(get_camera_crud),
+    session: AsyncSession = Depends(get_session),
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[DetectionWithUrl]:
-    telemetry_client.capture(token_payload.sub, event="unacknowledged-fetch")
-
-    bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(token_payload.organization_id))
-
-    def get_url(detection: Detection) -> str:
-        return bucket.get_public_url(detection.bucket_key)
-
-    async def get_url_with_bucket(detection: Detection) -> str:
-        camera = cast(Camera, await cameras.get(detection.camera_id, strict=True))
-        bucket_ = s3_service.get_bucket(s3_service.resolve_bucket_name(camera.organization_id))
-        return bucket_.get_public_url(detection.bucket_key)
+    telemetry_client.capture(token_payload.sub, event="detections-fetch-unlabeled")
 
     if UserRole.ADMIN in token_payload.scopes:
-        all_unck_detections = await detections.fetch_all(
+        unlabeled_detections = await detections.fetch_all(
             filter_pair=("is_wildfire", None),
             inequality_pair=("created_at", ">=", from_date),
             limit=limit,
             offset=offset,
         )
-        urls = [await get_url_with_bucket(detection) for detection in all_unck_detections]
+        bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(token_payload.organization_id))
+        urls = [bucket.get_public_url(detection.bucket_key) for detection in unlabeled_detections]
     else:
-        org_cams = await cameras.fetch_all(filter_pair=("organization_id", token_payload.organization_id))
-        all_unck_detections = await detections.fetch_all(
-            filter_pair=("is_wildfire", None),
-            in_pair=("camera_id", [camera.id for camera in org_cams]),
-            inequality_pair=("created_at", ">=", from_date),
-            limit=limit,
-            offset=offset,
+        # Custom SQL query to fetch detections along with corresponding organization_id
+        query = await session.exec(
+            select(Detection, Camera.organization_id)
+            .join(Camera, Detection.camera_id == Camera.id)
+            .where(Detection.is_wildfire.is_(None))
+            .where(Detection.created_at >= from_date)
+            .where(Camera.organization_id == token_payload.organization_id)
+            .limit(limit)
+            .offset(offset)
         )
-        urls = [get_url(detection) for detection in all_unck_detections]
+        results = query.all()
+        unlabeled_detections = [Detection(**detection.__dict__) for detection, _ in results]
+        urls = [
+            s3_service.get_bucket(s3_service.resolve_bucket_name(org_id)).get_public_url(det.bucket_key)
+            for det, org_id in results
+        ]
 
-    return [DetectionWithUrl(**detection.model_dump(), url=url) for detection, url in zip(all_unck_detections, urls)]
+    return [DetectionWithUrl(**detection.model_dump(), url=url) for detection, url in zip(unlabeled_detections, urls)]
 
 
 @router.patch("/{detection_id}/label", status_code=status.HTTP_200_OK, summary="Label the nature of the detection")

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -191,7 +191,7 @@ async def fetch_unlabeled_detections(
             .offset(offset)
         )
         results = query.all()
-        unlabeled_detections = [Detection(**detection.__dict__) for detection, _ in results]
+        unlabeled_detections = [Detection(**detection.__dict__) for detection in results]
         bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(token_payload.organization_id))
         urls = [bucket.get_public_url(detection.bucket_key) for detection in unlabeled_detections]
 

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -140,7 +140,7 @@ async def fetch_detections(
 @router.get("/unlabeled/fromdate", status_code=status.HTTP_200_OK, summary="Fetch all the unlabeled detections")
 async def fetch_unlabeled_detections(
     from_date: datetime = Query(),
-    limit: Optional[int] = Query(None, description="Maximum number of detections to fetch"),
+    limit: Optional[int] = Query(15, description="Maximum number of detections to fetch"),
     offset: Optional[int] = Query(0, description="Number of detections to skip before starting to fetch"),
     detections: DetectionCRUD = Depends(get_detection_crud),
     cameras: CameraCRUD = Depends(get_camera_crud),

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -177,9 +177,9 @@ async def fetch_unlabeled_detections(
     else:
         # Custom SQL query to fetch detections along with corresponding organization_id
         query = await session.exec(
-            select(Detection, Camera.organization_id)
-            .join(Camera, Detection.camera_id == Camera.id)
-            .where(Detection.is_wildfire.is_(None))
+            select(Detection, Camera.organization_id)  # type: ignore[attr-defined]
+            .join(Camera, Detection.camera_id == Camera.id)  # type: ignore[arg-type]
+            .where(Detection.is_wildfire.is_(None))  # type: ignore[union-attr]
             .where(Detection.created_at >= from_date)
             .where(Camera.organization_id == token_payload.organization_id)
             .limit(limit)

--- a/src/app/crud/base.py
+++ b/src/app/crud/base.py
@@ -63,6 +63,8 @@ class BaseCRUD(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         filter_pair: Union[Tuple[str, Any], None] = None,
         in_pair: Union[Tuple[str, List], None] = None,
         inequality_pair: Optional[Tuple[str, str, Any]] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[ModelType]:
         statement = select(self.model)  # type: ignore[var-annotated]
         if isinstance(filter_pair, tuple):
@@ -83,6 +85,12 @@ class BaseCRUD(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
                 statement = statement.where(getattr(self.model, field) < value)
             else:
                 raise ValueError(f"Unsupported inequality operator: {op}")
+
+        if offset is not None:
+            statement = statement.offset(offset)
+
+        if limit is not None:
+            statement = statement.limit(limit)
 
         result = await self.session.exec(statement=statement)
         return [r for r in result]


### PR DESCRIPTION
When calling the fetch unlabeled detections endpoint with an ADMIN token, the pictures were not found in the S3 because the organisation_id of ADMIN is = 1, while we would like to get all the Detection of all the organization.

So for ADMIN token we should find the organization_id thanks to the Camera.detection_id