### PR TITLE
feat(webhooks): add webhook mechanism on detection creation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -72,6 +72,12 @@
     - src/app/api/*/endpoints/organizations.py
     - src/app/crud/organizations.py
 
+'endpoint: webhooks':
+- changed-files:
+  - any-glob-to-any-file:
+    - src/app/api/*/endpoints/webhooks.py
+    - src/app/crud/webhooks.py
+
 
 'topic: build':
 - changed-files:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The back-end core feature is to interact with the metadata tables. For the servi
 
 - Detection: association of a picture and a camera.
 
-![UML diagram](https://github.com/user-attachments/assets/cd45d9e3-c570-4d84-95b9-7a8c5ae00af0)
+![UML diagram](https://github.com/user-attachments/assets/d0160a58-b494-4b81-bef0-b1a9f483be3e)
 
 ### What is the full detection workflow through the API
 

--- a/scripts/dbdiagram.txt
+++ b/scripts/dbdiagram.txt
@@ -37,6 +37,7 @@ Table "Detection" as D {
   "camera_id" int [ref: > C.id, not null]
   "azimuth" float [not null]
   "bucket_key" str [not null]
+  "bboxes" str [not null]
   "is_wildfire" bool
   "created_at" timestamp [not null]
   "updated_at" timestamp [not null]
@@ -48,6 +49,15 @@ Table "Detection" as D {
 Table "Organization" as O {
   "id" int [not null]
   "name" str [not null]
+  Indexes {
+    (id) [pk]
+  }
+}
+
+
+Table "Webhook" as W {
+  "id" int [not null]
+  "url" str [not null]
   Indexes {
     (id) [pk]
   }

--- a/src/app/api/api_v1/endpoints/webhooks.py
+++ b/src/app/api/api_v1/endpoints/webhooks.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2024, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+from typing import List, cast
+
+from fastapi import APIRouter, Depends, Path, Security, status
+
+from app.api.dependencies import get_jwt, get_webhook_crud
+from app.crud import WebhookCRUD
+from app.models import UserRole, Webhook
+from app.schemas.login import TokenPayload
+from app.schemas.webhooks import WebhookCreate, WebhookCreation
+from app.services.telemetry import telemetry_client
+
+router = APIRouter()
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED, summary="Register a new webhook")
+async def register_webhook(
+    payload: WebhookCreate,
+    webhooks: WebhookCRUD = Depends(get_webhook_crud),
+    token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN]),
+) -> Webhook:
+    telemetry_client.capture(token_payload.sub, event="webhooks-create")
+    return await webhooks.create(WebhookCreation(url=str(payload.url)))
+
+
+@router.get("/{webhook_id}", status_code=status.HTTP_200_OK, summary="Fetch the information of a specific webhook")
+async def get_webhook(
+    webhook_id: int = Path(..., gt=0),
+    webhooks: WebhookCRUD = Depends(get_webhook_crud),
+    token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN]),
+) -> Webhook:
+    telemetry_client.capture(token_payload.sub, event="webhooks-get", properties={"webhook_id": webhook_id})
+    return cast(Webhook, await webhooks.get(webhook_id, strict=True))
+
+
+@router.get("/", status_code=status.HTTP_200_OK, summary="Fetch all the webhooks")
+async def fetch_webhooks(
+    webhooks: WebhookCRUD = Depends(get_webhook_crud),
+    token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN]),
+) -> List[Webhook]:
+    telemetry_client.capture(token_payload.sub, event="webhooks-fetch")
+    return [elt for elt in await webhooks.fetch_all()]
+
+
+@router.delete("/{webhook_id}", status_code=status.HTTP_200_OK, summary="Delete a webhook")
+async def delete_webhook(
+    webhook_id: int = Path(..., gt=0),
+    webhooks: WebhookCRUD = Depends(get_webhook_crud),
+    token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN]),
+) -> None:
+    telemetry_client.capture(token_payload.sub, event="webhooks-deletion", properties={"webhook_id": webhook_id})
+    await webhooks.delete(webhook_id)

--- a/src/app/api/api_v1/router.py
+++ b/src/app/api/api_v1/router.py
@@ -5,7 +5,7 @@
 
 from fastapi import APIRouter
 
