### PR TITLE
feat(organizations): add optional Telegram notifications for detections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ SERVER_NAME=
 POSTHOG_HOST='https://eu.posthog.com'
 POSTHOG_KEY=
 SUPPORT_EMAIL=
+TELEGRAM_TOKEN=
 
 # Production-only
 ACME_EMAIL=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ None :)
 - `S3_REGION`: your S3 bucket is geographically identified by its location's region
 - `S3_ENDPOINT_URL`: the URL providing a S3 endpoint by your cloud provider
 - `S3_PROXY_URL`: the url of the proxy to hide the real s3 url behind, do not use proxy if ""
-
+- `TELEGRAM_TOKEN`: the token of your Telegram bot
 #### Production-only values
 - `ACME_EMAIL`: the email linked to your certificate for HTTPS
 - `BACKEND_HOST`: the subdomain where your users will access your API (e.g "api.mydomain.com")

--- a/poetry.lock
+++ b/poetry.lock
@@ -618,13 +618,13 @@ files = [
 
 [[package]]
 name = "httpcore"
-version = "0.18.0"
+version = "0.17.3"
 description = "A minimal low-level HTTP client."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "httpcore-0.18.0-py3-none-any.whl", hash = "sha256:adc5398ee0a476567bf87467063ee63584a8bce86078bf748e48754f60202ced"},
-    {file = "httpcore-0.18.0.tar.gz", hash = "sha256:13b5e5cd1dca1a6636a6aaea212b19f4f85cd88c366a2b82304181b769aab3c9"},
+    {file = "httpcore-0.17.3-py3-none-any.whl", hash = "sha256:c2789b767ddddfa2a5782e3199b2b7f6894540b17b16ec26b2c4d8e103510b87"},
+    {file = "httpcore-0.17.3.tar.gz", hash = "sha256:a6f30213335e34c1ade7be6ec7c47f19f50c56db36abef1a9dfa3815b1cb3888"},
 ]
 
 [package.dependencies]
@@ -639,18 +639,18 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "httpx"
-version = "0.25.0"
+version = "0.24.1"
 description = "The next generation HTTP client."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "httpx-0.25.0-py3-none-any.whl", hash = "sha256:181ea7f8ba3a82578be86ef4171554dd45fec26a02556a744db029a0a27b7100"},
-    {file = "httpx-0.25.0.tar.gz", hash = "sha256:47ecda285389cb32bb2691cc6e069e3ab0205956f681c5b2ad2325719751d875"},
+    {file = "httpx-0.24.1-py3-none-any.whl", hash = "sha256:06781eb9ac53cde990577af654bd990a4949de37a28bdb4a230d434f3a30b9bd"},
+    {file = "httpx-0.24.1.tar.gz", hash = "sha256:5853a43053df830c20f8110c5e69fe44d035d850b2dfe795e196f00fdb774bdd"},
 ]
 
 [package.dependencies]
 certifi = "*"
-httpcore = ">=0.18.0,<0.19.0"
+httpcore = ">=0.15.0,<0.18.0"
 idna = "*"
 sniffio = "*"
 
@@ -1862,4 +1862,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "0e7af23ffb795de65d9c1a5a8559278d0eb20e7ddb362dd9bd3480ca4dd57f44"
+content-hash = "0169348499d2357bf0b5effb8f8001d93f0657ec17bd7e446e3d0883a34f89ff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ prometheus-fastapi-instrumentator = "^6.1.0"
 python-multipart = "==0.0.7"
 python-magic = "^0.4.17"
 boto3 = "^1.26.0"
+httpx = "^0.24.0"
 
 [tool.poetry.group.quality]
 optional = true

