### PR TITLE
feat(sequences): add limit and desc params in fetch_sequence_detections

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -278,12 +278,17 @@ class Client:
             timeout=self.timeout,
         )
 
-    def fetch_sequences_detections(self, sequence_id: int) -> Response:
+    def fetch_sequences_detections(self, sequence_id: int, limit: int = 10, desc: bool = True) -> Response:
         """List the detections of a sequence
 
         >>> from pyroclient import client
         >>> api_client = Client("MY_USER_TOKEN")
         >>> response = api_client.fetch_sequences_detections(1)
+
+        Args:
+            sequence_id: ID of the associated sequence entry
+            limit: maximum number of detections to fetch
+            desc: whether to order the detections by created_at in descending order
 
         Returns:
             HTTP response
@@ -291,6 +296,7 @@ class Client:
         return requests.get(
             urljoin(self._route_prefix, ClientRoute.SEQUENCES_FETCH_DETECTIONS.format(seq_id=sequence_id)),
             headers=self.headers,
+            params={"limit": limit, "desc": desc},
             timeout=self.timeout,
         )
 

--- a/scripts/test_e2e.py
+++ b/scripts/test_e2e.py
@@ -159,6 +159,12 @@ def main(args):
     assert dets[0]["id"] == det_id_3
     assert dets[1]["id"] == det_id_2
     assert dets[2]["id"] == detection_id
+    dets = api_request("get", f"{args.endpoint}/sequences/{sequence['id']}/detections?limit=1", agent_auth)
+    assert len(dets) == 1
+    assert dets[0]["id"] == det_id_3
+    dets = api_request("get", f"{args.endpoint}/sequences/{sequence['id']}/detections?limit=1&desc=false", agent_auth)
+    assert len(dets) == 1
+    assert dets[0]["id"] == detection_id
 
     # Cleaning (order is important because of foreign key protection in existing tables)
     api_request("delete", f"{args.endpoint}/detections/{detection_id}/", superuser_auth)

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -103,6 +103,8 @@ async def get_sequence(
 )
 async def fetch_sequence_detections(
     sequence_id: int = Path(..., gt=0),
+    limit: int = Query(10, description="Maximum number of detections to fetch", ge=1, le=100),
+    desc: bool = Query(True, description="Whether to order the detections by created_at in descending order"),
     cameras: CameraCRUD = Depends(get_camera_crud),
     detections: DetectionCRUD = Depends(get_detection_crud),
     sequences: SequenceCRUD = Depends(get_sequence_crud),
@@ -124,8 +126,8 @@ async def fetch_sequence_detections(
         for elt in await detections.fetch_all(
             filters=("sequence_id", sequence_id),
             order_by="created_at",
-            order_desc=True,
-            limit=10,
+            order_desc=desc,
+            limit=limit,
         )
     ]
 


### PR DESCRIPTION
This PR adds new params to the backend endpoint `GET /api/v1/sequences/{sequence_id}/detections` and the corresponding client method:
- limit: change the maximum number of items returned (default 10, min 1, max 100)
- desc: boolean flag specifying whether the result should be ordered by decreasing creation date (default = True)