### PR TITLE
docs: Updated sequences/unlabeled/latest endpoint summary

### DIFF
--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -79,7 +79,7 @@ async def fetch_sequence_detections(
     ]
 
 
-@router.get("/unlabeled/latest", status_code=status.HTTP_200_OK, summary="Fetch all the latest sequences")
+@router.get("/unlabeled/latest", status_code=status.HTTP_200_OK, summary="Fetch all the unlabeled sequences from the last 24 hours")
 async def fetch_latest_unlabeled_sequences(
     session: AsyncSession = Depends(get_session),
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),


### PR DESCRIPTION
Hi there, 

Small suggestion for the summary of the endpoint `sequences/unlabeled/latest`. 
The actual summary is a bit ambiguous to me as the term `unlabeled` does not appear (albeit it is present in the endpoint name) & there is no explanation of what is meant by `latest`

Hence, this small PR introduces a more explicit formulation : "Fetch all the unlabeled sequences from the last 24 hours".
If we do not want to explicit latest, this formulation could be ok : "Fetch all the latest unlabeled sequences"

What do you think ? 
Happy to discuss it ! 