-from app.api.api_v1.endpoints import cameras, detections, login, organizations, users
+from app.api.api_v1.endpoints import cameras, detections, login, organizations, users, webhooks
 
 api_router = APIRouter(redirect_slashes=True)
 api_router.include_router(login.router, prefix="/login", tags=["login"])
@@ -13,3 +13,4 @@ api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(cameras.router, prefix="/cameras", tags=["cameras"])
 api_router.include_router(detections.router, prefix="/detections", tags=["detections"])
 api_router.include_router(organizations.router, prefix="/organizations", tags=["organizations"])
+api_router.include_router(webhooks.router, prefix="/webhooks", tags=["webhooks"])

--- a/src/app/api/dependencies.py
+++ b/src/app/api/dependencies.py
@@ -121,6 +121,4 @@ async def dispatch_webhook(url: str, payload: BaseModel) -> None:
             response.raise_for_status()
             logger.info(f"Successfully dispatched to {url}")
         except HTTPStatusError as e:
-            logger.error(f"Error sending notification to {url}: {e.response.status_code} - {e.response.text}")
-        except Exception as e:
-            logger.error(f"Failed to dispatch webhook to {url}: {e!s}")
+            logger.error(f"Error dispatching webhook to {url}: {e.response.status_code} - {e.response.text}")

--- a/src/app/api/dependencies.py
+++ b/src/app/api/dependencies.py
@@ -3,22 +3,25 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+import logging
 from typing import Dict, Type, TypeVar, Union, cast
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, SecurityScopes
+from httpx import AsyncClient, HTTPStatusError
 from jwt import DecodeError, ExpiredSignatureError, InvalidSignatureError
 from jwt import decode as jwt_decode
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
-from app.crud import CameraCRUD, DetectionCRUD, OrganizationCRUD, UserCRUD
+from app.crud import CameraCRUD, DetectionCRUD, OrganizationCRUD, UserCRUD, WebhookCRUD
 from app.db import get_session
 from app.models import User, UserRole
 from app.schemas.login import TokenPayload
 
 JWTTemplate = TypeVar("JWTTemplate")
+logger = logging.getLogger("uvicorn.error")
 
 __all__ = ["get_user_crud"]
 
@@ -47,6 +50,10 @@ def get_detection_crud(session: AsyncSession = Depends(get_session)) -> Detectio
 
 def get_organization_crud(session: AsyncSession = Depends(get_session)) -> OrganizationCRUD:
     return OrganizationCRUD(session=session)
+
+
+def get_webhook_crud(session: AsyncSession = Depends(get_session)) -> WebhookCRUD:
+    return WebhookCRUD(session=session)
 
 
 def decode_token(token: str, authenticate_value: Union[str, None] = None) -> Dict[str, str]:
