### PR TITLE
docs: Updated fromdate desc

### DIFF
--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -105,7 +105,7 @@ async def fetch_latest_unlabeled_sequences(
     return [Sequence(**elt.__dict__) for elt in fetched_sequences.all()]
 
 
-@router.get("/all/fromdate", status_code=status.HTTP_200_OK, summary="Fetch all the sequences from a specific date")
+@router.get("/all/fromdate", status_code=status.HTTP_200_OK, summary="Fetch all the sequences for a specific date")
 async def fetch_sequences_from_date(
     from_date: date = Query(),
     limit: Union[int, None] = Query(15, description="Maximum number of sequences to fetch"),


### PR DESCRIPTION
Hi there, 

Small PR to update doc of sequences fromdate

## Context

In https://github.com/pyronear/pyro-api/blob/bdceda16852d3df43e03cdcbbd8d3a045842eb28/src/app/api/api_v1/endpoints/sequences.py#L109

In my understanding "Fetch all the sequences **from** a specific date" implies obtaining all sequences from that date to the present day, while the code (and the code does what we want) returns sequences that occurred on a specific date. 

Hence, this PR introduces updates of endpoint summary for greater clarity.

## Question
Perhaps this opens up a wider need to change the endpoint name for greater clarity (meaning to update the endpoint, the .client, etc.) ?
-> At this stage, as far as I know, only the history feature on the platform under development uses this endpoint. 

Happy to discuss it ! =) 