### PR TITLE
Fix redirect error when calling cameras/

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -24,7 +24,7 @@ ROUTES: Dict[str, str] = {
     #################
     "cameras-heartbeat": "/cameras/heartbeat",
     "cameras-image": "/cameras/image",
-    "cameras-fetch": "/cameras",
+    "cameras-fetch": "/cameras/",
     #################
     # DETECTIONS
     #################


### PR DESCRIPTION
Without  this "/" there was a redirection to the port 80 (which was causing an error since it's not proxied)

According to this : https://github.com/fastapi/fastapi/discussions/9328
There is surely a proper solution if the HTTP headers are set up correctly, but I didn't succeed

