### PR TITLE
feat: add endpoint to update camera is_trustable status

### DIFF
--- a/src/app/api/api_v1/endpoints/cameras.py
+++ b/src/app/api/api_v1/endpoints/cameras.py
@@ -199,7 +199,9 @@ async def update_camera_name(
     return CameraOut(**camera.model_dump())
 
 
-@router.patch("/{camera_id}/trustable", status_code=status.HTTP_200_OK, summary="Update the trustable status of a camera")
+@router.patch(
+    "/{camera_id}/trustable", status_code=status.HTTP_200_OK, summary="Update the trustable status of a camera"
+)
 async def update_camera_trustable(
     payload: CameraTrustable,
     camera_id: int = Path(..., gt=0),

--- a/src/app/api/api_v1/endpoints/cameras.py
+++ b/src/app/api/api_v1/endpoints/cameras.py
@@ -22,6 +22,7 @@ from app.schemas.cameras import (
     CameraName,
     CameraOut,
     CameraRead,
+    CameraTrustable,
     LastActive,
     LastImage,
 )
@@ -194,6 +195,22 @@ async def update_camera_name(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN]),
 ) -> CameraOut:
     telemetry_client.capture(token_payload.sub, event="cameras-update-name", properties={"camera_id": camera_id})
+    camera = await cameras.update(camera_id, payload)
+    return CameraOut(**camera.model_dump())
+
+
+@router.patch("/{camera_id}/trustable", status_code=status.HTTP_200_OK, summary="Update the trustable status of a camera")
+async def update_camera_trustable(
+    payload: CameraTrustable,
+    camera_id: int = Path(..., gt=0),
+    cameras: CameraCRUD = Depends(get_camera_crud),
+    token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN]),
+) -> CameraOut:
+    telemetry_client.capture(
+        token_payload.sub,
+        event="cameras-update-trustable",
+        properties={"camera_id": camera_id, "is_trustable": payload.is_trustable},
+    )
     camera = await cameras.update(camera_id, payload)
     return CameraOut(**camera.model_dump())
 

--- a/src/app/crud/crud_camera.py
+++ b/src/app/crud/crud_camera.py
@@ -12,12 +12,15 @@ from app.schemas.cameras import (
     CameraDeviceConfig,
     CameraEdit,
     CameraName,
+    CameraTrustable,
     LastActive,
 )
 
 __all__ = ["CameraCRUD"]
 
 
-class CameraCRUD(BaseCRUD[Camera, CameraCreate, LastActive | CameraEdit | CameraName | CameraDeviceConfig]):
+class CameraCRUD(
+    BaseCRUD[Camera, CameraCreate, LastActive | CameraEdit | CameraName | CameraDeviceConfig | CameraTrustable]
+):
     def __init__(self, session: AsyncSession) -> None:
         super().__init__(session, Camera)

--- a/src/app/schemas/cameras.py
+++ b/src/app/schemas/cameras.py
@@ -58,6 +58,10 @@ class CameraName(BaseModel):
     name: str = Field(..., min_length=5, max_length=100, description="name of the camera")
 
 
+class CameraTrustable(BaseModel):
+    is_trustable: bool = Field(..., description="whether the detection from this camera can be trusted")
+
+
 class CameraDeviceConfig(BaseModel):
     """Internal-only: set the device connection details for a camera. Never returned in public responses."""
 

--- a/src/tests/endpoints/test_cameras.py
+++ b/src/tests/endpoints/test_cameras.py
@@ -1,9 +1,15 @@
+from datetime import datetime
 from typing import Any, Dict, List, Union
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.api.dependencies import get_camera_crud, get_jwt
+from app.main import app
+from app.models import Camera, Role
+from app.schemas.login import TokenPayload
 from app.services.storage import s3_service
 
 
@@ -608,6 +614,54 @@ async def test_update_camera_name(
         assert response.json()["detail"] == status_detail
     if response.status_code // 100 == 2:
         assert all(response.json()[k] == v for k, v in payload.items())
+
+
+@pytest.mark.asyncio
+async def test_update_camera_trustable(
+    async_client: AsyncClient,
+):
+    updated_camera = Camera(
+        id=1,
+        organization_id=1,
+        name="cam-1",
+        angle_of_view=91.3,
+        elevation=110.6,
+        lat=3.6,
+        lon=-45.2,
+        is_trustable=False,
+        last_active_at=None,
+        last_image=None,
+        created_at=datetime.utcnow(),
+    )
+    mock_cameras = AsyncMock()
+    mock_cameras.update = AsyncMock(return_value=updated_camera)
+
+    def override_cameras():
+        return mock_cameras
+
+    def override_jwt():
+        return TokenPayload(sub=1, scopes=[Role.ADMIN], organization_id=1)
+
+    app.dependency_overrides[get_camera_crud] = override_cameras
+    app.dependency_overrides[get_jwt] = override_jwt
+
+    try:
+        with patch("app.api.api_v1.endpoints.cameras.telemetry_client.capture") as capture:
+            response = await async_client.patch("/cameras/1/trustable", json={"is_trustable": False})
+    finally:
+        app.dependency_overrides.pop(get_camera_crud, None)
+        app.dependency_overrides.pop(get_jwt, None)
+
+    assert response.status_code == 200, print(response.__dict__)
+    assert response.json()["is_trustable"] is False
+    mock_cameras.update.assert_awaited_once()
+    assert mock_cameras.update.await_args.args[0] == 1
+    assert mock_cameras.update.await_args.args[1].is_trustable is False
+    capture.assert_called_once_with(
+        1,
+        event="cameras-update-trustable",
+        properties={"camera_id": 1, "is_trustable": False},
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I did #565 witout adding a route to update the status, here it is ..