### PR TITLE
chore: replace deprecated datetime.utcnow() with a helper

### DIFF
--- a/src/app/api/api_v1/endpoints/alerts.py
+++ b/src/app/api/api_v1/endpoints/alerts.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from typing import Any, Dict, List, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Security, status
@@ -13,6 +13,7 @@ from sqlmodel import delete, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import get_alert_crud, get_jwt
+from app.core.time import utcnow
 from app.crud import AlertCRUD
 from app.db import get_session
 from app.models import Alert, AlertSequence, Sequence, UserRole
@@ -109,8 +110,9 @@ async def fetch_latest_unlabeled_alerts(
     alerts_stmt: Any = select(Alert).join(AlertSequence, cast(Any, AlertSequence.alert_id == Alert.id))
     alerts_stmt = alerts_stmt.join(Sequence, cast(Any, Sequence.id == AlertSequence.sequence_id))
     alerts_stmt = (
-        alerts_stmt.where(Alert.organization_id == token_payload.organization_id)
-        .where(Sequence.last_seen_at > datetime.utcnow() - timedelta(hours=24))
+        alerts_stmt
+        .where(Alert.organization_id == token_payload.organization_id)
+        .where(Sequence.last_seen_at > utcnow() - timedelta(hours=24))
         .where(Sequence.is_wildfire.is_(None))  # type: ignore[union-attr]
         .order_by(Alert.started_at.desc())  # type: ignore[attr-defined]
         .limit(15)

--- a/src/app/api/api_v1/endpoints/alerts.py
+++ b/src/app/api/api_v1/endpoints/alerts.py
@@ -110,8 +110,7 @@ async def fetch_latest_unlabeled_alerts(
     alerts_stmt: Any = select(Alert).join(AlertSequence, cast(Any, AlertSequence.alert_id == Alert.id))
     alerts_stmt = alerts_stmt.join(Sequence, cast(Any, Sequence.id == AlertSequence.sequence_id))
     alerts_stmt = (
-        alerts_stmt
-        .where(Alert.organization_id == token_payload.organization_id)
+        alerts_stmt.where(Alert.organization_id == token_payload.organization_id)
         .where(Sequence.last_seen_at > utcnow() - timedelta(hours=24))
         .where(Sequence.is_wildfire.is_(None))  # type: ignore[union-attr]
         .order_by(Alert.started_at.desc())  # type: ignore[attr-defined]

--- a/src/app/api/api_v1/endpoints/cameras.py
+++ b/src/app/api/api_v1/endpoints/cameras.py
@@ -4,7 +4,6 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 import asyncio
-from datetime import datetime
 from typing import Any, List, cast
 
 from fastapi import APIRouter, Depends, File, HTTPException, Path, Security, UploadFile, status
@@ -12,6 +11,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, Path, Security, Upl
 from app.api.dependencies import get_camera_crud, get_jwt, get_pose_crud
 from app.core.config import settings
 from app.core.security import create_access_token
+from app.core.time import utcnow
 from app.crud import CameraCRUD
 from app.crud.crud_pose import PoseCRUD
 from app.models import Camera, Role, UserRole
@@ -140,7 +140,7 @@ async def heartbeat(
     token_payload: TokenPayload = Security(get_jwt, scopes=[Role.CAMERA]),
 ) -> CameraOut:
     # telemetry_client.capture(f"camera|{token_payload.sub}", event="cameras-heartbeat")
-    camera = await cameras.update(token_payload.sub, LastActive(last_active_at=datetime.utcnow()))
+    camera = await cameras.update(token_payload.sub, LastActive(last_active_at=utcnow()))
     return CameraOut(**camera.model_dump())
 
 
@@ -157,7 +157,7 @@ async def update_image(
     if isinstance(cam.last_image, str):
         s3_service.get_bucket(s3_service.resolve_bucket_name(token_payload.organization_id)).delete_file(cam.last_image)
     # Update the DB entry
-    camera = await cameras.update(token_payload.sub, LastImage(last_image=bucket_key, last_active_at=datetime.utcnow()))
+    camera = await cameras.update(token_payload.sub, LastImage(last_image=bucket_key, last_active_at=utcnow()))
     return CameraOut(**camera.model_dump())
 
 

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -39,6 +39,7 @@ from app.api.dependencies import (
     get_webhook_crud,
 )
 from app.core.config import settings
+from app.core.time import utcnow
 from app.crud import AlertCRUD, CameraCRUD, DetectionCRUD, OrganizationCRUD, PoseCRUD, SequenceCRUD, WebhookCRUD
 from app.models import Alert, AlertSequence, Camera, Detection, Organization, Pose, Role, Sequence, UserRole
 from app.schemas.alerts import AlertCreate, AlertUpdate
@@ -132,7 +133,7 @@ async def _get_recent_sequences(
         inequality_pair=(
             "last_seen_at",
             ">",
-            datetime.utcnow() - timedelta(seconds=settings.SEQUENCE_RELAXATION_SECONDS),
+            utcnow() - timedelta(seconds=settings.SEQUENCE_RELAXATION_SECONDS),
         ),
     )
     if all(seq.id != sequence_.id for seq in recent_sequences):
@@ -387,7 +388,7 @@ async def create_detection(
             inequality_pair=(
                 "last_seen_at",
                 ">",
-                datetime.utcnow() - timedelta(seconds=settings.SEQUENCE_RELAXATION_SECONDS),
+                utcnow() - timedelta(seconds=settings.SEQUENCE_RELAXATION_SECONDS),
             ),
             order_by="last_seen_at",
             order_desc=True,
@@ -415,7 +416,7 @@ async def create_detection(
                 inequality_pair=(
                     "created_at",
                     ">",
-                    datetime.utcnow() - timedelta(seconds=settings.SEQUENCE_MIN_INTERVAL_SECONDS),
+                    utcnow() - timedelta(seconds=settings.SEQUENCE_MIN_INTERVAL_SECONDS),
                 ),
                 order_by="created_at",
                 order_desc=False,

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from typing import Any, List, Union, cast
 
 import pandas as pd
@@ -13,6 +13,7 @@ from sqlmodel import delete, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import get_alert_crud, get_camera_crud, get_detection_crud, get_jwt, get_sequence_crud
+from app.core.time import utcnow
 from app.crud import AlertCRUD, CameraCRUD, DetectionCRUD, SequenceCRUD
 from app.db import get_session
 from app.models import AlertSequence, AnnotationType, Camera, Detection, Sequence, UserRole
@@ -147,7 +148,7 @@ async def fetch_latest_unlabeled_sequences(
     fetched_sequences = (
         await session.exec(
             select(Sequence)
-            .where(Sequence.started_at > datetime.utcnow() - timedelta(hours=24))
+            .where(Sequence.started_at > utcnow() - timedelta(hours=24))
             .where(Sequence.camera_id.in_(camera_ids.all()))  # type: ignore[attr-defined]
             .where(Sequence.is_wildfire.is_(None))  # type: ignore[union-attr]
             .order_by(Sequence.started_at.desc())  # type: ignore[attr-defined]

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -3,13 +3,14 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, Dict, Optional
 
 import jwt
 from passlib.context import CryptContext
 
 from app.core.config import settings
+from app.core.time import utcnow
 
 __all__ = ["create_access_token", "hash_password", "verify_password"]
 
@@ -19,7 +20,7 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 def create_access_token(content: Dict[str, Any], expires_minutes: Optional[int] = None) -> str:
     """Encode content dict using security algorithm, setting expiration."""
     expire_delta = timedelta(minutes=expires_minutes or settings.JWT_EXPIRE_MINUTES)
-    expire = datetime.utcnow() + expire_delta
+    expire = utcnow() + expire_delta
     return jwt.encode({**content, "exp": expire}, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
 
 

--- a/src/app/core/time.py
+++ b/src/app/core/time.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2024-2026, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+from datetime import datetime, timezone
+
+
+def utcnow() -> datetime:
+    """UTC wall clock, returned as a naive datetime to match existing DB columns."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -10,6 +10,7 @@ from typing import Union
 from sqlmodel import Field, SQLModel
 
 from app.core.config import settings
+from app.core.time import utcnow
 
 __all__ = ["Alert", "AlertSequence", "Camera", "Detection", "Organization", "Pose", "Sequence", "User"]
 
@@ -41,7 +42,7 @@ class User(SQLModel, table=True):
     # Allow sign-up/in via login + password
     login: str = Field(..., index=True, unique=True, min_length=2, max_length=50, nullable=False)
     hashed_password: str = Field(..., min_length=5, max_length=70, nullable=False)
-    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    created_at: datetime = Field(default_factory=utcnow, nullable=False)
 
 
 class Camera(SQLModel, table=True):
@@ -56,7 +57,7 @@ class Camera(SQLModel, table=True):
     is_trustable: bool = True
     last_active_at: Union[datetime, None] = None
     last_image: Union[str, None] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    created_at: datetime = Field(default_factory=utcnow, nullable=False)
     # Device connection — never exposed in public API responses
     camera_ip: Union[str, None] = Field(default=None, nullable=True)
     device_ip: Union[str, None] = Field(default=None, nullable=True)
@@ -76,7 +77,7 @@ class OcclusionMask(SQLModel, table=True):
     id: int = Field(default=None, primary_key=True)
     pose_id: int = Field(..., foreign_key="poses.id", nullable=False)
     mask: str = Field(..., min_length=2, max_length=255, nullable=False)
-    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    created_at: datetime = Field(default_factory=utcnow, nullable=False)
 
 
 class Detection(SQLModel, table=True):
@@ -88,7 +89,7 @@ class Detection(SQLModel, table=True):
     bucket_key: str
     bbox: str = Field(..., min_length=2, max_length=settings.MAX_BBOX_STR_LENGTH_SINGLE, nullable=False)
     others_bboxes: Union[str, None] = Field(default=None, max_length=settings.MAX_BBOX_STR_LENGTH_OTHERS, nullable=True)
-    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    created_at: datetime = Field(default_factory=utcnow, nullable=False)
 
 
 class Sequence(SQLModel, table=True):

--- a/src/app/schemas/cameras.py
+++ b/src/app/schemas/cameras.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from app.core.time import utcnow
 from app.schemas.poses import PoseReadWithoutImgInfo
 
 __all__ = [
@@ -16,7 +17,7 @@ __all__ = [
 
 
 class LastActive(BaseModel):
-    last_active_at: datetime = Field(default_factory=datetime.utcnow)
+    last_active_at: datetime = Field(default_factory=utcnow)
 
 
 class LastImage(LastActive):

--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -5,7 +5,6 @@
 
 import hashlib
 import logging
-from datetime import datetime
 from mimetypes import guess_extension
 from typing import Any, Dict, Union
 
@@ -15,6 +14,7 @@ from botocore.exceptions import ClientError, EndpointConnectionError, NoCredenti
 from fastapi import HTTPException, UploadFile, status
 
 from app.core.config import settings
+from app.core.time import utcnow
 
 __all__ = ["s3_service", "upload_file"]
 
@@ -166,7 +166,7 @@ async def upload_file(file: UploadFile, organization_id: int, camera_id: int) ->
     # guess_extension will return none if this fails
     extension = guess_extension(magic.from_buffer(file.file.read(), mime=True)) or ""
     # Concatenate timestamp & hash
-    bucket_key = f"{camera_id}-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}-{sha_hash[:8]}{extension}"
+    bucket_key = f"{camera_id}-{utcnow().strftime('%Y%m%d%H%M%S')}-{sha_hash[:8]}{extension}"
     # Reset byte position of the file (cf. https://fastapi.tiangolo.com/tutorial/request-files/#uploadfile)
     await file.seek(0)
     bucket_name = s3_service.resolve_bucket_name(organization_id)

--- a/src/tests/endpoints/test_alerts.py
+++ b/src/tests/endpoints/test_alerts.py
@@ -3,7 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, List, Tuple, cast
 
 import pandas as pd
@@ -13,6 +13,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
+from app.core.time import utcnow
 from app.models import Alert, AlertSequence, AnnotationType, Camera, Organization, Pose, Sequence
 from app.services.overlap import compute_overlap
 
@@ -20,7 +21,7 @@ from app.services.overlap import compute_overlap
 async def _create_alert_with_sequences(
     session: AsyncSession, org_id: int, camera_id: int, lat: float, lon: float
 ) -> Tuple[Alert, List[int]]:
-    now = datetime.utcnow()
+    now = utcnow()
     seq_payloads = [
         {
             "camera_id": camera_id,

--- a/src/tests/endpoints/test_cameras.py
+++ b/src/tests/endpoints/test_cameras.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any, Dict, List, Union
 from unittest.mock import AsyncMock, patch
 
@@ -7,6 +6,7 @@ from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import get_camera_crud, get_jwt
+from app.core.time import utcnow
 from app.main import app
 from app.models import Camera, Role
 from app.schemas.login import TokenPayload
@@ -631,7 +631,7 @@ async def test_update_camera_trustable(
         is_trustable=False,
         last_active_at=None,
         last_image=None,
-        created_at=datetime.utcnow(),
+        created_at=utcnow(),
     )
     mock_cameras = AsyncMock()
     mock_cameras.update = AsyncMock(return_value=updated_camera)

--- a/src/tests/endpoints/test_detections.py
+++ b/src/tests/endpoints/test_detections.py
@@ -2,7 +2,7 @@ import asyncio
 import io
 from ast import literal_eval
 from collections import Counter
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, Dict, List, Union
 
 import pytest  # type: ignore
@@ -27,6 +27,7 @@ from app.api.api_v1.endpoints.detections import (
     create_detection,
 )
 from app.core.config import settings
+from app.core.time import utcnow
 from app.crud import AlertCRUD, CameraCRUD, DetectionCRUD, OrganizationCRUD, PoseCRUD, SequenceCRUD, WebhookCRUD
 from app.models import Alert, AlertSequence, Camera, Detection, Organization, Pose, Role, Sequence, Webhook
 from app.schemas.login import TokenPayload
@@ -225,7 +226,7 @@ async def test_create_detection_rejects_empty_bbox_strings(
 @pytest.mark.asyncio
 async def test_get_last_bbox_for_sequence_returns_latest(detection_session: AsyncSession):
     detections = DetectionCRUD(detection_session)
-    now = datetime.utcnow()
+    now = utcnow()
     camera_id = pytest.camera_table[0]["id"]
 
     pose = Pose(camera_id=camera_id, azimuth=50.0)
@@ -273,7 +274,7 @@ async def test_get_last_bbox_for_sequence_returns_latest(detection_session: Asyn
 @pytest.mark.asyncio
 async def test_get_last_bbox_for_sequence_returns_none_without_detections(detection_session: AsyncSession):
     detections = DetectionCRUD(detection_session)
-    now = datetime.utcnow()
+    now = utcnow()
     camera_id = pytest.camera_table[0]["id"]
     pose = Pose(camera_id=camera_id, azimuth=60.0)
     detection_session.add(pose)
@@ -300,7 +301,7 @@ async def test_get_last_bbox_for_sequence_returns_none_without_detections(detect
 @pytest.mark.asyncio
 async def test_get_last_bbox_for_sequence_returns_none_for_invalid_bbox(detection_session: AsyncSession):
     detections = DetectionCRUD(detection_session)
-    now = datetime.utcnow()
+    now = utcnow()
     camera_id = pytest.camera_table[0]["id"]
     pose = Pose(camera_id=camera_id, azimuth=70.0)
     detection_session.add(pose)
@@ -349,7 +350,7 @@ async def test_get_camera_by_id_adds_missing_sequence_camera(detection_session: 
 @pytest.mark.asyncio
 async def test_get_recent_sequences_appends_missing_sequence(detection_session: AsyncSession):
     seq_crud = SequenceCRUD(detection_session)
-    now = datetime.utcnow()
+    now = utcnow()
     camera_id = pytest.camera_table[0]["id"]
     pose_id = pytest.pose_table[0]["id"]
     old_seq = Sequence(
@@ -381,7 +382,7 @@ async def test_get_recent_sequences_appends_missing_sequence(detection_session: 
 
 @pytest.mark.asyncio
 async def test_build_overlap_records_skips_missing_cone_data(detection_session: AsyncSession):
-    now = datetime.utcnow()
+    now = utcnow()
     camera = await detection_session.get(Camera, pytest.camera_table[0]["id"])
     assert camera is not None
     seq = Sequence(
@@ -402,7 +403,7 @@ def test_resolve_groups_and_locations_empty_records_returns_none():
 
 
 def test_resolve_groups_and_locations_no_match_returns_none():
-    now = datetime.utcnow()
+    now = utcnow()
     records = [
         {
             "id": 1,
@@ -426,7 +427,7 @@ async def test_fetch_alert_mapping_empty(detection_session: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_fetch_alert_mapping_returns_mapping(detection_session: AsyncSession):
-    now = datetime.utcnow()
+    now = utcnow()
     alert = Alert(organization_id=1, lat=1.0, lon=1.0, started_at=now, last_seen_at=now)
     detection_session.add(alert)
     await detection_session.commit()
@@ -445,7 +446,7 @@ async def test_fetch_alert_mapping_returns_mapping(detection_session: AsyncSessi
 @pytest.mark.asyncio
 async def test_maybe_update_alert_updates_fields(detection_session: AsyncSession):
     alert_crud = AlertCRUD(detection_session)
-    now = datetime.utcnow()
+    now = utcnow()
     alert = Alert(organization_id=1, lat=None, lon=None, started_at=now, last_seen_at=now)
     detection_session.add(alert)
     await detection_session.commit()
@@ -466,7 +467,7 @@ async def test_maybe_update_alert_updates_fields(detection_session: AsyncSession
 @pytest.mark.asyncio
 async def test_get_or_create_alert_id_reuses_existing_alert(detection_session: AsyncSession):
     alert_crud = AlertCRUD(detection_session)
-    now = datetime.utcnow()
+    now = utcnow()
     alert1 = Alert(organization_id=1, lat=None, lon=None, started_at=now, last_seen_at=now)
     alert2 = Alert(organization_id=1, lat=None, lon=None, started_at=now, last_seen_at=now)
     detection_session.add(alert1)
@@ -506,7 +507,7 @@ async def test_attach_sequence_to_alert_returns_without_overlap_records(detectio
     cam_crud = CameraCRUD(detection_session)
     camera = await detection_session.get(Camera, pytest.camera_table[0]["id"])
     assert camera is not None
-    now = datetime.utcnow()
+    now = utcnow()
     sequence = Sequence(
         camera_id=camera.id,
         pose_id=None,
@@ -1037,7 +1038,7 @@ async def test_attach_sequence_to_alert_creates_alert(detection_session: AsyncSe
     seq_crud = SequenceCRUD(detection_session)
     alert_crud = AlertCRUD(detection_session)
     cam_crud = CameraCRUD(detection_session)
-    now = datetime.utcnow()
+    now = utcnow()
     cam1 = await detection_session.get(Camera, 1)
     assert cam1 is not None
     cam2 = Camera(

--- a/src/tests/endpoints/test_sequences.py
+++ b/src/tests/endpoints/test_sequences.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, Dict, List, Union
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,6 +9,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.api_v1.endpoints.sequences import label_sequence
+from app.core.time import utcnow
 from app.models import Alert, AlertSequence, AnnotationType, Camera, Detection, Pose, Sequence, UserRole
 from app.schemas.login import TokenPayload
 from app.schemas.sequences import SequenceLabel
@@ -233,7 +234,7 @@ async def test_sequence_label_updates_alerts(async_client: AsyncClient, detectio
     # Create a sequence linked to a camera and an alert
     camera = await detection_session.get(Camera, 1)
     assert camera is not None
-    now = datetime.utcnow()
+    now = utcnow()
     seq1 = Sequence(
         camera_id=camera.id,
         pose_id=None,
@@ -320,7 +321,7 @@ async def test_sequence_label_updates_alerts(async_client: AsyncClient, detectio
 async def test_delete_sequence_cleans_alerts_and_detections(async_client: AsyncClient, detection_session: AsyncSession):
     camera = await detection_session.get(Camera, 1)
     assert camera is not None
-    now = datetime.utcnow()
+    now = utcnow()
     pose = Pose(camera_id=camera.id, azimuth=45.0)
     detection_session.add(pose)
     await detection_session.commit()
@@ -391,7 +392,7 @@ async def test_delete_sequence_cleans_alerts_and_detections(async_client: AsyncC
 async def test_delete_sequence_refreshes_alert(async_client: AsyncClient, detection_session: AsyncSession):
     camera = await detection_session.get(Camera, 1)
     assert camera is not None
-    now = datetime.utcnow()
+    now = utcnow()
     seq1 = Sequence(
         camera_id=camera.id,
         pose_id=None,
@@ -466,8 +467,8 @@ async def test_unit_label_sequence_as_other_smoke_refreshes_alert(
         id=1,
         camera_id=1,
         is_wildfire=None,
-        started_at=datetime.utcnow(),
-        last_seen_at=datetime.utcnow(),
+        started_at=utcnow(),
+        last_seen_at=utcnow(),
     )
     mock_camera = Camera(id=1, organization_id=1)
 

--- a/src/tests/services/test_overlap.py
+++ b/src/tests/services/test_overlap.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 
+from app.core.time import utcnow
 from app.services.overlap import compute_overlap
 
 
@@ -35,7 +36,7 @@ def _make_sequence(
 
 
 def test_compute_overlap_groups_and_locations() -> None:
-    now = datetime.utcnow()
+    now = utcnow()
     seqs = [
         _make_sequence(1, 48.3792, 2.8208, 276.5, 3.0, now - timedelta(seconds=9), now - timedelta(seconds=1)),
         _make_sequence(2, 48.2605, 2.7064, 8.3, 0.8, now - timedelta(seconds=8), now - timedelta(seconds=2)),
@@ -56,7 +57,7 @@ def test_compute_overlap_groups_and_locations() -> None:
 
 
 def test_compute_overlap_skips_same_pose_pair() -> None:
-    now = datetime.utcnow()
+    now = utcnow()
     # Two sequences from the exact same pose with time and angular overlap
     # share the same apex, so they must not be triangulated together.
     seqs = [

--- a/src/tests/test_security.py
+++ b/src/tests/test_security.py
@@ -5,6 +5,7 @@ import pytest
 
 from app.core.config import settings
 from app.core.security import create_access_token, hash_password, verify_password
+from app.core.time import utcnow
 
 
 def test_hash_password():
@@ -34,7 +35,7 @@ def test_verify_password():
 )
 def test_create_access_token(content, expires_minutes, expected_delta):
     payload = create_access_token(content, expires_minutes)
-    after = datetime.utcnow()
+    after = utcnow()
     assert isinstance(payload, str)
     decoded_data = jwt.decode(payload, settings.JWT_SECRET, algorithms=[settings.JWT_ALGORITHM])
     # Verify data integrity

--- a/src/tests/test_time.py
+++ b/src/tests/test_time.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timezone
+
+from app.core.time import utcnow
+
+
+def test_utcnow_returns_naive_datetime():
+    result = utcnow()
+    assert isinstance(result, datetime)
+    assert result.tzinfo is None
+
+
+def test_utcnow_matches_wall_clock():
+    before = datetime.now(timezone.utc).replace(tzinfo=None)
+    result = utcnow()
+    after = datetime.now(timezone.utc).replace(tzinfo=None)
+    assert before <= result <= after
+
+
+def test_utcnow_is_monotonic_across_quick_calls():
+    first = utcnow()
+    second = utcnow()
+    assert first <= second


### PR DESCRIPTION
## Summary
- Python 3.12 deprecated `datetime.utcnow()` and 3.13 will remove it. Swapped every call site in `src/` for a new helper `app.core.time.utcnow()`.
- Helper returns a naive UTC datetime (`datetime.now(timezone.utc).replace(tzinfo=None)`). Keeps semantics identical to what we had, so no migration is needed right now.
- Also cleaned up the `datetime` imports that became unused after the swap (ruff auto-fix).

## Context
I picked this up as a ramp-up exercise. I haven't touched this repo in a while and wanted a small, mechanical change to get back into the layout. Figured I'd turn it into a real PR since the deprecation is going to bite us on Python 3.13 anyway.

## Why not go fully tz-aware
All our `datetime` columns map to `TIMESTAMP WITHOUT TIME ZONE`, and several handlers (detection sequence-relaxation, 24h windows in sequences/alerts, camera `last_active_at`) compare DB-returned naive values against `utcnow() - timedelta(...)`. Going tz-aware here without a matching Alembic migration would start throwing `can't compare offset-naive and offset-aware datetimes`. Worth doing eventually, but I'd rather keep this PR just about the deprecation.

## Out of scope
- `datetime.utcfromtimestamp` in `tests/test_security.py:43`: same class of deprecation, will do in a follow-up.
- `client/` package untouched (published separately).

## Test plan
- [x] `ruff format --check .` and `ruff check .` clean (one pre-existing `RUF069` in `client/tests/test_client.py` is unrelated)
- [x] `src/tests/test_time.py` passes (3/3) locally
- [ ] `make test` in CI
- [ ] Sanity: login + inspect JWT `exp`, create a detection and verify `created_at` is set