### PR TITLE
feat(detections): restrict webhook and telegram to sequence creation

### DIFF
--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -120,20 +120,20 @@ async def create_detection(
                 )
             )
             # Update the detection with the sequence ID
-            await detections.update(det.id, DetectionSequence(sequence_id=sequence_.id))
+            det = await detections.update(det.id, DetectionSequence(sequence_id=sequence_.id))
             for det_ in dets_:
                 await detections.update(det_.id, DetectionSequence(sequence_id=sequence_.id))
 
-    # Webhooks
-    whs = await webhooks.fetch_all()
-    if any(whs):
-        for webhook in await webhooks.fetch_all():
-            background_tasks.add_task(dispatch_webhook, webhook.url, det)
-    # Telegram notifications
-    if telegram_client.is_enabled:
-        org = cast(Organization, await organizations.get(token_payload.organization_id, strict=True))
-        if org.telegram_id:
-            background_tasks.add_task(telegram_client.notify, org.telegram_id, det.model_dump_json())
+            # Webhooks
+            whs = await webhooks.fetch_all()
+            if any(whs):
+                for webhook in await webhooks.fetch_all():
+                    background_tasks.add_task(dispatch_webhook, webhook.url, det)
+            # Telegram notifications
+            if telegram_client.is_enabled:
+                org = cast(Organization, await organizations.get(token_payload.organization_id, strict=True))
+                if org.telegram_id:
+                    background_tasks.add_task(telegram_client.notify, org.telegram_id, det.model_dump_json())
     return det
 
 


### PR DESCRIPTION
As mentioned in #413, I think the webhook trigger and Telegram notifications should only be considered when a sequence is created (several detections in a row from the same camera and azimuth) vs. when a detection is created (more prone to false positives and noise).

This PR moves both to sequence creation