### PR TITLE
refactor(api): enforce fetch results to be ordered by ID

### DIFF
--- a/src/app/api/api_v1/endpoints/cameras.py
+++ b/src/app/api/api_v1/endpoints/cameras.py
@@ -52,7 +52,7 @@ async def fetch_cameras(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[Camera]:
     telemetry_client.capture(token_payload.sub, event="cameras-fetch")
-    all_cameras = [elt for elt in await cameras.fetch_all()]
+    all_cameras = [elt for elt in await cameras.fetch_all(order_by="id")]
     if UserRole.ADMIN in token_payload.scopes:
         return all_cameras
     return [camera for camera in all_cameras if camera.organization_id == token_payload.organization_id]

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -194,7 +194,7 @@ async def fetch_detections(
     cameras_list = await cameras.fetch_all(filters=("organization_id", token_payload.organization_id))
     camera_ids = [camera.id for camera in cameras_list]
 
-    return await detections.fetch_all(in_pair=("camera_id", camera_ids))
+    return await detections.fetch_all(in_pair=("camera_id", camera_ids), order_by="id")
 
 
 @router.delete("/{detection_id}", status_code=status.HTTP_200_OK, summary="Delete a detection")


### PR DESCRIPTION
This PR enforces ordering by ID for fetch commands. This changes the order on the camera fetching and detection fetching routes

Close #425 