--- a/scripts/dbdiagram.txt
+++ b/scripts/dbdiagram.txt
@@ -8,8 +8,8 @@ Table "User" as U {
   "id" int [not null]
   "organization_id" int [ref: > O.id, not null]
   "role" userrole [not null]
-  "login" text [not null]
-  "hashed_password" text [not null]
+  "login" varchar [not null]
+  "hashed_password" varchar [not null]
   "created_at" timestamp [not null]
   Indexes {
     (id, login) [pk]
@@ -19,7 +19,7 @@ Table "User" as U {
 Table "Camera" as C {
   "id" int [not null]
   "organization_id" int [ref: > O.id, not null]
-  "name" text [not null]
+  "name" varchar [not null]
   "angle_of_view" float [not null]
   "elevation" float [not null]
   "lat" float [not null]
@@ -27,7 +27,7 @@ Table "Camera" as C {
   "is_trustable" bool [not null]
   "created_at" timestamp [not null]
   "last_active_at" timestamp
-  "last_image" text
+  "last_image" varchar
   Indexes {
     (id) [pk]
   }
@@ -37,8 +37,8 @@ Table "Detection" as D {
   "id" int [not null]
   "camera_id" int [ref: > C.id, not null]
   "azimuth" float [not null]
-  "bucket_key" text [not null]
-  "bboxes" text [not null]
+  "bucket_key" varchar [not null]
+  "bboxes" varchar [not null]
   "is_wildfire" bool
   "created_at" timestamp [not null]
   "updated_at" timestamp [not null]
@@ -49,7 +49,8 @@ Table "Detection" as D {
 
 Table "Organization" as O {
   "id" int [not null]
-  "name" text [not null]
+  "name" varchar [not null]
+  "telegram_id" varchar
   Indexes {
     (id) [pk]
   }
@@ -58,7 +59,7 @@ Table "Organization" as O {
 
 Table "Webhook" as W {
   "id" int [not null]
-  "url" text [not null]
+  "url" varchar [not null]
   Indexes {
     (id) [pk]
   }

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -20,10 +20,17 @@ from fastapi import (
     status,
 )
 
-from app.api.dependencies import dispatch_webhook, get_camera_crud, get_detection_crud, get_jwt, get_webhook_crud
+from app.api.dependencies import (
+    dispatch_webhook,
+    get_camera_crud,
+    get_detection_crud,
+    get_jwt,
+    get_organization_crud,
+    get_webhook_crud,
+)
 from app.core.config import settings
-from app.crud import CameraCRUD, DetectionCRUD, WebhookCRUD
-from app.models import Camera, Detection, Role, UserRole
+from app.crud import CameraCRUD, DetectionCRUD, OrganizationCRUD, WebhookCRUD
+from app.models import Camera, Detection, Organization, Role, UserRole
 from app.schemas.detections import (
     BOXES_PATTERN,
     COMPILED_BOXES_PATTERN,
@@ -34,6 +41,7 @@ from app.schemas.detections import (
 )
 from app.schemas.login import TokenPayload
 from app.services.storage import s3_service, upload_file
+from app.services.telegram import telegram_client
 from app.services.telemetry import telemetry_client
 
 router = APIRouter()
@@ -53,6 +61,7 @@ async def create_detection(
     file: UploadFile = File(..., alias="file"),
     detections: DetectionCRUD = Depends(get_detection_crud),
     webhooks: WebhookCRUD = Depends(get_webhook_crud),
+    organizations: OrganizationCRUD = Depends(get_organization_crud),
     token_payload: TokenPayload = Security(get_jwt, scopes=[Role.CAMERA]),
 ) -> Detection:
     telemetry_client.capture(f"camera|{token_payload.sub}", event="detections-create")
@@ -74,6 +83,11 @@ async def create_detection(
     if any(whs):
         for webhook in await webhooks.fetch_all():
             background_tasks.add_task(dispatch_webhook, webhook.url, det)
+    # Telegram notifications
+    if telegram_client.is_enabled:
+        org = cast(Organization, await organizations.get(token_payload.organization_id, strict=True))
+        if org.telegram_id:
+            background_tasks.add_task(telegram_client.notify, org.telegram_id, det.model_dump_json())
     return det
 
 

--- a/src/app/api/api_v1/endpoints/organizations.py
+++ b/src/app/api/api_v1/endpoints/organizations.py
@@ -12,8 +12,9 @@ from app.api.dependencies import get_jwt, get_organization_crud
 from app.crud import OrganizationCRUD
 from app.models import Organization, UserRole
 from app.schemas.login import TokenPayload
-from app.schemas.organizations import OrganizationCreate
+from app.schemas.organizations import OrganizationCreate, TelegramChannelId
 from app.services.storage import s3_service
+from app.services.telegram import telegram_client
 from app.services.telemetry import telemetry_client
 
 router = APIRouter()
@@ -73,3 +74,21 @@ async def delete_organization(
     if not (await s3_service.delete_bucket(bucket_name)):
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create bucket")
     await organizations.delete(organization_id)
+
+
+@router.patch(
+    "/{organization_id}", status_code=status.HTTP_200_OK, summary="Update telegram channel ID of an organization"
+)
+async def update_telegram_id(
+    payload: TelegramChannelId,
+    organization_id: int = Path(..., gt=0),
+    organizations: OrganizationCRUD = Depends(get_organization_crud),
+    token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN]),
+) -> Organization:
+    telemetry_client.capture(
+        token_payload.sub, event="organizations-update-telegram-id", properties={"organization_id": organization_id}
+    )
+    # Check if the telegram channel ID is valid
+    if payload.telegram_id and not telegram_client.has_channel_access(payload.telegram_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unable to access Telegram channel")
+    return await organizations.update(organization_id, payload)

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -58,6 +58,9 @@ class Settings(BaseSettings):
     S3_PROXY_URL: str = os.environ.get("S3_PROXY_URL", "")
     S3_URL_EXPIRATION: int = int(os.environ.get("S3_URL_EXPIRATION") or 24 * 3600)
 
+    # Notifications
+    TELEGRAM_TOKEN: Union[str, None] = os.environ.get("TELEGRAM_TOKEN")
+
     # Error monitoring
     SENTRY_DSN: Union[str, None] = os.environ.get("SENTRY_DSN")
     SERVER_NAME: str = os.environ.get("SERVER_NAME", socket.gethostname())

--- a/src/app/crud/crud_organization.py
+++ b/src/app/crud/crud_organization.py
@@ -7,11 +7,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.crud.base import BaseCRUD
 from app.models import Organization
-from app.schemas.organizations import OrganizationCreate, OrganizationUpdate
+from app.schemas.organizations import OrganizationCreate, TelegramChannelId
 
 __all__ = ["OrganizationCRUD"]
 
 
-class OrganizationCRUD(BaseCRUD[Organization, OrganizationCreate, OrganizationUpdate]):
+class OrganizationCRUD(BaseCRUD[Organization, OrganizationCreate, TelegramChannelId]):
     def __init__(self, session: AsyncSession) -> None:
         super().__init__(session, Organization)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -69,7 +69,7 @@ class Organization(SQLModel, table=True):
     __tablename__ = "organizations"
     id: int = Field(None, primary_key=True)
     name: str = Field(..., min_length=5, max_length=100, nullable=False, unique=True)
-    telegram_id: Union[str, None] = Field(None, pattern=r"^@[a-zA-Z0-9_-]+$", nullable=True)
+    telegram_id: Union[str, None] = Field(None, nullable=True)
 
 
 class Webhook(SQLModel, table=True):

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -69,6 +69,7 @@ class Organization(SQLModel, table=True):
     __tablename__ = "organizations"
     id: int = Field(None, primary_key=True)
     name: str = Field(..., min_length=5, max_length=100, nullable=False, unique=True)
+    telegram_id: Union[str, None] = Field(None, pattern=r"^@[a-zA-Z0-9_-]+$", nullable=True)
 
 
 class Webhook(SQLModel, table=True):

--- a/src/app/schemas/organizations.py
+++ b/src/app/schemas/organizations.py
@@ -3,6 +3,8 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
+from typing import Union
+
 from pydantic import BaseModel, Field
 
 __all__ = ["OrganizationCreate", "OrganizationUpdate"]
@@ -26,3 +28,7 @@ class OrganizationUpdate(BaseModel):
         description="name of the organization",
         json_schema_extra={"examples": ["pyro-org-01"]},
     )
+
+
+class TelegramChannelId(BaseModel):
+    telegram_id: Union[str, None] = Field(None, pattern=r"^@[a-zA-Z0-9_-]+$")

--- a/src/app/services/telegram.py
+++ b/src/app/services/telegram.py
@@ -32,6 +32,8 @@ class TelegramClient:
             logger.info("Telegram notifications enabled")
 
     def has_channel_access(self, channel_id: str) -> bool:
+        if not self.is_enabled:
+            raise AssertionError("Telegram notifications are not enabled")
         response = requests.get(
             f"{self.BASE_URL.format(token=self.token)}/getChat",
             json={"chat_id": channel_id},
@@ -40,6 +42,8 @@ class TelegramClient:
         return response.status_code == 200
 
     def notify(self, channel_id: str, message: str) -> requests.Response:
+        if not self.is_enabled:
+            raise AssertionError("Telegram notifications are not enabled")
         response = requests.post(
             f"{self.BASE_URL.format(token=self.token)}/sendMessage",
             json={"chat_id": channel_id, "text": message},

--- a/src/app/services/telegram.py
+++ b/src/app/services/telegram.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2024, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+import logging
+from typing import Union
+
+import requests
+
+from app.core.config import settings
+
+logger = logging.getLogger("uvicorn.error")
+
+__all__ = ["telegram_client"]
+
+
+class TelegramClient:
+    BASE_URL = "https://api.telegram.org/bot{token}"
+
+    def __init__(self, token: Union[str, None] = None) -> None:
+        self.is_enabled = isinstance(token, str)
+        if isinstance(token, str):
+            self.token = token
+            # Validate token
+            response = requests.get(
+                f"{self.BASE_URL.format(token=self.token)}/getMe",
+                timeout=1,
+            )
+            if response.status_code != 200:
+                raise ValueError(f"Invalid Telegram Bot token: {response.text}")
+            logger.info("Telegram notifications enabled")
+
+    def has_channel_access(self, channel_id: str) -> bool:
+        response = requests.get(
+            f"{self.BASE_URL.format(token=self.token)}/getChat",
+            json={"chat_id": channel_id},
+            timeout=1,
+        )
+        return response.status_code == 200
+
+    def notify(self, channel_id: str, message: str) -> requests.Response:
+        response = requests.post(
+            f"{self.BASE_URL.format(token=self.token)}/sendMessage",
+            json={"chat_id": channel_id, "text": message},
+            timeout=2,
+        )
+        if response.status_code != 200:
+            logger.error(f"Failed to send message to Telegram: {response.text}")
+
+        return response
+
+
+telegram_client = TelegramClient(token=settings.TELEGRAM_TOKEN)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -53,10 +53,12 @@ ORGANIZATION_TABLE = [
     {
         "id": 1,
         "name": "organization-1",
+        "telegram_id": None,
     },
     {
         "id": 2,
         "name": "organization-2",
+        "telegram_id": None,
     },
 ]
 

--- a/src/tests/endpoints/test_organizations.py
+++ b/src/tests/endpoints/test_organizations.py
@@ -56,7 +56,7 @@ async def test_create_organization(
         assert response.json()["detail"] == status_detail
     if response.status_code // 100 == 2:
         assert {
-            k: v for k, v in response.json().items() if k not in {"id", "created_at", "last_active_at", "is_trustable"}
+            k: v for k, v in response.json().items() if k not in {"id", "telegram_id"}
         } == payload
 
 

--- a/src/tests/endpoints/test_organizations.py
+++ b/src/tests/endpoints/test_organizations.py
@@ -55,9 +55,7 @@ async def test_create_organization(
     if isinstance(status_detail, str):
         assert response.json()["detail"] == status_detail
     if response.status_code // 100 == 2:
-        assert {
-            k: v for k, v in response.json().items() if k not in {"id", "telegram_id"}
-        } == payload
+        assert {k: v for k, v in response.json().items() if k not in {"id", "telegram_id"}} == payload
 
 
 @pytest.mark.parametrize(

--- a/src/tests/services/test_telegram.py
+++ b/src/tests/services/test_telegram.py
@@ -1,0 +1,18 @@
+import pytest
+
+from app.core.config import settings
+from app.services.telegram import TelegramClient
+
+
+def test_telegram_client():
+    with pytest.raises(ValueError, match="Invalid Telegram Bot token"):
+        TelegramClient("invalid-token")
+
+    client = TelegramClient(None)
+    assert not client.is_enabled
+
+    client = TelegramClient(settings.TELEGRAM_TOKEN)
+    assert client.is_enabled
+
+    assert not client.has_channel_access("invalid-channel-id")
+    assert client.notify("invalid-channel-id", "test").status_code == 404

--- a/src/tests/services/test_telegram.py
+++ b/src/tests/services/test_telegram.py
@@ -14,5 +14,11 @@ def test_telegram_client():
     client = TelegramClient(settings.TELEGRAM_TOKEN)
     assert client.is_enabled == isinstance(settings.TELEGRAM_TOKEN, str)
 
-    assert not client.has_channel_access("invalid-channel-id")
-    assert client.notify("invalid-channel-id", "test").status_code == 404
+    if isinstance(settings.TELEGRAM_TOKEN, str):
+        assert not client.has_channel_access("invalid-channel-id")
+        assert client.notify("invalid-channel-id", "test").status_code == 404
+    else:
+        with pytest.raises(AssertionError, match="Telegram notifications are not enabled"):
+            client.has_channel_access("invalid-channel-id")
+        with pytest.raises(AssertionError, match="Telegram notifications are not enabled"):
+            client.notify("invalid-channel-id", "test")

--- a/src/tests/services/test_telegram.py
+++ b/src/tests/services/test_telegram.py
@@ -12,7 +12,7 @@ def test_telegram_client():
     assert not client.is_enabled
 
     client = TelegramClient(settings.TELEGRAM_TOKEN)
-    assert client.is_enabled
+    assert client.is_enabled == isinstance(settings.TELEGRAM_TOKEN, str)
 
     assert not client.has_channel_access("invalid-channel-id")
     assert client.notify("invalid-channel-id", "test").status_code == 404


### PR DESCRIPTION
This PR is greatly inspired from #272 by @blenzi 🙏 
It introduces the following modifications:
- add Telegram as a service + test cases (verifying token, channel access, etc.)
- add the possibility for each org to have a dedicated telegram channel ID (created by human admins, where the bot has to be invited)
- when a detection is created, on top of webhooks, we send the detection payload to the channel (unformatted for now)


Here is the updated DB schema: https://dbdiagram.io/d/Pyronear-DB-671e1b9897a66db9a3673d76

cc @MateoLostanlen 
