### PR TITLE
fix: relax triangulation time gate and prevent cross-event alert merging

### DIFF
--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -54,7 +54,7 @@ from app.schemas.detections import (
 from app.schemas.login import TokenPayload
 from app.schemas.sequences import SequenceUpdate
 from app.services.cones import resolve_cone
-from app.services.overlap import compute_overlap
+from app.services.overlap import compute_overlap, haversine_km
 from app.services.slack import slack_client
 from app.services.storage import s3_service, upload_file
 from app.services.telegram import telegram_client
@@ -229,6 +229,24 @@ async def _maybe_update_alert(
         )
 
 
+async def _filter_candidate_alert_ids(
+    existing_alert_ids: Set[int],
+    location: Optional[Tuple[float, float]],
+    alerts: AlertCRUD,
+) -> Set[int]:
+    if location is None or not existing_alert_ids:
+        return existing_alert_ids
+    kept: Set[int] = set()
+    for aid in existing_alert_ids:
+        alert = cast(Alert, await alerts.get(aid, strict=True))
+        if alert.lat is None or alert.lon is None:
+            kept.add(aid)
+            continue
+        if haversine_km(location[0], location[1], alert.lat, alert.lon) <= settings.ALERT_MERGE_MAX_DISTANCE_KM:
+            kept.add(aid)
+    return kept
+
+
 async def _get_or_create_alert_id(
     existing_alert_ids: Set[int],
     location: Optional[Tuple[float, float]],
@@ -237,8 +255,9 @@ async def _get_or_create_alert_id(
     last_seen_at: datetime,
     alerts: AlertCRUD,
 ) -> int:
-    if existing_alert_ids:
-        target_alert_id = min(existing_alert_ids)
+    candidates = await _filter_candidate_alert_ids(existing_alert_ids, location, alerts)
+    if candidates:
+        target_alert_id = min(candidates)
         if isinstance(location, tuple):
             await _maybe_update_alert(alerts, target_alert_id, location, start_at, last_seen_at)
         return target_alert_id

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -70,6 +70,7 @@ class Settings(BaseSettings):
     SEQUENCE_RELAXATION_SECONDS: int = int(os.environ.get("SEQUENCE_RELAXATION_SECONDS") or 120 * 60)
     SEQUENCE_MIN_INTERVAL_DETS: int = int(os.environ.get("SEQUENCE_MIN_INTERVAL_DETS") or 3)
     SEQUENCE_MIN_INTERVAL_SECONDS: int = int(os.environ.get("SEQUENCE_MIN_INTERVAL_SECONDS") or 5 * 60)
+    TRIANGULATION_RELAXATION_SECONDS: int = int(os.environ.get("TRIANGULATION_RELAXATION_SECONDS") or 30 * 60)
 
     # Notifications
     TELEGRAM_TOKEN: Union[str, None] = os.environ.get("TELEGRAM_TOKEN")

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -71,6 +71,7 @@ class Settings(BaseSettings):
     SEQUENCE_MIN_INTERVAL_DETS: int = int(os.environ.get("SEQUENCE_MIN_INTERVAL_DETS") or 3)
     SEQUENCE_MIN_INTERVAL_SECONDS: int = int(os.environ.get("SEQUENCE_MIN_INTERVAL_SECONDS") or 5 * 60)
     TRIANGULATION_RELAXATION_SECONDS: int = int(os.environ.get("TRIANGULATION_RELAXATION_SECONDS") or 30 * 60)
+    ALERT_MERGE_MAX_DISTANCE_KM: float = float(os.environ.get("ALERT_MERGE_MAX_DISTANCE_KM") or 2.0)
 
     # Notifications
     TELEGRAM_TOKEN: Union[str, None] = os.environ.get("TELEGRAM_TOKEN")

--- a/src/app/services/overlap.py
+++ b/src/app/services/overlap.py
@@ -305,7 +305,7 @@ def _find_overlapping_pairs(
     # window is a single instant and prior sequences' windows haven't been bumped yet.
     # Treat any pair within `time_relaxation_seconds` of each other as concurrent so we
     # don't drop them before the spatial test.
-    slack = timedelta(seconds=time_relaxation_seconds)
+    tolerance = timedelta(seconds=time_relaxation_seconds)
     overlapping_pairs: List[Tuple[int, int]] = []
     for i, id1 in enumerate(ids):
         row1 = rows_by_id[id1]
@@ -316,7 +316,10 @@ def _find_overlapping_pairs(
                 pose1, pose2 = row1["pose_id"], row2["pose_id"]
                 if pd.notna(pose1) and pd.notna(pose2) and pose1 == pose2:
                     continue
-            if row1["started_at"] - row2["last_seen_at"] > slack or row2["started_at"] - row1["last_seen_at"] > slack:
+            if (
+                row1["started_at"] - row2["last_seen_at"] > tolerance
+                or row2["started_at"] - row1["last_seen_at"] > tolerance
+            ):
                 continue
             # Spatial overlap test
             if projected_cones[id1].intersects(projected_cones[id2]):

--- a/src/app/services/overlap.py
+++ b/src/app/services/overlap.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import itertools
 import logging
 from collections import defaultdict
+from datetime import timedelta
 from math import atan2, cos, radians, sin, sqrt
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -21,6 +22,8 @@ from pyproj import Transformer
 from shapely.geometry import Polygon
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform as shapely_transform
+
+from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -285,13 +288,24 @@ def _build_projected_cones(df_valid: pd.DataFrame, r_km: float, r_min_km: float)
     return projected_cones
 
 
-def _find_overlapping_pairs(df_valid: pd.DataFrame, projected_cones: Dict[int, Polygon]) -> List[Tuple[int, int]]:
+def _find_overlapping_pairs(
+    df_valid: pd.DataFrame,
+    projected_cones: Dict[int, Polygon],
+    time_relaxation_seconds: Optional[float] = None,
+) -> List[Tuple[int, int]]:
+    if time_relaxation_seconds is None:
+        time_relaxation_seconds = settings.SEQUENCE_RELAXATION_SECONDS
     ids = df_valid["id"].astype(int).tolist()
     cols = ["started_at", "last_seen_at"]
     has_pose = "pose_id" in df_valid.columns
     if has_pose:
         cols = [*cols, "pose_id"]
     rows_by_id: Dict[int, Dict[str, Any]] = df_valid.set_index("id")[cols].to_dict("index")
+    # `_attach_sequence_to_alert` runs once at sequence creation, when the new sequence's
+    # window is a single instant and prior sequences' windows haven't been bumped yet.
+    # Treat any pair within `time_relaxation_seconds` of each other as concurrent so we
+    # don't drop them before the spatial test.
+    slack = timedelta(seconds=time_relaxation_seconds)
     overlapping_pairs: List[Tuple[int, int]] = []
     for i, id1 in enumerate(ids):
         row1 = rows_by_id[id1]
@@ -302,8 +316,7 @@ def _find_overlapping_pairs(df_valid: pd.DataFrame, projected_cones: Dict[int, P
                 pose1, pose2 = row1["pose_id"], row2["pose_id"]
                 if pd.notna(pose1) and pd.notna(pose2) and pose1 == pose2:
                     continue
-            # Require overlapping time windows
-            if row1["started_at"] > row2["last_seen_at"] or row2["started_at"] > row1["last_seen_at"]:
+            if row1["started_at"] - row2["last_seen_at"] > slack or row2["started_at"] - row1["last_seen_at"] > slack:
                 continue
             # Spatial overlap test
             if projected_cones[id1].intersects(projected_cones[id2]):
@@ -371,6 +384,7 @@ def compute_overlap(
     r_km: float = 35.0,
     r_min_km: float = 0.5,
     max_dist_km: float = 2.0,
+    time_relaxation_seconds: Optional[float] = None,
 ) -> pd.DataFrame:
     """
     Build localized event groups and attach them to the input DataFrame.
@@ -390,6 +404,11 @@ def compute_overlap(
         Inner radius of the camera detection cone in kilometers.
     max_dist_km : float
         Maximum allowed distance between pair intersection barycenters to keep a group.
+    time_relaxation_seconds : float, optional
+        Tolerance applied to the time-window overlap check between two sequences. Pairs
+        whose windows are within this slack of each other are still considered concurrent.
+        Defaults to ``settings.SEQUENCE_RELAXATION_SECONDS`` so triangulation uses the
+        same window as the candidate-sequence fetch.
 
     Returns
     -------
@@ -408,7 +427,7 @@ def compute_overlap(
     projected_cones = _build_projected_cones(df_valid, r_km, r_min_km)
 
     # Phase 1, build overlap graph gated by time overlap
-    overlapping_pairs = _find_overlapping_pairs(df_valid, projected_cones)
+    overlapping_pairs = _find_overlapping_pairs(df_valid, projected_cones, time_relaxation_seconds)
     cliques = _build_overlap_cliques(overlapping_pairs)
 
     # Phase 2, localized groups from cliques

--- a/src/app/services/overlap.py
+++ b/src/app/services/overlap.py
@@ -294,7 +294,7 @@ def _find_overlapping_pairs(
     time_relaxation_seconds: Optional[float] = None,
 ) -> List[Tuple[int, int]]:
     if time_relaxation_seconds is None:
-        time_relaxation_seconds = settings.SEQUENCE_RELAXATION_SECONDS
+        time_relaxation_seconds = settings.TRIANGULATION_RELAXATION_SECONDS
     ids = df_valid["id"].astype(int).tolist()
     cols = ["started_at", "last_seen_at"]
     has_pose = "pose_id" in df_valid.columns
@@ -410,8 +410,7 @@ def compute_overlap(
     time_relaxation_seconds : float, optional
         Tolerance applied to the time-window overlap check between two sequences. Pairs
         whose windows are within this slack of each other are still considered concurrent.
-        Defaults to ``settings.SEQUENCE_RELAXATION_SECONDS`` so triangulation uses the
-        same window as the candidate-sequence fetch.
+        Defaults to ``settings.TRIANGULATION_RELAXATION_SECONDS``.
 
     Returns
     -------

--- a/src/tests/endpoints/test_detections.py
+++ b/src/tests/endpoints/test_detections.py
@@ -1237,3 +1237,123 @@ async def test_attach_sequence_to_alert_creates_alert(detection_session: AsyncSe
     mappings_res = await detection_session.exec(select(AlertSequence))
     mappings = mappings_res.all()
     assert {(m.alert_id, m.sequence_id) for m in mappings} == {(alert.id, seq1.id), (alert.id, seq2.id)}
+
+
+@pytest.mark.asyncio
+async def test_attach_sequence_does_not_bridge_to_distant_alert(detection_session: AsyncSession):
+    """
+    Regression guard for the bridging bug.
+
+    Geometry (from the dev-API replay):
+      - cam7 (48.260, 2.706) NNW + cam5 (48.379, 2.821) W  → triangulate at ~(48.39, 2.66)  [smoke A]
+      - cam7 NNW + cam2 (48.478, 2.424) ENE                → triangulate at ~(48.51, 2.59)  [smoke B]
+
+    If cam7's sequence is already linked to the smoke-A alert, adding a cam2 sequence whose
+    only clique with an existing sequence is `{cam7-seq, cam2-seq}` must NOT drag the new
+    sequence into the smoke-A alert — its clique barycenter sits >14 km away from A.
+    """
+    seq_crud = SequenceCRUD(detection_session)
+    alert_crud = AlertCRUD(detection_session)
+    cam_crud = CameraCRUD(detection_session)
+    now = datetime.utcnow()
+
+    cam2 = Camera(
+        organization_id=1,
+        name="videlles-02",
+        angle_of_view=54.2,
+        elevation=110.0,
+        lat=48.4783,
+        lon=2.4242,
+        is_trustable=True,
+        last_active_at=now,
+        last_image=None,
+        created_at=now,
+    )
+    cam5 = Camera(
+        organization_id=1,
+        name="moret-01",
+        angle_of_view=54.2,
+        elevation=110.0,
+        lat=48.3792,
+        lon=2.8208,
+        is_trustable=True,
+        last_active_at=now,
+        last_image=None,
+        created_at=now,
+    )
+    cam7 = Camera(
+        organization_id=1,
+        name="nemours-01",
+        angle_of_view=54.2,
+        elevation=110.0,
+        lat=48.2605,
+        lon=2.7064,
+        is_trustable=True,
+        last_active_at=now,
+        last_image=None,
+        created_at=now,
+    )
+    detection_session.add_all([cam2, cam5, cam7])
+    await detection_session.commit()
+    await detection_session.refresh(cam2)
+    await detection_session.refresh(cam5)
+    await detection_session.refresh(cam7)
+
+    # Smoke A: cam7 NNW + cam5 W
+    seq_cam7 = Sequence(
+        camera_id=cam7.id,
+        pose_id=1,
+        camera_azimuth=0.0,
+        sequence_azimuth=-17.5,
+        cone_angle=1.4,
+        is_wildfire=None,
+        started_at=now - timedelta(seconds=30),
+        last_seen_at=now - timedelta(seconds=20),
+    )
+    seq_cam5 = Sequence(
+        camera_id=cam5.id,
+        pose_id=2,
+        camera_azimuth=280.0,
+        sequence_azimuth=276.5,
+        cone_angle=3.0,
+        is_wildfire=None,
+        started_at=now - timedelta(seconds=25),
+        last_seen_at=now - timedelta(seconds=15),
+    )
+    detection_session.add_all([seq_cam7, seq_cam5])
+    await detection_session.commit()
+    await detection_session.refresh(seq_cam7)
+    await detection_session.refresh(seq_cam5)
+
+    # Step 1 — attach cam5 sequence triangulates with cam7, creates smoke-A alert.
+    smoke_a_alert_id = await _attach_sequence_to_alert(seq_cam5, cam5, cam_crud, seq_crud, alert_crud)
+    assert smoke_a_alert_id is not None
+    smoke_a = await alert_crud.get(smoke_a_alert_id, strict=True)
+    assert smoke_a.lat is not None
+    assert smoke_a.lon is not None
+
+    # Step 2 — new cam2 sequence whose cone crosses cam7's far from smoke A.
+    seq_cam2 = Sequence(
+        camera_id=cam2.id,
+        pose_id=3,
+        camera_azimuth=60.0,
+        sequence_azimuth=75.2,
+        cone_angle=1.4,
+        is_wildfire=None,
+        started_at=now - timedelta(seconds=5),
+        last_seen_at=now,
+    )
+    detection_session.add(seq_cam2)
+    await detection_session.commit()
+    await detection_session.refresh(seq_cam2)
+
+    target_id = await _attach_sequence_to_alert(seq_cam2, cam2, cam_crud, seq_crud, alert_crud)
+
+    # The cam2 sequence must land on a NEW alert, not the smoke-A one.
+    assert target_id is not None
+    assert target_id != smoke_a_alert_id
+
+    # And it must not have been retroactively linked to smoke A.
+    mappings_res = await detection_session.exec(select(AlertSequence).where(AlertSequence.alert_id == smoke_a_alert_id))
+    seqs_in_a = {m.sequence_id for m in mappings_res.all()}
+    assert seq_cam2.id not in seqs_in_a

--- a/src/tests/endpoints/test_detections.py
+++ b/src/tests/endpoints/test_detections.py
@@ -512,8 +512,11 @@ async def test_filter_candidate_keeps_alert_within_threshold(detection_session: 
     alert_crud = AlertCRUD(detection_session)
     now = datetime.utcnow()
     nearby = Alert(
-        organization_id=1, lat=SMOKE_LOCATION[0] + 0.005, lon=SMOKE_LOCATION[1] + 0.005,
-        started_at=now, last_seen_at=now,
+        organization_id=1,
+        lat=SMOKE_LOCATION[0] + 0.005,
+        lon=SMOKE_LOCATION[1] + 0.005,
+        started_at=now,
+        last_seen_at=now,
     )
     detection_session.add(nearby)
     await detection_session.commit()
@@ -528,8 +531,11 @@ async def test_filter_candidate_drops_alert_beyond_threshold(detection_session: 
     alert_crud = AlertCRUD(detection_session)
     now = datetime.utcnow()
     far = Alert(
-        organization_id=1, lat=DISTANT_LOCATION[0], lon=DISTANT_LOCATION[1],
-        started_at=now, last_seen_at=now,
+        organization_id=1,
+        lat=DISTANT_LOCATION[0],
+        lon=DISTANT_LOCATION[1],
+        started_at=now,
+        last_seen_at=now,
     )
     detection_session.add(far)
     await detection_session.commit()
@@ -557,8 +563,11 @@ async def test_filter_candidate_returns_unchanged_when_location_missing(detectio
     alert_crud = AlertCRUD(detection_session)
     now = datetime.utcnow()
     a = Alert(
-        organization_id=1, lat=DISTANT_LOCATION[0], lon=DISTANT_LOCATION[1],
-        started_at=now, last_seen_at=now,
+        organization_id=1,
+        lat=DISTANT_LOCATION[0],
+        lon=DISTANT_LOCATION[1],
+        started_at=now,
+        last_seen_at=now,
     )
     detection_session.add(a)
     await detection_session.commit()
@@ -573,8 +582,11 @@ async def test_get_or_create_alert_id_creates_new_when_existing_too_far(detectio
     alert_crud = AlertCRUD(detection_session)
     now = datetime.utcnow()
     distant = Alert(
-        organization_id=1, lat=DISTANT_LOCATION[0], lon=DISTANT_LOCATION[1],
-        started_at=now, last_seen_at=now,
+        organization_id=1,
+        lat=DISTANT_LOCATION[0],
+        lon=DISTANT_LOCATION[1],
+        started_at=now,
+        last_seen_at=now,
     )
     detection_session.add(distant)
     await detection_session.commit()
@@ -598,12 +610,18 @@ async def test_get_or_create_alert_id_picks_nearby_over_distant(detection_sessio
     alert_crud = AlertCRUD(detection_session)
     now = datetime.utcnow()
     distant = Alert(
-        organization_id=1, lat=DISTANT_LOCATION[0], lon=DISTANT_LOCATION[1],
-        started_at=now, last_seen_at=now,
+        organization_id=1,
+        lat=DISTANT_LOCATION[0],
+        lon=DISTANT_LOCATION[1],
+        started_at=now,
+        last_seen_at=now,
     )
     nearby = Alert(
-        organization_id=1, lat=SMOKE_LOCATION[0] + 0.003, lon=SMOKE_LOCATION[1] + 0.003,
-        started_at=now, last_seen_at=now,
+        organization_id=1,
+        lat=SMOKE_LOCATION[0] + 0.003,
+        lon=SMOKE_LOCATION[1] + 0.003,
+        started_at=now,
+        last_seen_at=now,
     )
     detection_session.add(distant)
     detection_session.add(nearby)

--- a/src/tests/endpoints/test_detections.py
+++ b/src/tests/endpoints/test_detections.py
@@ -17,6 +17,7 @@ from app.api.api_v1.endpoints.detections import (
     _build_links_for_group,
     _build_overlap_records,
     _fetch_alert_mapping,
+    _filter_candidate_alert_ids,
     _get_camera_by_id,
     _get_last_bbox_for_sequence,
     _get_or_create_alert_id,
@@ -497,6 +498,129 @@ def test_build_links_for_group_skips_existing_alert():
     links = _build_links_for_group(group, 10, mapping)
     assert {link.sequence_id for link in links} == {2}
     assert mapping[2] == {10}
+
+
+# Real-world geometry from a dev-API alert (org 2 / 2026-04-21):
+# - smoke triangulated by seq 5 (cam 7 NNW) + seq 20 (cam 5 W) lands at ~(48.39, 2.66)
+# - seq 1 + seq 2 cone-axes cross ~14 km north at ~(48.55, 2.85)
+SMOKE_LOCATION = (48.3913, 2.6582)
+DISTANT_LOCATION = (48.5529, 2.8536)
+
+
+@pytest.mark.asyncio
+async def test_filter_candidate_keeps_alert_within_threshold(detection_session: AsyncSession):
+    alert_crud = AlertCRUD(detection_session)
+    now = datetime.utcnow()
+    nearby = Alert(
+        organization_id=1, lat=SMOKE_LOCATION[0] + 0.005, lon=SMOKE_LOCATION[1] + 0.005,
+        started_at=now, last_seen_at=now,
+    )
+    detection_session.add(nearby)
+    await detection_session.commit()
+    await detection_session.refresh(nearby)
+
+    kept = await _filter_candidate_alert_ids({nearby.id}, SMOKE_LOCATION, alert_crud)
+    assert kept == {nearby.id}
+
+
+@pytest.mark.asyncio
+async def test_filter_candidate_drops_alert_beyond_threshold(detection_session: AsyncSession):
+    alert_crud = AlertCRUD(detection_session)
+    now = datetime.utcnow()
+    far = Alert(
+        organization_id=1, lat=DISTANT_LOCATION[0], lon=DISTANT_LOCATION[1],
+        started_at=now, last_seen_at=now,
+    )
+    detection_session.add(far)
+    await detection_session.commit()
+    await detection_session.refresh(far)
+
+    kept = await _filter_candidate_alert_ids({far.id}, SMOKE_LOCATION, alert_crud)
+    assert kept == set()
+
+
+@pytest.mark.asyncio
+async def test_filter_candidate_keeps_alert_with_no_location(detection_session: AsyncSession):
+    alert_crud = AlertCRUD(detection_session)
+    now = datetime.utcnow()
+    anchorless = Alert(organization_id=1, lat=None, lon=None, started_at=now, last_seen_at=now)
+    detection_session.add(anchorless)
+    await detection_session.commit()
+    await detection_session.refresh(anchorless)
+
+    kept = await _filter_candidate_alert_ids({anchorless.id}, SMOKE_LOCATION, alert_crud)
+    assert kept == {anchorless.id}
+
+
+@pytest.mark.asyncio
+async def test_filter_candidate_returns_unchanged_when_location_missing(detection_session: AsyncSession):
+    alert_crud = AlertCRUD(detection_session)
+    now = datetime.utcnow()
+    a = Alert(
+        organization_id=1, lat=DISTANT_LOCATION[0], lon=DISTANT_LOCATION[1],
+        started_at=now, last_seen_at=now,
+    )
+    detection_session.add(a)
+    await detection_session.commit()
+    await detection_session.refresh(a)
+
+    kept = await _filter_candidate_alert_ids({a.id}, None, alert_crud)
+    assert kept == {a.id}
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_alert_id_creates_new_when_existing_too_far(detection_session: AsyncSession):
+    alert_crud = AlertCRUD(detection_session)
+    now = datetime.utcnow()
+    distant = Alert(
+        organization_id=1, lat=DISTANT_LOCATION[0], lon=DISTANT_LOCATION[1],
+        started_at=now, last_seen_at=now,
+    )
+    detection_session.add(distant)
+    await detection_session.commit()
+    await detection_session.refresh(distant)
+
+    target_id = await _get_or_create_alert_id(
+        {distant.id},
+        SMOKE_LOCATION,
+        1,
+        now - timedelta(seconds=10),
+        now + timedelta(seconds=10),
+        alert_crud,
+    )
+    assert target_id != distant.id
+    new_alert = await alert_crud.get(target_id, strict=True)
+    assert (new_alert.lat, new_alert.lon) == SMOKE_LOCATION
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_alert_id_picks_nearby_over_distant(detection_session: AsyncSession):
+    alert_crud = AlertCRUD(detection_session)
+    now = datetime.utcnow()
+    distant = Alert(
+        organization_id=1, lat=DISTANT_LOCATION[0], lon=DISTANT_LOCATION[1],
+        started_at=now, last_seen_at=now,
+    )
+    nearby = Alert(
+        organization_id=1, lat=SMOKE_LOCATION[0] + 0.003, lon=SMOKE_LOCATION[1] + 0.003,
+        started_at=now, last_seen_at=now,
+    )
+    detection_session.add(distant)
+    detection_session.add(nearby)
+    await detection_session.commit()
+    await detection_session.refresh(distant)
+    await detection_session.refresh(nearby)
+
+    # Even though `distant` may have a smaller id, it must be filtered out by the distance gate.
+    target_id = await _get_or_create_alert_id(
+        {distant.id, nearby.id},
+        SMOKE_LOCATION,
+        1,
+        now - timedelta(seconds=10),
+        now + timedelta(seconds=10),
+        alert_crud,
+    )
+    assert target_id == nearby.id
 
 
 @pytest.mark.asyncio

--- a/src/tests/services/test_overlap.py
+++ b/src/tests/services/test_overlap.py
@@ -55,6 +55,26 @@ def test_compute_overlap_groups_and_locations() -> None:
     assert row4["event_smoke_locations"] == [None]
 
 
+def test_compute_overlap_time_relaxation_recovers_just_started_pair() -> None:
+    # Two cones from different poses whose first-detection windows are 30 s apart:
+    # at sequence-creation time, last_seen_at == started_at, so the strict time
+    # gate would drop the pair before the spatial test runs. With relaxation
+    # they must be re-considered as concurrent.
+    now = datetime.utcnow()
+    seqs = [
+        _make_sequence(20, 48.3792, 2.8208, 276.5, 3.0, now - timedelta(seconds=30), now - timedelta(seconds=30)),
+        _make_sequence(21, 48.4267, 2.7109, 163.4, 1.0, now, now),
+    ]
+    df_strict = compute_overlap(pd.DataFrame.from_records(seqs), time_relaxation_seconds=0)
+    assert df_strict[df_strict["id"] == 20].iloc[0]["event_groups"] == [(20,)]
+    assert df_strict[df_strict["id"] == 21].iloc[0]["event_groups"] == [(21,)]
+
+    # Default relaxation (settings.SEQUENCE_RELAXATION_SECONDS) recovers the pair.
+    df_relaxed = compute_overlap(pd.DataFrame.from_records(seqs))
+    assert df_relaxed[df_relaxed["id"] == 20].iloc[0]["event_groups"] == [(20, 21)]
+    assert df_relaxed[df_relaxed["id"] == 21].iloc[0]["event_groups"] == [(20, 21)]
+
+
 def test_compute_overlap_skips_same_pose_pair() -> None:
     now = datetime.utcnow()
     # Two sequences from the exact same pose with time and angular overlap

--- a/src/tests/services/test_overlap.py
+++ b/src/tests/services/test_overlap.py
@@ -69,7 +69,7 @@ def test_compute_overlap_time_relaxation_recovers_just_started_pair() -> None:
     assert df_strict[df_strict["id"] == 20].iloc[0]["event_groups"] == [(20,)]
     assert df_strict[df_strict["id"] == 21].iloc[0]["event_groups"] == [(21,)]
 
-    # Default relaxation (settings.SEQUENCE_RELAXATION_SECONDS) recovers the pair.
+    # Default relaxation (settings.TRIANGULATION_RELAXATION_SECONDS) recovers the pair.
     df_relaxed = compute_overlap(pd.DataFrame.from_records(seqs))
     assert df_relaxed[df_relaxed["id"] == 20].iloc[0]["event_groups"] == [(20, 21)]
     assert df_relaxed[df_relaxed["id"] == 21].iloc[0]["event_groups"] == [(20, 21)]


### PR DESCRIPTION
  Fixes two distinct bugs that caused triangulation to misbehave on real-world data — sequences that should
  triangulate ended up as separate single-sequence alerts, and (separately) unrelated sequences ended up merged into
  a single sprawling alert.

  Bug 1 — strict time gate dropped just-started pairs

  _attach_sequence_to_alert runs once per sequence — at creation. At that moment:

  - the new sequence has last_seen_at == started_at (a single instant)
  - prior sequences still hold the last_seen_at from their previous detection

  The time-overlap gate in _find_overlapping_pairs required strict window intersection:

  if row1.started_at > row2.last_seen_at or row2.started_at > row1.last_seen_at:
      continue

  A sequence starting even 17 s after another's only detection was rejected before the spatial test ran. Alert
  merging never re-runs on later last_seen_at updates, so even after both sequences had wide overlapping windows, the
   singletons were frozen in.

  Real-world example: alerts 38720/38721/38722 (cams moret-sur-loing-02, croix-augas-02, nemours-01) on 2026-04-19
  ~08:35 UTC — all three cones spatially overlapped pairwise (areas 600k / 374k / 324k m²) but each became its own
  alert.

  Fix

  Added a time_relaxation_seconds tolerance to the time gate, defaulting to a new dedicated setting:

  TRIANGULATION_RELAXATION_SECONDS = 30 * 60   # 30 min

  Kept separate from SEQUENCE_RELAXATION_SECONDS (2 h) which governs candidate-sequence fetch and
  detection-to-sequence matching, so the triangulation window can be tuned independently.

  Bug 2 — unrelated alerts merged via bridging sequences

  While replaying production traffic, we found alerts where 10+ sequences from cones pointing in wildly different
  directions all ended up linked to one alert. Root cause:

  _get_or_create_alert_id merged into any existing alert whose sequence list shared a member with the new clique,
  without checking whether that alert's lat/lon was anywhere near the new group's barycenter. So a sequence forming a
   clique at location X with a sequence-already-in-alert-A could pull the new sequence into alert A even though A's
  actual location was 15 km away at location Y.

  Fix

  Added a haversine distance gate around the merge step. Candidates whose lat/lon is more than
  ALERT_MERGE_MAX_DISTANCE_KM (default 2 km, matching the existing max_dist_km clique-split threshold) from the new
  group's barycenter are filtered out. If all candidates fail the gate, a fresh alert is created at the new location.
  
  
  
<img width="1544" height="602" alt="Screenshot 2026-04-21 at 16 19 18" src="https://github.com/user-attachments/assets/cc8fb0c7-6de8-4bda-8bbd-c81684cee3a2" />


  