### PR TITLE
fix(detections): map each crop to its own bbox

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -349,7 +349,7 @@ class Client:
         media: bytes,
         bboxes: List[Tuple[float, float, float, float, float]],
         pose_id: int,
-        crop: bytes | None = None,
+        crops: List[bytes] | None = None,
     ) -> Response:
         """Notify the detection of a wildfire on the picture taken by a camera.
 
@@ -362,20 +362,24 @@ class Client:
             media: byte data of the picture
             bboxes: list of tuples where each tuple is a relative coordinate in order xmin, ymin, xmax, ymax, conf
             pose_id: pose_id of the detection
-            crop: optional byte data of a cropped picture associated with the detection
+            crops: optional list of cropped pictures, one per bbox (must align with `bboxes`).
+                Each crop frames a single object, so its length must equal that of `bboxes`.
 
         Returns:
             HTTP response
         """
         if not isinstance(bboxes, (list, tuple)) or len(bboxes) == 0 or len(bboxes) > 5:
             raise ValueError("bboxes must be a non-empty list of tuples with a maximum of 5 boxes")
+        if crops is not None and len(crops) != len(bboxes):
+            raise ValueError("crops must have the same length as bboxes")
         data: Dict[str, str] = {
             "bboxes": _dump_bbox_to_json(bboxes),
         }
         data["pose_id"] = str(pose_id)
-        files: Dict[str, Tuple[str, bytes, str]] = {"file": ("frame.jpg", media, "image/jpeg")}
-        if crop is not None:
-            files["crop"] = ("crop.jpg", crop, "image/jpeg")
+        # Use a list of tuples (not a dict) so the repeated "crop" key is preserved per bbox.
+        files: List[Tuple[str, Tuple[str, bytes, str]]] = [("file", ("frame.jpg", media, "image/jpeg"))]
+        if crops is not None:
+            files.extend(("crop", ("crop.jpg", crop, "image/jpeg")) for crop in crops)
         return requests.post(
             urljoin(self._route_prefix, ClientRoute.DETECTIONS_CREATE),
             headers=self.headers,

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -105,6 +105,22 @@ def test_cam_workflow(cam_token, cam_pose_id, mock_img):
     assert response.status_code == 201, response.__dict__
     response = cam_client.create_detection(mock_img, [(0, 0, 1.0, 0.9, 0.5)], pose_id=cam_pose_id)
     assert response.status_code == 201, response.__dict__
+    # One crop per bbox is accepted
+    response = cam_client.create_detection(
+        mock_img,
+        [(0, 0, 1.0, 0.9, 0.5), (0.2, 0.2, 0.7, 0.7, 0.8)],
+        pose_id=cam_pose_id,
+        crops=[mock_img, mock_img],
+    )
+    assert response.status_code == 201, response.__dict__
+    # A crop/bbox count mismatch is rejected client-side
+    with pytest.raises(ValueError, match="crops must have the same length as bboxes"):
+        cam_client.create_detection(
+            mock_img,
+            [(0, 0, 1.0, 0.9, 0.5), (0.2, 0.2, 0.7, 0.7, 0.8)],
+            pose_id=cam_pose_id,
+            crops=[mock_img],
+        )
     return response.json()["id"]
 
 

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -103,17 +103,10 @@ def test_cam_workflow(cam_token, cam_pose_id, mock_img):
         pose_id=cam_pose_id,
     )
     assert response.status_code == 201, response.__dict__
-    response = cam_client.create_detection(mock_img, [(0, 0, 1.0, 0.9, 0.5)], pose_id=cam_pose_id)
+    # One crop per bbox is accepted over HTTP
+    response = cam_client.create_detection(mock_img, [(0, 0, 1.0, 0.9, 0.5)], pose_id=cam_pose_id, crops=[mock_img])
     assert response.status_code == 201, response.__dict__
