### PR TITLE
fix: skip triangulation between sequences from the same pose

### DIFF
--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -151,6 +151,7 @@ def _build_overlap_records(
             continue
         records.append({
             "id": int(seq.id),
+            "pose_id": seq.pose_id,
             "lat": float(cam.lat),
             "lon": float(cam.lon),
             "sequence_azimuth": float(seq.sequence_azimuth),

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -59,6 +59,7 @@ async def _refresh_alert_state(alert_id: int, session: AsyncSession, alerts: Ale
         for seq, cam in zip(seqs, cams, strict=False):
             records.append({
                 "id": seq.id,
+                "pose_id": seq.pose_id,
                 "lat": cam.lat,
                 "lon": cam.lon,
                 "sequence_azimuth": seq.sequence_azimuth,

--- a/src/app/services/overlap.py
+++ b/src/app/services/overlap.py
@@ -10,7 +10,7 @@ import itertools
 import logging
 from collections import defaultdict
 from math import atan2, cos, radians, sin, sqrt
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import networkx as nx  # type: ignore
 import numpy as np
@@ -287,14 +287,19 @@ def _build_projected_cones(df_valid: pd.DataFrame, r_km: float, r_min_km: float)
 
 def _find_overlapping_pairs(df_valid: pd.DataFrame, projected_cones: Dict[int, Polygon]) -> List[Tuple[int, int]]:
     ids = df_valid["id"].astype(int).tolist()
-    rows_by_id: Dict[int, Dict[str, pd.Timestamp]] = df_valid.set_index("id")[["started_at", "last_seen_at"]].to_dict(
-        "index"
-    )
+    cols = ["started_at", "last_seen_at"]
+    has_pose = "pose_id" in df_valid.columns
+    if has_pose:
+        cols = cols + ["pose_id"]
+    rows_by_id: Dict[int, Dict[str, Any]] = df_valid.set_index("id")[cols].to_dict("index")
     overlapping_pairs: List[Tuple[int, int]] = []
     for i, id1 in enumerate(ids):
         row1 = rows_by_id[id1]
         for id2 in ids[i + 1 :]:
             row2 = rows_by_id[id2]
+            # Same pose shares the same apex; any cone intersection is degenerate, not a real triangulation.
+            if has_pose and row1["pose_id"] == row2["pose_id"]:
+                continue
             # Require overlapping time windows
             if row1["started_at"] > row2["last_seen_at"] or row2["started_at"] > row1["last_seen_at"]:
                 continue

--- a/src/app/services/overlap.py
+++ b/src/app/services/overlap.py
@@ -298,8 +298,10 @@ def _find_overlapping_pairs(df_valid: pd.DataFrame, projected_cones: Dict[int, P
         for id2 in ids[i + 1 :]:
             row2 = rows_by_id[id2]
             # Same pose shares the same apex; any cone intersection is degenerate, not a real triangulation.
-            if has_pose and row1["pose_id"] == row2["pose_id"]:
-                continue
+            if has_pose:
+                pose1, pose2 = row1["pose_id"], row2["pose_id"]
+                if pd.notna(pose1) and pd.notna(pose2) and pose1 == pose2:
+                    continue
             # Require overlapping time windows
             if row1["started_at"] > row2["last_seen_at"] or row2["started_at"] > row1["last_seen_at"]:
                 continue

--- a/src/app/services/overlap.py
+++ b/src/app/services/overlap.py
@@ -290,7 +290,7 @@ def _find_overlapping_pairs(df_valid: pd.DataFrame, projected_cones: Dict[int, P
     cols = ["started_at", "last_seen_at"]
     has_pose = "pose_id" in df_valid.columns
     if has_pose:
-        cols = cols + ["pose_id"]
+        cols = [*cols, "pose_id"]
     rows_by_id: Dict[int, Dict[str, Any]] = df_valid.set_index("id")[cols].to_dict("index")
     overlapping_pairs: List[Tuple[int, int]] = []
     for i, id1 in enumerate(ids):

--- a/src/tests/endpoints/test_alerts.py
+++ b/src/tests/endpoints/test_alerts.py
@@ -244,6 +244,7 @@ async def test_triangulation_creates_single_alert(
     records = [
         {
             "id": seq.id,
+            "pose_id": seq.pose_id,
             "lat": camera_by_id[seq.camera_id].lat,
             "lon": camera_by_id[seq.camera_id].lon,
             "sequence_azimuth": seq.sequence_azimuth,

--- a/src/tests/services/test_overlap.py
+++ b/src/tests/services/test_overlap.py
@@ -19,9 +19,11 @@ def _make_sequence(
     started_at: datetime,
     last_seen_at: datetime,
     is_wildfire=None,
+    pose_id: int | None = None,
 ):
     return {
         "id": id_,
+        "pose_id": pose_id if pose_id is not None else id_,
         "lat": lat,
         "lon": lon,
         "sequence_azimuth": sequence_azimuth,
@@ -51,3 +53,23 @@ def test_compute_overlap_groups_and_locations() -> None:
     # Non-overlapping singleton keeps its own group and no location
     assert row4["event_groups"] == [(4,)]
     assert row4["event_smoke_locations"] == [None]
+
+
+def test_compute_overlap_skips_same_pose_pair() -> None:
+    now = datetime.utcnow()
+    # Two sequences from the exact same pose with time and angular overlap
+    # share the same apex, so they must not be triangulated together.
+    seqs = [
+        _make_sequence(
+            10, 48.3792, 2.8208, 180.0, 10.0, now - timedelta(seconds=9), now - timedelta(seconds=1), pose_id=42
+        ),
+        _make_sequence(
+            11, 48.3792, 2.8208, 185.0, 10.0, now - timedelta(seconds=8), now - timedelta(seconds=2), pose_id=42
+        ),
+    ]
+    df = compute_overlap(pd.DataFrame.from_records(seqs))
+
+    row10 = df[df["id"] == 10].iloc[0]
+    row11 = df[df["id"] == 11].iloc[0]
+    assert row10["event_groups"] == [(10,)]
+    assert row11["event_groups"] == [(11,)]


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                
  - Two sequences from the same `pose_id` share the same camera apex. Any cone                                                                                                              
    intersection between them is degenerate (a wedge along the bisector, not a                                                                                                              
    real smoke location), so they must not be triangulated together.                                                                                                                        
  - `_find_overlapping_pairs` now skips pairs that share a `pose_id`. The check                                                                                                             
    is guarded by `has_pose`, so callers that don't pass `pose_id` keep working.                                                                                                            
  - Added `pose_id` to the records built in `detections.py` and `sequences.py`                                                                                                              
    so the filter actually fires in production.                                                                                                                                             
                                                                                                                                                                                            
  ## Context                                                                                                                                                                                
  Investigated alert 38460 on prod. Camera 66 / pose 105 produced two separate                                                                                                              
  sequences (38540 and 38547) with non-overlapping bboxes, both linked to the                                                                                                               
  same alert via cam 41. The current time-overlap check happened to block direct                                                                                                            
  pairing between the two pose-105 sequences in that case, but the guard was                                                                                                                
  missing: two concurrent sequences on the same pose (e.g. two plumes in                                                                                                                    
  different parts of the frame) would pass the time check and fake-triangulate.  