### PR TITLE
feat(cameras): add last image URLs when fetching all cameras

### DIFF
--- a/scripts/test_e2e.py
+++ b/scripts/test_e2e.py
@@ -91,6 +91,24 @@ def main(args):
 
     # Take a picture
     file_bytes = requests.get("https://pyronear.org/img/logo.png", timeout=5).content
+    # Update cam last image
+    response = requests.patch(
+        f"{args.endpoint}/cameras/{cam_id}/image",
+        headers=cam_auth,
+        files={"file": ("logo.png", file_bytes, "image/png")},
+        timeout=5,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["last_image"] is not None
+    assert response.json()["last_image_url"] is not None
+    assert response.json()["last_image_url"].endswith(".png")
+    # Check that URL is displayed when we fetch all cameras
+    response = requests.get(f"{args.endpoint}/cameras", headers=agent_auth, timeout=5)
+    assert response.status_code == 200, response.text
+    assert response.json()[0]["last_image_url"] is not None
+    assert response.json()[0]["last_image_url"].endswith(".png")
+
+    file_bytes = requests.get("https://pyronear.org/img/logo.png", timeout=5).content
     # Create a detection
     response = requests.post(
         f"{args.endpoint}/detections",

--- a/src/app/api/api_v1/endpoints/cameras.py
+++ b/src/app/api/api_v1/endpoints/cameras.py
@@ -3,6 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+import asyncio
 from datetime import datetime
 from typing import List, cast
 
@@ -61,14 +62,34 @@ async def get_camera(
 async def fetch_cameras(
     cameras: CameraCRUD = Depends(get_camera_crud),
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
-) -> List[Camera]:
+) -> List[CameraWithLastImgUrl]:
     telemetry_client.capture(token_payload.sub, event="cameras-fetch")
     if UserRole.ADMIN in token_payload.scopes:
-        return [elt for elt in await cameras.fetch_all(order_by="id")]
-    return [
-        elt
-        for elt in await cameras.fetch_all(order_by="id", filters=("organization_id", token_payload.organization_id))
-    ]
+        cams = [elt for elt in await cameras.fetch_all(order_by="id")]
+
+        async def get_url_for_cam(cam: Camera) -> str | None:  # noqa: RUF029
+            if cam.last_image:
+                bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(cam.organization_id))
+                return bucket.get_public_url(cam.last_image)
+            return None
+
+        urls = await asyncio.gather(*[get_url_for_cam(cam) for cam in cams])
+    else:
+        bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(token_payload.organization_id))
+        cams = [
+            elt
+            for elt in await cameras.fetch_all(
+                order_by="id", filters=("organization_id", token_payload.organization_id)
+            )
+        ]
+
+        async def get_url_for_cam_single_bucket(cam: Camera) -> str | None:  # noqa: RUF029
+            if cam.last_image:
+                return bucket.get_public_url(cam.last_image)
+            return None
+
+        urls = await asyncio.gather(*[get_url_for_cam_single_bucket(cam) for cam in cams])
+    return [CameraWithLastImgUrl(**cam.model_dump(), last_image_url=url) for cam, url in zip(cams, urls)]
 
 
 @router.patch("/heartbeat", status_code=status.HTTP_200_OK, summary="Update last ping of a camera")

--- a/src/tests/endpoints/test_cameras.py
+++ b/src/tests/endpoints/test_cameras.py
@@ -167,7 +167,9 @@ async def test_fetch_cameras(
     if isinstance(status_detail, str):
         assert response.json()["detail"] == status_detail
     if response.status_code // 100 == 2:
-        assert response.json()[0] == expected_response
+        json_response = response.json()
+        assert {k: v for k, v in json_response[0].items() if k != "last_image_url"} == expected_response
+        assert isinstance(json_response[0]["last_image_url"], str) or json_response[0]["last_image_url"] is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR:
- adds "last_image_url" in the response of `GET /api/v1/cameras`
- update the unit tests and the end to end test