@@ -105,3 +112,15 @@ async def get_current_user(
     """Dependency to use as fastapi.security.Security with scopes"""
     token_payload = get_jwt(security_scopes, token)
     return cast(User, await users.get(token_payload.sub, strict=True))
+
+
+async def dispatch_webhook(url: str, payload: BaseModel) -> None:
+    async with AsyncClient() as client:
+        try:
+            response = await client.post(url, json=payload.model_dump_json())
+            response.raise_for_status()
+            logger.info(f"Successfully dispatched to {url}")
+        except HTTPStatusError as e:
+            logger.error(f"Error sending notification to {url}: {e.response.status_code} - {e.response.text}")
+        except Exception as e:
+            logger.error(f"Failed to dispatch webhook to {url}: {e!s}")

--- a/src/app/crud/__init__.py
+++ b/src/app/crud/__init__.py
@@ -2,3 +2,4 @@ from .crud_user import *
 from .crud_camera import *
 from .crud_detection import *
 from .crud_organization import *
+from .crud_webhook import *

--- a/src/app/crud/crud_webhook.py
+++ b/src/app/crud/crud_webhook.py
@@ -4,15 +4,15 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 
-from pydantic import AnyHttpUrl
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.crud.base import BaseCRUD
 from app.models import Webhook
+from app.schemas.webhooks import WebhookCreation
 
 __all__ = ["WebhookCRUD"]
 
 
-class WebhookCRUD(BaseCRUD[Webhook, AnyHttpUrl, AnyHttpUrl]):
+class WebhookCRUD(BaseCRUD[Webhook, WebhookCreation, WebhookCreation]):
     def __init__(self, session: AsyncSession) -> None:
         super().__init__(session, Webhook)

--- a/src/app/crud/crud_webhook.py
+++ b/src/app/crud/crud_webhook.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2024, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+
+from pydantic import AnyHttpUrl
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.crud.base import BaseCRUD
+from app.models import Webhook
+
+__all__ = ["WebhookCRUD"]
+
+
+class WebhookCRUD(BaseCRUD[Webhook, AnyHttpUrl, AnyHttpUrl]):
+    def __init__(self, session: AsyncSession) -> None:
+        super().__init__(session, Webhook)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -64,3 +64,8 @@ class Detection(SQLModel, table=True):
 class Organization(SQLModel, table=True):
     id: int = Field(None, primary_key=True)
     name: str = Field(..., min_length=5, max_length=100, nullable=False, unique=True)
+
+
+class Webhook(SQLModel, table=True):
+    id: int = Field(None, primary_key=True)
+    url: str = Field(..., nullable=False, unique=True)

--- a/src/app/schemas/__init__.py
+++ b/src/app/schemas/__init__.py
@@ -4,3 +4,4 @@ from .cameras import *
 from .login import *
 from .users import *
 from .organizations import *
+from .webhooks import *

--- a/src/app/schemas/webhooks.py
+++ b/src/app/schemas/webhooks.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2024, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+__all__ = ["WebhookCreate", "WebhookCreation"]
+
+
+class WebhookCreate(BaseModel):
+    url: AnyHttpUrl
+
+
+class WebhookCreation(BaseModel):
+    url: str = Field(..., min_length=1, examples=["https://example.com"])

--- a/src/tests/endpoints/test_webhooks.py
+++ b/src/tests/endpoints/test_webhooks.py
@@ -1,0 +1,170 @@
+from typing import Any, Dict, List, Union
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.mark.parametrize(
+    ("user_idx", "payload", "status_code", "status_detail"),
+    [
+        (
+            None,
+            {"url": "http://www.google.com/"},
+            401,
+            "Not authenticated",
+        ),
+        (
+            0,
+            {"url": pytest.webhook_table[0]["url"]},
+            409,
+            None,
+        ),
+        (
+            0,
+            {"url": "http://www.google.com/"},
+            201,
+            None,
+        ),
+        (
+            1,
+            {"url": "http://www.google.com/"},
+            403,
+            "Incompatible token scope.",
+        ),
+        (
+            2,
+            {"url": "http://www.google.com/"},
+            403,
+            "Incompatible token scope.",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_webhook(
+    async_client: AsyncClient,
+    user_idx: Union[int, None],
+    payload: Dict[str, Any],
+    status_code: int,
+    status_detail: Union[str, None],
+):
+    auth = None
+    if isinstance(user_idx, int):
+        auth = pytest.get_token(
+            pytest.user_table[user_idx]["id"],
+            pytest.user_table[user_idx]["role"].split(),
+            pytest.user_table[user_idx]["organization_id"],
+        )
+
+    response = await async_client.post("/webhooks", json=payload, headers=auth)
+    assert response.status_code == status_code, print(response.__dict__)
+    if isinstance(status_detail, str):
+        assert response.json()["detail"] == status_detail
+    if response.status_code // 100 == 2:
+        assert {k: v for k, v in response.json().items() if k != "id"} == payload
+
+
+@pytest.mark.parametrize(
+    ("user_idx", "webhook_id", "status_code", "status_detail", "expected_idx"),
+    [
+        (None, 1, 401, "Not authenticated", None),
+        (0, 1, 200, None, 0),
+        (1, 1, 403, "Incompatible token scope.", 0),
+        (2, 1, 403, "Incompatible token scope.", 0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_webhook(
+    async_client: AsyncClient,
+    webhook_session: AsyncSession,
+    user_idx: Union[int, None],
+    webhook_id: int,
+    status_code: int,
+    status_detail: Union[str, None],
+    expected_idx: Union[int, None],
+):
+    auth = None
+    organization_id_from_table = pytest.user_table[user_idx]["organization_id"] if user_idx is not None else None
+    if isinstance(user_idx, int):
+        auth = pytest.get_token(
+            pytest.user_table[user_idx]["id"],
+            pytest.user_table[user_idx]["role"].split(),
+            organization_id_from_table,
+        )
+
+    response = await async_client.get(f"/webhooks/{webhook_id}", headers=auth)
+    assert response.status_code == status_code, print(response.__dict__)
+    if isinstance(status_detail, str):
+        assert response.json()["detail"] == status_detail
+    if response.status_code // 100 == 2:
+        assert response.json() == pytest.webhook_table[expected_idx]
+
+
+@pytest.mark.parametrize(
+    ("user_idx", "status_code", "status_detail", "expected_response"),
+    [
+        (None, 401, "Not authenticated", None),
+        (0, 200, None, pytest.webhook_table),
+        (1, 403, "Incompatible token scope.", None),
+        (2, 403, "Incompatible token scope.", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_fetch_webhooks(
+    async_client: AsyncClient,
+    webhook_session: AsyncSession,
+    user_idx: Union[int, None],
+    status_code: int,
+    status_detail: Union[str, None],
+    expected_response: Union[List[Dict[str, Any]], None],
+):
+    auth = None
+    if isinstance(user_idx, int):
+        auth = pytest.get_token(
+            pytest.user_table[user_idx]["id"],
+            pytest.user_table[user_idx]["role"].split(),
+            pytest.user_table[user_idx]["organization_id"],
+        )
+
+    response = await async_client.get("/webhooks", headers=auth)
+    assert response.status_code == status_code, print(response.__dict__)
+    if isinstance(status_detail, str):
+        assert response.json()["detail"] == status_detail
+    if response.status_code // 100 == 2:
+        assert response.json() == expected_response
+
+
+@pytest.mark.parametrize(
+    ("user_idx", "webhook_id", "status_code", "status_detail"),
+    [
+        (None, 1, 401, "Not authenticated"),
+        (0, 1, 200, None),
+        (1, 1, 403, "Incompatible token scope."),
+        (1, 2, 403, "Incompatible token scope."),
+        (2, 2, 403, "Incompatible token scope."),
+    ],
+)
+@pytest.mark.asyncio
+async def test_delete_webhook(
+    async_client: AsyncClient,
+    webhook_session: AsyncSession,
+    user_idx: Union[int, None],
+    webhook_id: int,
+    status_code: int,
+    status_detail: Union[str, None],
+):
+    auth = None
+    organization_id_from_table = pytest.user_table[user_idx]["organization_id"] if user_idx is not None else None
+    if isinstance(user_idx, int):
+        auth = pytest.get_token(
+            pytest.user_table[user_idx]["id"],
+            pytest.user_table[user_idx]["role"].split(),
+            organization_id_from_table,
+        )
+
+    response = await async_client.delete(f"/webhooks/{webhook_id}", headers=auth)
+    assert response.status_code == status_code, print(response.__dict__)
+    if isinstance(status_detail, str):
+        assert response.json()["detail"] == status_detail
+    if response.status_code // 100 == 2:
+        assert response.json() is None

--- a/src/tests/endpoints/test_webhooks.py
+++ b/src/tests/endpoints/test_webhooks.py
@@ -43,6 +43,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 @pytest.mark.asyncio
 async def test_create_webhook(
     async_client: AsyncClient,
+    webhook_session: AsyncSession,
     user_idx: Union[int, None],
     payload: Dict[str, Any],
     status_code: int,


### PR DESCRIPTION
This PR adds a small webhook table, and used when detection are created as background tasks. I made webhooks editable only by admins, and they post the detection payload for now. We'll be able to edit what gets sent upon dispatch later if needed

Here is the new UML:
![UML diagram](https://github.com/user-attachments/assets/d0160a58-b494-4b81-bef0-b1a9f483be3e)