### PR TITLE
fix: normalize sequence azimuth to [0, 360) range

### DIFF
--- a/src/app/services/cones.py
+++ b/src/app/services/cones.py
@@ -12,6 +12,6 @@ def resolve_cone(azimuth: float, bboxes_str: str, aov: float) -> Tuple[float, fl
     """Compute the cone azimuth and opening angle using the most confident bbox."""
     bboxes = literal_eval(bboxes_str)
     xmin, _, xmax, _, _ = max(bboxes, key=itemgetter(2))
-    cone_azimuth = round(azimuth + aov * ((xmin + xmax) / 2 - 0.5), 1)
+    cone_azimuth = round((azimuth + aov * ((xmin + xmax) / 2 - 0.5)) % 360, 1)
     cone_angle = round(aov * (xmax - xmin), 1)
     return cone_azimuth, cone_angle

--- a/src/app/services/cones.py
+++ b/src/app/services/cones.py
@@ -12,6 +12,6 @@ def resolve_cone(azimuth: float, bboxes_str: str, aov: float) -> Tuple[float, fl
     """Compute the cone azimuth and opening angle using the most confident bbox."""
     bboxes = literal_eval(bboxes_str)
     xmin, _, xmax, _, _ = max(bboxes, key=itemgetter(2))
-    cone_azimuth = round((azimuth + aov * ((xmin + xmax) / 2 - 0.5)) % 360, 1)
+    cone_azimuth = round(azimuth + aov * ((xmin + xmax) / 2 - 0.5), 1) % 360
     cone_angle = round(aov * (xmax - xmin), 1)
     return cone_azimuth, cone_angle

--- a/src/tests/services/test_cones.py
+++ b/src/tests/services/test_cones.py
@@ -26,10 +26,3 @@ def test_resolve_cone_normalizes_azimuth(azimuth, bbox, aov, expected_azimuth, e
     assert 0.0 <= cone_azimuth < 360.0
     assert cone_azimuth == expected_azimuth
     assert cone_angle == expected_angle
-
-
-def test_resolve_cone_picks_most_confident_bbox():
-    bboxes = "[(0.0, 0.0, 0.2, 1.0, 0.1), (0.8, 0.0, 1.0, 1.0, 0.9)]"
-    cone_azimuth, _ = resolve_cone(180.0, bboxes, 60.0)
-    # The high-confidence bbox is on the right (center 0.9), so cone shifts +24°.
-    assert cone_azimuth == 204.0

--- a/src/tests/services/test_cones.py
+++ b/src/tests/services/test_cones.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2025-2026, Pyronear.
+#
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+import pytest
+
+from app.services.cones import resolve_cone
+
+
+@pytest.mark.parametrize(
+    ("azimuth", "bbox", "aov", "expected_azimuth", "expected_angle"),
+    [
+        # Centered bbox: cone azimuth equals camera azimuth.
+        (180.0, "[(0.4, 0.0, 0.6, 1.0, 0.9)]", 60.0, 180.0, 12.0),
+        # Negative wrap: small camera azimuth + bbox on the left.
+        (5.0, "[(0.0, 0.0, 0.2, 1.0, 0.9)]", 60.0, 341.0, 12.0),
+        # Over-360 wrap: large camera azimuth + bbox on the right.
+        (355.0, "[(0.8, 0.0, 1.0, 1.0, 0.9)]", 60.0, 19.0, 12.0),
+        # Exactly 360 -> normalized to 0.
+        (336.0, "[(0.8, 0.0, 1.0, 1.0, 0.9)]", 60.0, 0.0, 12.0),
+    ],
+)
+def test_resolve_cone_normalizes_azimuth(azimuth, bbox, aov, expected_azimuth, expected_angle):
+    cone_azimuth, cone_angle = resolve_cone(azimuth, bbox, aov)
+    assert 0.0 <= cone_azimuth < 360.0
+    assert cone_azimuth == expected_azimuth
+    assert cone_angle == expected_angle
+
+
+def test_resolve_cone_picks_most_confident_bbox():
+    bboxes = "[(0.0, 0.0, 0.2, 1.0, 0.1), (0.8, 0.0, 1.0, 1.0, 0.9)]"
+    cone_azimuth, _ = resolve_cone(180.0, bboxes, 60.0)
+    # The high-confidence bbox is on the right (center 0.9), so cone shifts +24°.
+    assert cone_azimuth == 204.0


### PR DESCRIPTION
- `resolve_cone` could return negative or >=360 cone azimuths when a bbox sat near a frame edge with a low/high camera azimuth, leaving rows with `sequence_azimuth < 0` in the DB. Observed in production on sdis-77, alert 39412 (https://platform.pyronear.org/alert/39412).
- Apply modulo 360 after the existing rounding so the returned cone azimuth always falls in `[0, 360)`, with the upper bound strictly exclusive.
- Adds a parametrized unit test covering the centered, negative-wrap, over-360-wrap, and exact-360 cases.