### PR TITLE
Filter out non-trustable cameras by default in fetch endpoint

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -110,7 +110,7 @@ class Client:
 
     # CAMERAS
     def fetch_cameras(self) -> Response:
-        """List the cameras accessible to the authenticated user
+        """List the cameras accessible to the authenticated user. By default, only trustable cameras are returned.
 
         >>> from pyroclient import client
         >>> api_client = Client("MY_USER_TOKEN")

--- a/src/app/api/api_v1/endpoints/cameras.py
+++ b/src/app/api/api_v1/endpoints/cameras.py
@@ -109,12 +109,7 @@ async def fetch_cameras(
         org_filters: list[tuple[str, Any]] = [("organization_id", token_payload.organization_id)]
         if not include_non_trustable:
             org_filters.append(("is_trustable", True))
-        cams = [
-            elt
-            for elt in await cameras.fetch_all(
-                order_by="id", filters=org_filters
-            )
-        ]
+        cams = [elt for elt in await cameras.fetch_all(order_by="id", filters=org_filters)]
 
         async def get_url_for_cam_single_bucket(cam: Camera) -> str | None:  # noqa: RUF029
             if cam.last_image:

--- a/src/app/api/api_v1/endpoints/cameras.py
+++ b/src/app/api/api_v1/endpoints/cameras.py
@@ -5,7 +5,7 @@
 
 import asyncio
 from datetime import datetime
-from typing import List, cast
+from typing import Any, List, cast
 
 from fastapi import APIRouter, Depends, File, HTTPException, Path, Security, UploadFile, status
 
@@ -84,13 +84,15 @@ async def get_camera(
     description="Returns all cameras accessible to the current user. `last_image_url` is null for a given camera if no image has been uploaded yet or if the image is temporarily unavailable in storage.",
 )
 async def fetch_cameras(
+    include_non_trustable: bool = False,
     cameras: CameraCRUD = Depends(get_camera_crud),
     poses: PoseCRUD = Depends(get_pose_crud),
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[CameraRead]:
     telemetry_client.capture(token_payload.sub, event="cameras-fetch")
+    trustable_filter: list[tuple[str, Any]] | None = None if include_non_trustable else [("is_trustable", True)]
     if UserRole.ADMIN in token_payload.scopes:
-        cams = [elt for elt in await cameras.fetch_all(order_by="id")]
+        cams = [elt for elt in await cameras.fetch_all(order_by="id", filters=trustable_filter)]
 
         async def get_url_for_cam(cam: Camera) -> str | None:  # noqa: RUF029
             if cam.last_image:
@@ -104,10 +106,13 @@ async def fetch_cameras(
         urls = await asyncio.gather(*[get_url_for_cam(cam) for cam in cams])
     else:
         bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(token_payload.organization_id))
+        org_filters: list[tuple[str, Any]] = [("organization_id", token_payload.organization_id)]
+        if not include_non_trustable:
+            org_filters.append(("is_trustable", True))
         cams = [
             elt
             for elt in await cameras.fetch_all(
-                order_by="id", filters=("organization_id", token_payload.organization_id)
+                order_by="id", filters=org_filters
             )
         ]
 

--- a/src/tests/endpoints/test_cameras.py
+++ b/src/tests/endpoints/test_cameras.py
@@ -158,12 +158,13 @@ async def test_get_camera(
 
 
 @pytest.mark.parametrize(
-    ("user_idx", "status_code", "status_detail", "expected_response", "expected_poses"),
+    ("user_idx", "status_code", "status_detail", "expected_response", "expected_poses", "include_non_trustable"),
     [
-        (None, 401, "Not authenticated", None, None),
-        (0, 200, None, pytest.camera_table[0], [pytest.pose_table[0], pytest.pose_table[1]]),
-        (1, 200, None, pytest.camera_table[0], [pytest.pose_table[0], pytest.pose_table[1]]),
-        (2, 200, None, pytest.camera_table[1], [pytest.pose_table[2]]),
+        (None, 401, "Not authenticated", None, None, False),
+        (0, 200, None, pytest.camera_table[0], [pytest.pose_table[0], pytest.pose_table[1]], False),
+        (1, 200, None, pytest.camera_table[0], [pytest.pose_table[0], pytest.pose_table[1]], False),
+        (2, 200, None, None, None, False),
+        (2, 200, None, pytest.camera_table[1], [pytest.pose_table[2]], True),
     ],
 )
 @pytest.mark.asyncio
@@ -176,6 +177,7 @@ async def test_fetch_cameras(
     status_detail: Union[str, None],
     expected_response: Union[List[Dict[str, Any]], None],
     expected_poses: Union[list, None],
+    include_non_trustable: bool,
 ):
     auth = None
     if isinstance(user_idx, int):
@@ -185,12 +187,19 @@ async def test_fetch_cameras(
             pytest.user_table[user_idx]["organization_id"],
         )
 
-    response = await async_client.get("/cameras", headers=auth)
+    params = {}
+    if include_non_trustable:
+        params["include_non_trustable"] = True
+    response = await async_client.get("/cameras", headers=auth, params=params)
     assert response.status_code == status_code, print(response.__dict__)
     if isinstance(status_detail, str):
         assert response.json()["detail"] == status_detail
     if response.status_code // 100 == 2:
         json_response = response.json()
+
+        if expected_response is None:
+            assert json_response == []
+            return
 
         for cam in json_response:
             assert "poses" in cam


### PR DESCRIPTION
  - GET /cameras now excludes cameras with is_trustable=False by default                                           
  - Added include_non_trustable boolean query parameter (default false) to opt into returning all cameras
  - Works for both admin (all orgs) and org-scoped users      