### PR TITLE
update python versions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -45,12 +45,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python: ['3.10', 3.11, 3.12]
         exclude:
-          - os: macos-latest
-            python: 3.8
-          - os: macos-latest
-            python: 3.9
           - os: macos-latest
             python: '3.10'
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.10'
           architecture: x64
       - uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python: ['3.10', 3.11, 3.12]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python: ['3.10', 3.11, 3.12]
     steps:
       - name: Miniconda setup
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.10'
           architecture: x64
       - uses: astral-sh/setup-uv@v6
         with:


### PR DESCRIPTION
[This test](https://github.com/pyronear/pyro-api/actions/runs/20366058037/job/58521278585?pr=531) is failing on Python 3.9 due to the use of the int | None type annotation syntax, which is only supported starting from Python 3.10.

Python 3.9 has been officially end of life since October, and Python 3.8 is also end of life. Keeping compatibility with these versions prevents us from using modern type annotations already present in the codebase

Rather than adding workarounds or downgrading type hints, I propose dropping support for outdated Python versions, specifically Python 3.8 and 3.9, and setting Python 3.10 as the minimum supported version

This will simplify the codebase, align the project with actively supported Python versions, and prevent similar issues in the future