### PR TITLE
feat(sequences): add offset query param to detections endpoint

### DIFF
--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -127,6 +127,7 @@ async def fetch_sequence_detections(
     if UserRole.ADMIN not in token_payload.scopes and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
+    # Get the bucket of the camera's organization
     bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(camera.organization_id))
     return [
         DetectionWithUrl(

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -114,6 +114,7 @@ async def get_sequence(
 async def fetch_sequence_detections(
     sequence_id: int = Path(..., gt=0),
     limit: int = Query(10, description="Maximum number of detections to fetch", ge=1, le=100),
+    offset: int = Query(0, description="Number of detections to skip", ge=0),
     desc: bool = Query(True, description="Whether to order the detections by created_at in descending order"),
     cameras: CameraCRUD = Depends(get_camera_crud),
     detections: DetectionCRUD = Depends(get_detection_crud),
@@ -126,7 +127,6 @@ async def fetch_sequence_detections(
     if UserRole.ADMIN not in token_payload.scopes and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
-    # Get the bucket of the camera's organization
     bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(camera.organization_id))
     return [
         DetectionWithUrl(
@@ -138,6 +138,7 @@ async def fetch_sequence_detections(
             order_by="created_at",
             order_desc=desc,
             limit=limit,
+            offset=offset,
         )
     ]
 

--- a/src/tests/endpoints/test_sequences.py
+++ b/src/tests/endpoints/test_sequences.py
@@ -691,6 +691,53 @@ async def test_unit_label_sequence_as_wildfire_smoke_does_not_refresh():
 
 
 @pytest.mark.asyncio
+async def test_fetch_sequence_detections_offset_paging(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """Page 1 (limit=2, offset=0) + page 2 (limit=2, offset=2) covers a 3-detection
+    sequence with no gaps and no duplicates."""
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    # Sequence id 1 has 3 detections in the test fixtures (see existing
+    # test_fetch_sequence_detections expectations).
+    full = await async_client.get("/sequences/1/detections?limit=10&offset=0&desc=false", headers=auth)
+    assert full.status_code == 200
+    full_ids = [det["id"] for det in full.json()]
+    assert len(full_ids) == 3
+
+    page1 = await async_client.get("/sequences/1/detections?limit=2&offset=0&desc=false", headers=auth)
+    page2 = await async_client.get("/sequences/1/detections?limit=2&offset=2&desc=false", headers=auth)
+    assert page1.status_code == 200
+    assert page2.status_code == 200
+
+    page1_ids = [det["id"] for det in page1.json()]
+    page2_ids = [det["id"] for det in page2.json()]
+    assert page1_ids + page2_ids == full_ids
+    assert len(page1_ids) == 2
+    assert len(page2_ids) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_offset_validation(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """Negative offset must be rejected."""
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+    response = await async_client.get("/sequences/1/detections?offset=-1", headers=auth)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_unit_label_sequence_forbidden_for_wrong_org():
     """Verify that an AGENT from a different organization cannot label the sequence."""
     # 1. Mocks Setup


### PR DESCRIPTION
## Summary
- Adds an `offset` query parameter to the `GET /sequences/{sequence_id}/detections` endpoint, wiring through the existing `fetch_all` offset support so callers can page through all detections of a sequence.

## Test plan
- [x] New tests in `src/tests/endpoints/test_sequences.py` cover the offset behavior
- [x] Verify pagination works end-to-end against a populated sequence