### PR TITLE
build(docker): update CI and docker to pythono 3.11 using uv

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -6,21 +6,24 @@ on:
   pull_request:
     branches: main
 
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "0.5.13"
+  POETRY_VERSION: "1.8.3"
+
+
 jobs:
   docker:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.8.2"
+          poetry-version: ${{ env.POETRY_VERSION }}
       - name: Resolve dependencies
         run: poetry export -f requirements.txt --without-hashes --output requirements.txt
       - name: Build, run & check docker
@@ -56,9 +59,10 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
       - name: Install project
         run: |
-          python -m pip install --upgrade uv
           uv pip install --system -e client/.
-      - name: Import package
-        run: python -c "import pyroclient; print(pyroclient.__version__)"
+          python -c "import pyroclient; print(pyroclient.__version__)"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,25 +3,25 @@ on:
   push:
     branches: main
 
+env:
+  UV_VERSION: "0.5.13"
+
 jobs:
   gh-pages:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python: [3.9]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.9
           architecture: x64
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade uv
-          uv pip install --system -e "client/.[docs]"
+        run: uv pip install --system -e "client/.[docs]"
 
       - name: Build documentation
         run: sphinx-build client/docs/source client/docs/build -a -v
@@ -37,8 +37,7 @@ jobs:
       - name: Deploy to Github Pages
         uses: JamesIves/github-pages-deploy-action@v4.7.2
         with:
-          BRANCH: gh-pages
-          FOLDER: 'client/docs/build'
-          COMMIT_MESSAGE: '[skip ci] Documentation updates'
-          CLEAN: true
-          SSH: true
+          branch: gh-pages
+          folder: 'client/docs/build'
+          commit-message: '[skip ci] Documentation updates'
+          clean: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [ published ]
 
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "0.5.13"
+
 jobs:
   pypi:
     if: "!github.event.release.prerelease"
@@ -12,12 +16,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade uv
-          uv pip install --system setuptools wheel twine --upgrade
+        run: uv pip install --system setuptools wheel twine --upgrade
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
@@ -42,9 +47,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
       - name: Install package
         run: |
-          python -m pip install --upgrade uv
           uv pip install --system pyroclient
           python -c "import pyroclient; print(pyroclient.__version__)"
 
@@ -57,7 +64,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         shell: bash -el {0}
         run: conda install -y conda-build conda-verify anaconda-client

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -4,25 +4,25 @@ on:
   pull_request:
     branches: main
 
+env:
+  UV_VERSION: "0.5.13"
+
 jobs:
   docs-client:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python: [3.9]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.9
           architecture: x64
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade uv
-          uv pip install --system -e "client/.[docs]"
+        run: uv pip install --system -e "client/.[docs]"
 
       - name: Build documentation
         run: sphinx-build client/docs/source client/docs/build -a -v

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,6 +6,8 @@ on:
 env:
   BACKEND_IMAGE_NAME: alert-api
   DOCKERHUB_USER: ${{ secrets.DOCKERHUB_LOGIN }}
+  PYTHON_VERSION: "3.11"
+  POETRY_VERSION: "1.8.3"
 
 jobs:
   docker:
@@ -14,11 +16,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.8.2"
+          poetry-version: ${{ env.POETRY_VERSION }}
       - name: Resolve dependencies
         run: poetry export -f requirements.txt --without-hashes --output requirements.txt
       - name: Build docker

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -6,27 +6,29 @@ on:
   pull_request:
     branches: main
 
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "0.5.13"
+  POETRY_VERSION: "1.8.3"
+
 jobs:
   end-to-end:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python: [3.9]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.8.2"
+          poetry-version: ${{ env.POETRY_VERSION }}
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
       - name: Resolve dependencies
         run: |
           poetry export -f requirements.txt --without-hashes --output requirements.txt
-          python -m pip install --upgrade uv
           uv pip install --system -r scripts/requirements.txt
       - name: Run the backend & the test
         env:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
       - name: Install dependencies
-        run: uv pip install -e "client/.[quality]" --upgrade
+        run: uv pip install --system -e "client/.[quality]"
       - name: Run mypy
         run: |
           mypy --version

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,53 +6,53 @@ on:
   pull_request:
     branches: main
 
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "0.5.13"
+  POETRY_VERSION: "1.8.3"
+
 jobs:
   ruff:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python: [3.9]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.8.2"
-      - name: Resolve dependencies
-        run: poetry export -f requirements.txt --without-hashes --only quality --output requirements.txt
+          poetry-version: ${{ env.POETRY_VERSION }}
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade uv
+          poetry export -f requirements.txt --without-hashes --only quality --output requirements.txt
           uv pip install --system -r requirements.txt
       - name: Run ruff
         run: |
           ruff --version
+          ruff format --check --diff .
           ruff check --diff .
 
   mypy:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python: [3.9]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.8.2"
-      - name: Resolve dependencies
-        run: poetry export -f requirements.txt --without-hashes --with quality --output requirements.txt
+          poetry-version: ${{ env.POETRY_VERSION }}
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade uv
+          poetry export -f requirements.txt --without-hashes --with quality --output requirements.txt
           uv pip install --system -r requirements.txt
       - name: Run mypy
         run: |
@@ -60,79 +60,40 @@ jobs:
           mypy
 
   mypy-client:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python: [3.9]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('client/pyproject.toml') }}
