### PR TITLE
feat(cameras): add PATCH route to edit camera location

### DIFF
--- a/src/app/crud/crud_camera.py
+++ b/src/app/crud/crud_camera.py
@@ -7,11 +7,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.crud.base import BaseCRUD
 from app.models import Camera
-from app.schemas.cameras import CameraCreate, LastActive
+from app.schemas.cameras import CameraCreate, CameraEdit, LastActive
 
 __all__ = ["CameraCRUD"]
 
 
-class CameraCRUD(BaseCRUD[Camera, CameraCreate, LastActive]):
+class CameraCRUD(BaseCRUD[Camera, CameraCreate, LastActive | CameraEdit]):
     def __init__(self, session: AsyncSession) -> None:
         super().__init__(session, Camera)

--- a/src/app/schemas/cameras.py
+++ b/src/app/schemas/cameras.py
@@ -21,7 +21,19 @@ class LastImage(LastActive):
     last_image: str
 
 
-class CameraCreate(BaseModel):
+class CameraEdit(BaseModel):
+    elevation: float = Field(
+        ...,
+        gt=0,
+        lt=10000,
+        description="number of meters from sea level",
+        json_schema_extra={"examples": [1582]},
+    )
+    lat: float = Field(..., gt=-90, lt=90, description="latitude", json_schema_extra={"examples": [44.765181]})
+    lon: float = Field(..., gt=-180, lt=180, description="longitude", json_schema_extra={"examples": [4.514880]})
+
+
+class CameraCreate(CameraEdit):
     organization_id: int = Field(..., gt=0)
     name: str = Field(
         ...,
@@ -37,13 +49,4 @@ class CameraCreate(BaseModel):
         description="angle between left and right camera view",
         json_schema_extra={"examples": [120.0]},
     )
-    elevation: float = Field(
-        ...,
-        gt=0,
-        lt=10000,
-        description="number of meters from sea level",
-        json_schema_extra={"examples": [1582]},
-    )
-    lat: float = Field(..., gt=-90, lt=90, description="latitude", json_schema_extra={"examples": [44.765181]})
-    lon: float = Field(..., gt=-180, lt=180, description="longitude", json_schema_extra={"examples": [4.514880]})
     is_trustable: bool = Field(True, description="whether the detection from this camera can be trusted")

--- a/src/tests/endpoints/test_cameras.py
+++ b/src/tests/endpoints/test_cameras.py
@@ -327,10 +327,11 @@ async def test_update_image(
 
 
 @pytest.mark.parametrize(
-    ("user_idx", "payload", "status_code", "status_detail"),
+    ("user_idx", "cam_id", "payload", "status_code", "status_detail"),
     [
         (
             None,
+            1,
             {
                 "elevation": 30.0,
                 "lat": 3.5,
@@ -341,12 +342,36 @@ async def test_update_image(
         ),
         (
             0,
+            1,
             {"elevation": 30.0, "lat": 3.5},
             422,
             None,
         ),
         (
             0,
+            999,
+            {
+                "elevation": 30.0,
+                "lat": 3.5,
+                "lon": 7.8,
+            },
+            404,
+            "Table Camera has no corresponding entry.",
+        ),
+        (
+            0,
+            1,
+            {
+                "elevation": 30.0,
+                "lat": 3.5,
+                "lon": 7.8,
+            },
+            200,
+            None,
+        ),
+        (
+            0,
+            2,
             {
                 "elevation": 30.0,
                 "lat": 3.5,
@@ -357,6 +382,7 @@ async def test_update_image(
         ),
         (
             1,
+            1,
             {
                 "elevation": 30.0,
                 "lat": 3.5,
@@ -366,6 +392,29 @@ async def test_update_image(
             "Incompatible token scope.",
         ),
         (
+            1,
+            2,
+            {
+                "elevation": 30.0,
+                "lat": 3.5,
+                "lon": 7.8,
+            },
+            403,
+            "Incompatible token scope.",
+        ),
+        (
+            2,
+            1,
+            {
+                "elevation": 30.0,
+                "lat": 3.5,
+                "lon": 7.8,
+            },
+            403,
+            "Incompatible token scope.",
+        ),
+        (
+            2,
             2,
             {
                 "elevation": 30.0,

--- a/src/tests/endpoints/test_cameras.py
+++ b/src/tests/endpoints/test_cameras.py
@@ -324,3 +324,80 @@ async def test_update_image(
         assert {k: v for k, v in response.json().items() if k not in {"last_active_at", "last_image"}} == {
             k: v for k, v in pytest.camera_table[cam_idx].items() if k not in {"last_active_at", "last_image"}
         }
+
+
+@pytest.mark.parametrize(
+    ("user_idx", "payload", "status_code", "status_detail"),
+    [
+        (
+            None,
+            {
+                "elevation": 30.0,
+                "lat": 3.5,
+                "lon": 7.8,
+            },
+            401,
+            "Not authenticated",
+        ),
+        (
+            0,
+            {"elevation": 30.0, "lat": 3.5},
+            422,
+            None,
+        ),
+        (
+            0,
+            {
+                "elevation": 30.0,
+                "lat": 3.5,
+                "lon": 7.8,
+            },
+            200,
+            None,
+        ),
+        (
+            1,
+            {
+                "elevation": 30.0,
+                "lat": 3.5,
+                "lon": 7.8,
+            },
+            403,
+            "Incompatible token scope.",
+        ),
+        (
+            2,
+            {
+                "elevation": 30.0,
+                "lat": 3.5,
+                "lon": 7.8,
+            },
+            403,
+            "Incompatible token scope.",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_update_camera_location(
+    async_client: AsyncClient,
+    camera_session: AsyncSession,
+    user_idx: Union[int, None],
+    cam_id: int,
+    payload: Dict[str, Any],
+    status_code: int,
+    status_detail: Union[str, None],
+):
+    auth = None
+    if isinstance(user_idx, int):
+        auth = pytest.get_token(
+            pytest.user_table[user_idx]["id"],
+            pytest.user_table[user_idx]["role"].split(),
+            pytest.user_table[user_idx]["organization_id"],
+        )
+
+    response = await async_client.patch(f"/cameras/{cam_id}/location", json=payload, headers=auth)
+    assert response.status_code == status_code, print(response.__dict__)
+    if isinstance(status_detail, str):
+        assert response.json()["detail"] == status_detail
+    if response.status_code // 100 == 2:
+        assert {k: v for k, v in response.json().items() if k in {"lat", "lon", "elevation"}} == payload


### PR DESCRIPTION
This PR adds `PATCH /cameras/{cam_id}/location` route to edit the lat, lon and elevation of a camera, along with test cases. Please note this isn't adding a client route on purpose, as this is only meant to be used by admins for now

Closes #447