### PR TITLE
fix(detections): allow azimuth=0 for the detection table

### DIFF
--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -62,7 +62,7 @@ async def create_detection(
         min_length=2,
         max_length=settings.MAX_BBOX_STR_LENGTH,
     ),
-    azimuth: float = Form(..., gt=0, lt=360, description="angle between north and direction in degrees"),
+    azimuth: float = Form(..., ge=0, lt=360, description="angle between north and direction in degrees"),
     file: UploadFile = File(..., alias="file"),
     detections: DetectionCRUD = Depends(get_detection_crud),
     webhooks: WebhookCRUD = Depends(get_webhook_crud),

--- a/src/app/schemas/detections.py
+++ b/src/app/schemas/detections.py
@@ -20,7 +20,7 @@ class DetectionLabel(BaseModel):
 class Azimuth(BaseModel):
     azimuth: float = Field(
         ...,
-        gt=0,
+        ge=0,
         lt=360,
         description="angle between north and direction in degrees",
         json_schema_extra={"examples": [110]},

--- a/src/tests/endpoints/test_detections.py
+++ b/src/tests/endpoints/test_detections.py
@@ -17,7 +17,9 @@ from sqlmodel.ext.asyncio.session import AsyncSession
         (None, 0, {"azimuth": 45.6, "bboxes": []}, 422, None),
         (None, 1, {"azimuth": 45.6, "bboxes": (0.6, 0.6, 0.6, 0.6, 0.6)}, 422, None),
         (None, 1, {"azimuth": 45.6, "bboxes": "[(0.6, 0.6, 0.6, 0.6, 0.6)]"}, 422, None),
+        (None, 1, {"azimuth": 360, "bboxes": "[(0.6,0.6,0.7,0.7,0.6)]"}, 422, None),
         (None, 1, {"azimuth": 45.6, "bboxes": "[(0.6,0.6,0.7,0.7,0.6)]"}, 201, None),
+        (None, 1, {"azimuth": 0, "bboxes": "[(0.6,0.6,0.7,0.7,0.6)]"}, 201, None),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
I couldn't rebase properly #399 so I went minimal with this one. This updates the lower bound constraint on azimuth value and add a test case

close #395