-    # One crop per bbox is accepted
-    response = cam_client.create_detection(
-        mock_img,
-        [(0, 0, 1.0, 0.9, 0.5), (0.2, 0.2, 0.7, 0.7, 0.8)],
-        pose_id=cam_pose_id,
-        crops=[mock_img, mock_img],
-    )
-    assert response.status_code == 201, response.__dict__
-    # A crop/bbox count mismatch is rejected client-side
+    # A crop/bbox count mismatch is rejected client-side before any request
     with pytest.raises(ValueError, match="crops must have the same length as bboxes"):
         cam_client.create_detection(
             mock_img,

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -359,7 +359,7 @@ async def create_detection(
     ),
     pose_id: int = Form(..., gt=0, description="pose id of the detection"),
     file: UploadFile = File(..., alias="file"),
-    crop_file: Optional[UploadFile] = File(None, alias="crop"),
+    crop_files: Optional[List[UploadFile]] = File(None, alias="crop"),
     detections: DetectionCRUD = Depends(get_detection_crud),
     webhooks: WebhookCRUD = Depends(get_webhook_crud),
     organizations: OrganizationCRUD = Depends(get_organization_crud),
@@ -389,12 +389,21 @@ async def create_detection(
     if not bbox_strings:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid bbox format.")
 
+    # Validate crop/bbox alignment before any S3 upload to avoid orphan objects.
+    # Each crop frames a single object, so there must be exactly one crop per bbox (or none at all).
+    crops = crop_files or []
+    if crops and len(crops) != len(bbox_strings):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Number of crops must match the number of bboxes.",
+        )
+
     # Upload media
     bucket_key = await upload_file(file, token_payload.organization_id, token_payload.sub)
-    crop_bucket_key: Optional[str] = None
-    if crop_file is not None:
-        crop_bucket_key = await upload_file(
-            crop_file, token_payload.organization_id, token_payload.sub, key_prefix="crop_"
+    crop_bucket_keys: List[Optional[str]] = [None] * len(bbox_strings)
+    for idx, crop in enumerate(crops):
+        crop_bucket_keys[idx] = await upload_file(
+            crop, token_payload.organization_id, token_payload.sub, key_prefix="crop_"
         )
 
     created: List[Detection] = []
@@ -409,7 +418,7 @@ async def create_detection(
                 camera_id=token_payload.sub,
                 pose_id=pose_id,
                 bucket_key=bucket_key,
-                crop_bucket_key=crop_bucket_key,
+                crop_bucket_key=crop_bucket_keys[idx],
                 bbox=single_bboxes,
                 others_bboxes=others_bboxes,
             )

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -402,8 +402,10 @@ async def create_detection(
     bucket_key = await upload_file(file, token_payload.organization_id, token_payload.sub)
     crop_bucket_keys: List[Optional[str]] = [None] * len(bbox_strings)
     for idx, crop in enumerate(crops):
+        # Prefix with the bbox index so byte-identical crops in the same request still get
+        # distinct keys; each detection then owns its crop object (safe to delete independently).
         crop_bucket_keys[idx] = await upload_file(
-            crop, token_payload.organization_id, token_payload.sub, key_prefix="crop_"
+            crop, token_payload.organization_id, token_payload.sub, key_prefix=f"crop_{idx}_"
         )
 
     created: List[Detection] = []

--- a/src/tests/endpoints/test_detections.py
+++ b/src/tests/endpoints/test_detections.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import io
 from ast import literal_eval
 from collections import Counter
@@ -879,7 +880,7 @@ async def test_create_detection_sequence_flow_direct(detection_session: AsyncSes
         bboxes="[(0.2,0.2,0.3,0.3,0.9)]",
         pose_id=pose_id,
         file=upload,
-        crop_file=None,
+        crop_files=None,
         detections=detections,
         webhooks=webhooks,
         organizations=organizations,
@@ -917,7 +918,7 @@ async def test_create_detection_sequence_flow_direct(detection_session: AsyncSes
         bboxes="[(0.25,0.25,0.35,0.35,0.9)]",
         pose_id=pose_id,
         file=upload_again,
-        crop_file=None,
+        crop_files=None,
         detections=detections,
         webhooks=webhooks,
         organizations=organizations,
@@ -1391,6 +1392,85 @@ async def test_create_detection_persists_crop_bucket_key(
     det = await detection_session.get(Detection, data["id"])
     assert det is not None
     assert det.crop_bucket_key == data["crop_bucket_key"]
+
+
+@pytest.mark.asyncio
+async def test_create_detection_assigns_distinct_crop_per_bbox(
+    async_client: AsyncClient, detection_session: AsyncSession, mock_img: bytes
+):
+    auth = pytest.get_token(
+        pytest.camera_table[1]["id"],
+        ["camera"],
+        pytest.camera_table[1]["organization_id"],
+    )
+    # Each crop frames a different object, so the two crops carry distinct bytes.
+    crop_0 = mock_img + b"crop-0"
+    crop_1 = mock_img + b"crop-1"
+    payload = {"pose_id": 3, "bboxes": "[(0.6,0.6,0.7,0.7,0.6),(0.2,0.2,0.3,0.3,0.8)]"}
+    response = await async_client.post(
+        "/detections",
+        data=payload,
+        files=[
+            ("file", ("frame.jpg", mock_img, "image/jpeg")),
+            ("crop", ("crop-0.jpg", crop_0, "image/jpeg")),
+            ("crop", ("crop-1.jpg", crop_1, "image/jpeg")),
+        ],
+        headers=auth,
+    )
+    assert response.status_code == 201, response.text
+    bucket_key = response.json()["bucket_key"]
+
+    dets_res = await detection_session.exec(
+        select(Detection)
+        .where(Detection.bucket_key == bucket_key)  # type: ignore[attr-defined]
+        .order_by(Detection.id)  # type: ignore[attr-defined]
+    )
+    dets = dets_res.all()
+    assert len(dets) == 2
+    crop_keys = [det.crop_bucket_key for det in dets]
+    # Every detection gets its own crop, and crops are not shared across detections.
+    assert all(isinstance(key, str) and key.startswith("crop_") for key in crop_keys)
+    assert len(set(crop_keys)) == 2
+    assert all(key != bucket_key for key in crop_keys)
+    # The first bbox maps to the first crop, the second bbox to the second crop.
+    bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(pytest.camera_table[1]["organization_id"]))
+    assert bucket.get_file_metadata(crop_keys[0])["ETag"].replace('"', "") == hashlib.md5(crop_0).hexdigest()  # noqa: S324
+    assert bucket.get_file_metadata(crop_keys[1])["ETag"].replace('"', "") == hashlib.md5(crop_1).hexdigest()  # noqa: S324
+
+
+@pytest.mark.asyncio
+async def test_create_detection_rejects_crop_bbox_count_mismatch(
+    async_client: AsyncClient, detection_session: AsyncSession, mock_img: bytes, monkeypatch
+):
+    upload_calls: List[str] = []
+
+    async def fake_upload_file(  # noqa: RUF029
+        file: UploadFile, organization_id: int, camera_id: int, key_prefix: str = ""
+    ) -> str:
+        upload_calls.append(file.filename or "")
+        return f"{key_prefix}should-never-persist"
+
+    monkeypatch.setattr(detections_api, "upload_file", fake_upload_file)
+
+    auth = pytest.get_token(
+        pytest.camera_table[1]["id"],
+        ["camera"],
+        pytest.camera_table[1]["organization_id"],
+    )
+    payload = {"pose_id": 3, "bboxes": "[(0.6,0.6,0.7,0.7,0.6),(0.2,0.2,0.3,0.3,0.8)]"}
+    response = await async_client.post(
+        "/detections",
+        data=payload,
+        files=[
+            ("file", ("frame.jpg", mock_img, "image/jpeg")),
+            ("crop", ("crop-0.jpg", mock_img, "image/jpeg")),
+        ],
+        headers=auth,
+    )
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == "Number of crops must match the number of bboxes."
+    # Validation runs before any upload, so no orphan S3 objects are created.
+    assert upload_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- `POST /detections/` accepted N bboxes (creating N detections) but a single `crop`, stamping the same `crop_bucket_key` onto every detection — so with multiple objects the one crop was misattributed. It now accepts one crop per bbox, validates the crop count matches the bbox count before any S3 upload (422 otherwise), and maps each crop to its bbox by index.
- The `crop` multipart field name is kept, so callers sending a single crop still work; crop keys are now prefixed by bbox index so byte-identical crops stay independently deletable.
- **Breaking (Python client):** `Client.create_detection`'s `crop: bytes` argument is replaced by `crops: list[bytes]` (raises `ValueError` on a length mismatch). The HTTP API stays backward compatible.
- Tests: multi-bbox/multi-crop alignment, crop/bbox count mismatch (422, no orphan upload), and client-side alignment + mismatch cases.