+          version: ${{ env.UV_VERSION }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e client/. --upgrade
-          pip install "mypy==1.4.1"
+        run: uv pip install -e "client/.[quality]" --upgrade
       - name: Run mypy
         run: |
           mypy --version
           cd client && mypy
 
-  ruff-format:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python: [3.9]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-          architecture: x64
-      - uses: abatilo/actions-poetry@v3
-        with:
-          poetry-version: "1.8.2"
-      - name: Resolve dependencies
-        run: poetry export -f requirements.txt --without-hashes --only quality --output requirements.txt
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade uv
-          uv pip install --system -r requirements.txt
-      - name: Run ruff
-        run: |
-          ruff --version
-          ruff format --check --diff .
-
   precommit-hooks:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python: [3.9]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.8.2"
-      - name: Resolve dependencies
-        run: poetry export -f requirements.txt --without-hashes --only quality --output requirements.txt
+          poetry-version: ${{ env.POETRY_VERSION }}
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade uv
+          poetry export -f requirements.txt --without-hashes --only quality --output requirements.txt
           uv pip install --system -r requirements.txt
       - name: Run pre-commit hooks
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: main
 
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "0.5.13"
+  POETRY_VERSION: "1.8.3"
+
 jobs:
   pytest:
     runs-on: ubuntu-latest
@@ -13,10 +18,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: x64
       - uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.8.2"
+          poetry-version: ${{ env.POETRY_VERSION }}
       - name: Resolve dependencies
         run: poetry export -f requirements.txt --without-hashes --with test --output requirements.txt
       - name: Run the backend & the test
@@ -39,24 +45,22 @@ jobs:
           fail_ci_if_error: true
 
   pytest-client:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python: [3.9]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.8.2"
+          poetry-version: ${{ env.POETRY_VERSION }}
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
       - name: Resolve dependencies
         run: |
           poetry export -f requirements.txt --without-hashes --output requirements.txt
-          python -m pip install --upgrade uv
           uv pip install --system -e "client/.[test]"
       - name: Run the backend & the test
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.9
+    python: python3.11
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -57,7 +57,6 @@ files = [
 ]
 
 [package.dependencies]
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
 
@@ -190,10 +189,7 @@ files = [
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = [
-    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
-    {version = ">=1.25.4,<2.1", markers = "python_version >= \"3.10\""},
-]
+urllib3 = {version = ">=1.25.4,<2.1", markers = "python_version >= \"3.10\""}
 
 [package.extras]
 crt = ["awscrt (==0.16.26)"]
@@ -469,9 +465,6 @@ files = [
     {file = "coverage-7.3.2.tar.gz", hash = "sha256:be32ad29341b0170e795ca590e1c07e81fc061cb5b10c74ce7203491484404ef"},
 ]
 
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
-
 [package.extras]
 toml = ["tomli"]
 
@@ -485,20 +478,6 @@ files = [
     {file = "distlib-0.3.7-py2.py3-none-any.whl", hash = "sha256:2e24928bc811348f0feb63014e97aaae3037f2cf48712d51ae61df7fd6075057"},
     {file = "distlib-0.3.7.tar.gz", hash = "sha256:9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8"},
 ]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.1.3"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
-    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
@@ -879,7 +858,6 @@ files = [
 
 [package.dependencies]
 mypy-extensions = ">=1.0.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=4.1.0"
 
 [package.extras]
@@ -1255,11 +1233,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -1730,21 +1706,9 @@ files = [
 
 [package.dependencies]
 anyio = ">=3.4.0,<5"
-typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
-
-[[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
 
 [[package]]
 name = "types-passlib"
@@ -1834,7 +1798,6 @@ files = [
 [package.dependencies]
 click = ">=7.0"
 h11 = ">=0.8"
-typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
@@ -1861,5 +1824,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "04852c90b733a4c3e3426b6e0926c01e5e1e6c3aaa6b31195adc60fc9d74a3f1"
+python-versions = "^3.11"
+content-hash = "9e4fc8e4a6358ba8ba7bac9e88498d9033da73683e17b94132b038d18b55bd45"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = ["Pyronear <contact@pyronear.org>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.11"
 fastapi = ">=0.109.1,<1.0.0"
 sqlmodel = "^0.0.16"
 pydantic = ">=2.0.0,<3.0.0"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,21 +1,26 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9-alpine3.14
+FROM python:3.11-slim
 
 WORKDIR /app
 
 # set environment variables
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONPATH "${PYTHONPATH}:/app"
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH="/app"
+
+# Install curl
+RUN apt-get -y update \
+    && apt-get -y install curl libmagic1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+# Ref: https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
+COPY --from=ghcr.io/astral-sh/uv:0.5.13 /uv /bin/uv
 
 # copy requirements file
-COPY requirements.txt /app/requirements.txt
-
+COPY requirements.txt /tmp/requirements.txt
 # install dependencies
-RUN set -eux \
-    && apk add --no-cache curl libmagic \
-    && pip install --no-cache-dir uv \
-    && uv pip install --no-cache --system -r /app/requirements.txt \
-    && rm -rf /root/.cache
+RUN uv pip install --no-cache --system -r /tmp/requirements.txt
 
 # copy project
 COPY src/alembic.ini /app/alembic.ini


### PR DESCRIPTION
This PR introduces the following modifications:
- update Dockerfile and CI to use python3.11 (faster execution)
- use uv instead of pip everywhere it's possible (dependency installation is considerably faster with that)
- use env variable for easier CI workflow version bump