### PR TITLE
fix(alerts): stop duplicate alerts from same-mast cones and merge overlaps

### DIFF
--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -212,22 +212,24 @@ def _collect_existing_alert_ids(group: Tuple[int, ...], mapping: Dict[int, Set[i
 async def _maybe_update_alert(
     alerts: AlertCRUD,
     target_alert_id: int,
-    location: Tuple[float, float],
+    location: Optional[Tuple[float, float]],
     start_at: datetime,
     last_seen_at: datetime,
 ) -> None:
     current_alert = cast(Alert, await alerts.get(target_alert_id, strict=True))
     new_start_at = min(start_at, current_alert.started_at) if current_alert.started_at else start_at
     new_last_seen = max(last_seen_at, current_alert.last_seen_at) if current_alert.last_seen_at else last_seen_at
+    # A location-less group (e.g. same-mast only) still widens the time bounds but must
+    # not erase a location the alert already has.
+    lat, lon = location if location is not None else (current_alert.lat, current_alert.lon)
     if (
-        current_alert.lat is None
-        or current_alert.lon is None
+        (location is not None and (current_alert.lat is None or current_alert.lon is None))
         or (current_alert.started_at is None or new_start_at < current_alert.started_at)
         or (current_alert.last_seen_at is None or new_last_seen > current_alert.last_seen_at)
     ):
         await alerts.update(
             target_alert_id,
-            AlertUpdate(lat=location[0], lon=location[1], started_at=new_start_at, last_seen_at=new_last_seen),
+            AlertUpdate(lat=lat, lon=lon, started_at=new_start_at, last_seen_at=new_last_seen),
         )
 
 
@@ -249,7 +251,12 @@ async def _filter_candidate_alert_ids(
     return kept
 
 
-async def _merge_alerts(target_alert_id: int, absorbed_ids: Set[int], alerts: AlertCRUD) -> None:
+async def _merge_alerts(
+    target_alert_id: int,
+    absorbed_ids: Set[int],
+    alerts: AlertCRUD,
+    queued_links: Optional[List[AlertSequence]] = None,
+) -> None:
     """Absorb duplicate alerts into the target: relink their sequences, widen the target's
     time bounds, inherit a location if the target has none, then delete the absorbed rows."""
     session = alerts.session
@@ -261,6 +268,9 @@ async def _merge_alerts(target_alert_id: int, absorbed_ids: Set[int], alerts: Al
     )
     links = (await session.exec(links_stmt)).all()
     target_seq_ids = {link.sequence_id for link in links if link.alert_id == target_alert_id}
+    # Links to the target queued by the caller but not committed yet count as existing,
+    # otherwise relinking would insert the same composite key twice.
+    target_seq_ids |= {link.sequence_id for link in queued_links or [] if link.alert_id == target_alert_id}
     for link in links:
         if link.alert_id == target_alert_id or link.sequence_id in target_seq_ids:
             continue
@@ -318,6 +328,7 @@ async def _get_or_create_alert_id(
     start_at: datetime,
     last_seen_at: datetime,
     alerts: AlertCRUD,
+    queued_links: Optional[List[AlertSequence]] = None,
 ) -> Tuple[int, Set[int]]:
     """Pick the alert a group belongs to, merging duplicates when the group's sequences
     span several compatible alerts. Returns the target alert id and the absorbed ids."""
@@ -326,9 +337,8 @@ async def _get_or_create_alert_id(
         target_alert_id = min(candidates)
         absorbed_ids = set(candidates) - {target_alert_id}
         if absorbed_ids:
-            await _merge_alerts(target_alert_id, absorbed_ids, alerts)
-        if isinstance(location, tuple):
-            await _maybe_update_alert(alerts, target_alert_id, location, start_at, last_seen_at)
+            await _merge_alerts(target_alert_id, absorbed_ids, alerts, queued_links)
+        await _maybe_update_alert(alerts, target_alert_id, location, start_at, last_seen_at)
         return target_alert_id, absorbed_ids
     alert = await alerts.create(
         AlertCreate(
@@ -398,6 +408,7 @@ async def _attach_sequence_to_alert(
             start_at,
             last_seen_at,
             alerts,
+            queued_links=to_link,
         )
         if absorbed_ids:
             _rewrite_after_merge(mapping, to_link, absorbed_ids, target_alert_id)

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -80,12 +80,15 @@ def _parse_bbox(bbox_str: str) -> Tuple[float, float, float, float, float]:
 def _bboxes_overlap(
     left: Tuple[float, float, float, float, float],
     right: Tuple[float, float, float, float, float],
+    tolerance: float = 0.0,
 ) -> bool:
+    # A negative intersection is a gap: allow up to `tolerance` (relative coords) per axis
+    # so a plume whose bbox drifts between frames still matches its sequence.
     lx_min, ly_min, lx_max, ly_max, _ = left
     rx_min, ry_min, rx_max, ry_max, _ = right
     inter_w = min(lx_max, rx_max) - max(lx_min, rx_min)
     inter_h = min(ly_max, ry_max) - max(ly_min, ry_min)
-    return inter_w > 0 and inter_h > 0
+    return inter_w > -tolerance and inter_h > -tolerance
 
 
 async def _get_last_bbox_for_sequence(
@@ -435,7 +438,7 @@ async def create_detection(
             if seq.id is None:
                 continue
             last_bbox = await _get_last_bbox_for_sequence(detections, seq.id)
-            if last_bbox is not None and _bboxes_overlap(last_bbox, det_bbox):
+            if last_bbox is not None and _bboxes_overlap(last_bbox, det_bbox, settings.SEQUENCE_BBOX_TOLERANCE):
                 matched_sequence = seq
                 break
 
@@ -469,7 +472,7 @@ async def create_detection(
                 if not cand_bbox_strs:
                     continue
                 cand_bbox = _parse_bbox(cand_bbox_strs[0])
-                if _bboxes_overlap(cand_bbox, det_bbox):
+                if _bboxes_overlap(cand_bbox, det_bbox, settings.SEQUENCE_BBOX_TOLERANCE):
                     overlapping_dets.append(cand)
 
             if len(overlapping_dets) >= settings.SEQUENCE_MIN_INTERVAL_DETS:

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 
+import itertools
 import logging
 import re
 from ast import literal_eval
@@ -321,6 +322,23 @@ def _rewrite_after_merge(
             alert_ids.add(target_alert_id)
 
 
+async def _candidates_are_one_event(candidates: Set[int], alerts: AlertCRUD) -> bool:
+    """Whether every located candidate sits within the merge radius of the others.
+
+    A location-less group passes the distance filter against every candidate, so on its
+    own it says nothing about which distant alerts are the same event — e.g. two cameras
+    on one mast can each watch a different fire along the same bearing."""
+    located = []
+    for aid in candidates:
+        alert = cast(Alert, await alerts.get(aid, strict=True))
+        if alert.lat is not None and alert.lon is not None:
+            located.append((alert.lat, alert.lon))
+    return all(
+        haversine_km(lat1, lon1, lat2, lon2) <= settings.ALERT_MERGE_MAX_DISTANCE_KM
+        for (lat1, lon1), (lat2, lon2) in itertools.combinations(located, 2)
+    )
+
+
 async def _get_or_create_alert_id(
     existing_alert_ids: Set[int],
     location: Optional[Tuple[float, float]],
@@ -336,6 +354,10 @@ async def _get_or_create_alert_id(
     if candidates:
         target_alert_id = min(candidates)
         absorbed_ids = set(candidates) - {target_alert_id}
+        if absorbed_ids and location is None and not await _candidates_are_one_event(candidates, alerts):
+            # Without a triangulated location, a group bridging distant alerts is not
+            # merge evidence: link to the oldest one and leave the others alive.
+            absorbed_ids = set()
         if absorbed_ids:
             await _merge_alerts(target_alert_id, absorbed_ids, alerts, queued_links)
         await _maybe_update_alert(alerts, target_alert_id, location, start_at, last_seen_at)

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -22,7 +22,7 @@ from fastapi import (
     UploadFile,
     status,
 )
-from sqlmodel import select
+from sqlmodel import delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import (
@@ -249,6 +249,68 @@ async def _filter_candidate_alert_ids(
     return kept
 
 
+async def _merge_alerts(target_alert_id: int, absorbed_ids: Set[int], alerts: AlertCRUD) -> None:
+    """Absorb duplicate alerts into the target: relink their sequences, widen the target's
+    time bounds, inherit a location if the target has none, then delete the absorbed rows."""
+    session = alerts.session
+    target = cast(Alert, await alerts.get(target_alert_id, strict=True))
+    absorbed = sorted(await alerts.get_in(list(absorbed_ids), "id"), key=lambda a: a.id)
+
+    links_stmt: Any = select(AlertSequence).where(
+        AlertSequence.alert_id.in_([target_alert_id, *absorbed_ids])  # type: ignore[attr-defined]
+    )
+    links = (await session.exec(links_stmt)).all()
+    target_seq_ids = {link.sequence_id for link in links if link.alert_id == target_alert_id}
+    for link in links:
+        if link.alert_id == target_alert_id or link.sequence_id in target_seq_ids:
+            continue
+        target_seq_ids.add(link.sequence_id)
+        session.add(AlertSequence(alert_id=target_alert_id, sequence_id=link.sequence_id))
+
+    target.started_at = min([target.started_at, *[a.started_at for a in absorbed]])
+    target.last_seen_at = max([target.last_seen_at, *[a.last_seen_at for a in absorbed]])
+    if target.lat is None or target.lon is None:
+        located = next((a for a in absorbed if a.lat is not None and a.lon is not None), None)
+        if located is not None:
+            target.lat = located.lat
+            target.lon = located.lon
+    session.add(target)
+
+    delete_links_stmt: Any = delete(AlertSequence).where(cast(Any, AlertSequence.alert_id).in_(list(absorbed_ids)))
+    await session.exec(delete_links_stmt)
+    delete_alerts_stmt: Any = delete(Alert).where(cast(Any, Alert.id).in_(list(absorbed_ids)))
+    await session.exec(delete_alerts_stmt)
+    await session.commit()
+
+
+def _rewrite_after_merge(
+    mapping: Dict[int, Set[int]],
+    to_link: List[AlertSequence],
+    absorbed_ids: Set[int],
+    target_alert_id: int,
+) -> None:
+    """Point in-memory attach state at the merge survivor so later groups neither reference
+    deleted alerts nor duplicate links the merge already created."""
+    kept: List[AlertSequence] = []
+    seen: Set[Tuple[int, int]] = set()
+    for link in to_link:
+        if link.alert_id in absorbed_ids:
+            if target_alert_id in mapping.get(link.sequence_id, set()):
+                # The merge relinked this sequence (or a link is already queued): drop it.
+                continue
+            link.alert_id = target_alert_id
+        pair = (link.alert_id, link.sequence_id)
+        if pair in seen:
+            continue
+        seen.add(pair)
+        kept.append(link)
+    to_link[:] = kept
+    for alert_ids in mapping.values():
+        if alert_ids & absorbed_ids:
+            alert_ids -= absorbed_ids
+            alert_ids.add(target_alert_id)
+
+
 async def _get_or_create_alert_id(
     existing_alert_ids: Set[int],
     location: Optional[Tuple[float, float]],
@@ -256,13 +318,18 @@ async def _get_or_create_alert_id(
     start_at: datetime,
     last_seen_at: datetime,
     alerts: AlertCRUD,
-) -> int:
+) -> Tuple[int, Set[int]]:
+    """Pick the alert a group belongs to, merging duplicates when the group's sequences
+    span several compatible alerts. Returns the target alert id and the absorbed ids."""
     candidates = await _filter_candidate_alert_ids(existing_alert_ids, location, alerts)
     if candidates:
         target_alert_id = min(candidates)
+        absorbed_ids = set(candidates) - {target_alert_id}
+        if absorbed_ids:
+            await _merge_alerts(target_alert_id, absorbed_ids, alerts)
         if isinstance(location, tuple):
             await _maybe_update_alert(alerts, target_alert_id, location, start_at, last_seen_at)
-        return target_alert_id
+        return target_alert_id, absorbed_ids
     alert = await alerts.create(
         AlertCreate(
             organization_id=organization_id,
@@ -272,7 +339,7 @@ async def _get_or_create_alert_id(
             last_seen_at=last_seen_at,
         )
     )
-    return alert.id
+    return alert.id, set()
 
 
 def _build_links_for_group(
@@ -324,7 +391,7 @@ async def _attach_sequence_to_alert(
         location = group_locations.get(g)
         start_at, last_seen_at = _group_time_bounds(g, seq_by_id)
         existing_alert_ids = _collect_existing_alert_ids(g, mapping)
-        target_alert_id = await _get_or_create_alert_id(
+        target_alert_id, absorbed_ids = await _get_or_create_alert_id(
             existing_alert_ids,
             location,
             camera.organization_id,
@@ -332,6 +399,8 @@ async def _attach_sequence_to_alert(
             last_seen_at,
             alerts,
         )
+        if absorbed_ids:
+            _rewrite_after_merge(mapping, to_link, absorbed_ids, target_alert_id)
         if int(sequence_.id) in g:
             alert_id = target_alert_id
         to_link.extend(_build_links_for_group(g, target_alert_id, mapping))

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -70,7 +70,11 @@ class Settings(BaseSettings):
     SEQUENCE_RELAXATION_SECONDS: int = int(os.environ.get("SEQUENCE_RELAXATION_SECONDS") or 120 * 60)
     SEQUENCE_MIN_INTERVAL_DETS: int = int(os.environ.get("SEQUENCE_MIN_INTERVAL_DETS") or 3)
     SEQUENCE_MIN_INTERVAL_SECONDS: int = int(os.environ.get("SEQUENCE_MIN_INTERVAL_SECONDS") or 5 * 60)
+    # Max gap (relative image coords) between two bboxes still considered the same smoke plume.
+    SEQUENCE_BBOX_TOLERANCE: float = float(os.environ.get("SEQUENCE_BBOX_TOLERANCE") or 0.05)
     TRIANGULATION_RELAXATION_SECONDS: int = int(os.environ.get("TRIANGULATION_RELAXATION_SECONDS") or 30 * 60)
+    # Cameras closer than this share an apex: their cone intersection cannot localize smoke.
+    TRIANGULATION_MIN_APEX_DISTANCE_KM: float = float(os.environ.get("TRIANGULATION_MIN_APEX_DISTANCE_KM") or 0.1)
     ALERT_MERGE_MAX_DISTANCE_KM: float = float(os.environ.get("ALERT_MERGE_MAX_DISTANCE_KM") or 2.0)
 
     # Notifications

--- a/src/app/services/overlap.py
+++ b/src/app/services/overlap.py
@@ -174,11 +174,32 @@ def get_projected_cone(row: pd.Series, r_km: float, r_min_km: float) -> Polygon:
     return _project_polygon_from_4326_to_3857(poly)
 
 
+def _build_apex_by_id(df_valid: pd.DataFrame) -> Dict[int, Tuple[float, float]]:
+    return {int(row["id"]): (float(row["lat"]), float(row["lon"])) for _, row in df_valid.iterrows()}
+
+
+def _is_degenerate_pair(
+    apex_by_id: Dict[int, Tuple[float, float]],
+    id1: int,
+    id2: int,
+    min_apex_km: float,
+) -> bool:
+    """Cameras (nearly) sharing an apex see the same event but their cone intersection
+    carries no range information: such pairs must not contribute to any location math."""
+    apex1 = apex_by_id.get(id1)
+    apex2 = apex_by_id.get(id2)
+    if apex1 is None or apex2 is None:
+        return False
+    return haversine_km(apex1[0], apex1[1], apex2[0], apex2[1]) < min_apex_km
+
+
 def _compute_localized_groups_from_cliques(
     df: pd.DataFrame,
     cliques: List[Tuple[int, ...]],
     projected_cones: Dict[int, Polygon],
     max_dist_km: float,
+    apex_by_id: Dict[int, Tuple[float, float]],
+    min_apex_km: float,
 ) -> List[Tuple[int, ...]]:
     """
     From maximal cliques, split each clique into localized groups.
@@ -187,7 +208,8 @@ def _compute_localized_groups_from_cliques(
     -----
     For groups with size at least three, keep the whole group if the maximum distance
     among all pair intersection barycenters is within max_dist_km. Otherwise split the
-    clique into all two by two pairs.
+    clique into all two by two pairs. Pairs of cameras closer than min_apex_km are
+    degenerate (no triangulation) and are ignored when collecting barycenters.
 
     Parameters
     ----------
@@ -199,6 +221,10 @@ def _compute_localized_groups_from_cliques(
         Mapping from sequence id to its cone geometry in EPSG:3857.
     max_dist_km : float
         Maximum allowed distance between pair barycenters to keep a group.
+    apex_by_id : dict[int, tuple[float, float]]
+        Mapping from sequence id to its camera (lat, lon).
+    min_apex_km : float
+        Minimum apex distance for a pair to count as a triangulation.
 
     Returns
     -------
@@ -217,7 +243,11 @@ def _compute_localized_groups_from_cliques(
 
         # Collect pairwise intersection barycenters
         pair_barys: List[Tuple[float, float]] = []
+        has_triangulable_pair = False
         for i, j in itertools.combinations(group, 2):
+            if _is_degenerate_pair(apex_by_id, i, j, min_apex_km):
+                continue
+            has_triangulable_pair = True
             gi = projected_cones.get(i)
             gj = projected_cones.get(j)
             if gi is None or gj is None:
@@ -228,6 +258,10 @@ def _compute_localized_groups_from_cliques(
             pair_barys.append(get_centroid_latlon(inter))
 
         if len(group) == 2:
+            return [group]
+
+        if not has_triangulable_pair:
+            # Every pair shares an apex (multi-camera mast): one event, nothing to localize
             return [group]
 
         if len(pair_barys) < 2:
@@ -297,25 +331,19 @@ def _find_overlapping_pairs(
         time_relaxation_seconds = settings.TRIANGULATION_RELAXATION_SECONDS
     ids = df_valid["id"].astype(int).tolist()
     cols = ["started_at", "last_seen_at"]
-    has_pose = "pose_id" in df_valid.columns
-    if has_pose:
-        cols = [*cols, "pose_id"]
     rows_by_id: Dict[int, Dict[str, Any]] = df_valid.set_index("id")[cols].to_dict("index")
     # `_attach_sequence_to_alert` runs when the validation worker validates a sequence,
     # which can be early in its life (a few frames in) while prior sequences' windows
     # haven't been bumped yet. Treat any pair within `time_relaxation_seconds` of each
     # other as concurrent so we don't drop them before the spatial test.
+    # Near-apex pairs (same pose or same mast) are kept as grouping evidence — they see
+    # the same event — but are excluded from location math downstream.
     tolerance = timedelta(seconds=time_relaxation_seconds)
     overlapping_pairs: List[Tuple[int, int]] = []
     for i, id1 in enumerate(ids):
         row1 = rows_by_id[id1]
         for id2 in ids[i + 1 :]:
             row2 = rows_by_id[id2]
-            # Same pose shares the same apex; any cone intersection is degenerate, not a real triangulation.
-            if has_pose:
-                pose1, pose2 = row1["pose_id"], row2["pose_id"]
-                if pd.notna(pose1) and pd.notna(pose2) and pose1 == pose2:
-                    continue
             if (
                 row1["started_at"] - row2["last_seen_at"] > tolerance
                 or row2["started_at"] - row1["last_seen_at"] > tolerance
@@ -336,11 +364,17 @@ def _build_overlap_cliques(overlapping_pairs: List[Tuple[int, int]]) -> List[Tup
 def _group_smoke_location(
     seq_tuple: Tuple[int, ...],
     projected_cones: Dict[int, Polygon],
+    apex_by_id: Dict[int, Tuple[float, float]],
+    min_apex_km: float,
 ) -> Optional[Tuple[float, float]]:
     if len(seq_tuple) < 2:
         return None
     pts: List[Tuple[float, float]] = []
+    has_triangulable_pair = False
     for i, j in itertools.combinations(seq_tuple, 2):
+        if _is_degenerate_pair(apex_by_id, i, j, min_apex_km):
+            continue
+        has_triangulable_pair = True
         gi = projected_cones.get(i)
         gj = projected_cones.get(j)
         if gi is None or gj is None:
@@ -350,6 +384,10 @@ def _group_smoke_location(
             continue
         pts.append(get_centroid_latlon(inter))
     if not pts:
+        if not has_triangulable_pair:
+            # Same-mast group: one event, but no pair carries range information
+            logger.debug("Group %s only has near-apex pairs, no location computed", seq_tuple)
+            return None
         # No intersections: use centroid of available cones as best-effort location
         polys: List[BaseGeometry] = [p for p in (projected_cones.get(sid) for sid in seq_tuple) if p is not None]
         if not polys:
@@ -388,6 +426,7 @@ def compute_overlap(
     r_min_km: float = 0.5,
     max_dist_km: float = 2.0,
     time_relaxation_seconds: Optional[float] = None,
+    min_apex_km: Optional[float] = None,
 ) -> pd.DataFrame:
     """
     Build localized event groups and attach them to the input DataFrame.
@@ -411,6 +450,10 @@ def compute_overlap(
         Tolerance applied to the time-window overlap check between two sequences. Pairs
         whose windows are within this slack of each other are still considered concurrent.
         Defaults to ``settings.TRIANGULATION_RELAXATION_SECONDS``.
+    min_apex_km : float, optional
+        Camera pairs closer than this share an apex: they still group together but are
+        excluded from location computation. Defaults to
+        ``settings.TRIANGULATION_MIN_APEX_DISTANCE_KM``.
 
     Returns
     -------
@@ -425,19 +468,25 @@ def compute_overlap(
         df["event_smoke_locations"] = [[] for _ in range(len(df))]
         return df
 
+    if min_apex_km is None:
+        min_apex_km = settings.TRIANGULATION_MIN_APEX_DISTANCE_KM
+
     # Precompute cones in Web Mercator
     projected_cones = _build_projected_cones(df_valid, r_km, r_min_km)
+    apex_by_id = _build_apex_by_id(df_valid)
 
     # Phase 1, build overlap graph gated by time overlap
     overlapping_pairs = _find_overlapping_pairs(df_valid, projected_cones, time_relaxation_seconds)
     cliques = _build_overlap_cliques(overlapping_pairs)
 
     # Phase 2, localized groups from cliques
-    localized_groups = _compute_localized_groups_from_cliques(df, cliques, projected_cones, max_dist_km)
+    localized_groups = _compute_localized_groups_from_cliques(
+        df, cliques, projected_cones, max_dist_km, apex_by_id, min_apex_km
+    )
 
     # Per group localization, median of pair barycenters for robustness
     group_to_smoke: Dict[Tuple[int, ...], Optional[Tuple[float, float]]] = {
-        g: _group_smoke_location(g, projected_cones) for g in localized_groups
+        g: _group_smoke_location(g, projected_cones, apex_by_id, min_apex_km) for g in localized_groups
     }
 
     # Attach back to df

--- a/src/tests/endpoints/test_detections.py
+++ b/src/tests/endpoints/test_detections.py
@@ -15,6 +15,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.api.api_v1.endpoints import detections as detections_api
 from app.api.api_v1.endpoints.detections import (
     _attach_sequence_to_alert,
+    _bboxes_overlap,
     _build_links_for_group,
     _build_overlap_records,
     _fetch_alert_mapping,
@@ -424,6 +425,26 @@ def test_resolve_groups_and_locations_no_match_returns_none():
         }
     ]
     assert _resolve_groups_and_locations(records, 999) is None
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "tolerance", "expected"),
+    [
+        # Overlapping boxes always match
+        ((0.1, 0.1, 0.3, 0.3, 0.9), (0.2, 0.2, 0.4, 0.4, 0.9), 0.0, True),
+        # Disjoint boxes with zero tolerance never match
+        ((0.1, 0.1, 0.3, 0.3, 0.9), (0.32, 0.1, 0.5, 0.3, 0.9), 0.0, False),
+        # Gap smaller than the tolerance matches
+        ((0.1, 0.1, 0.3, 0.3, 0.9), (0.32, 0.1, 0.5, 0.3, 0.9), 0.05, True),
+        # Gap larger than the tolerance does not match
+        ((0.1, 0.1, 0.3, 0.3, 0.9), (0.4, 0.1, 0.5, 0.3, 0.9), 0.05, False),
+        # Tolerance applies per axis
+        ((0.1, 0.1, 0.3, 0.3, 0.9), (0.32, 0.32, 0.5, 0.5, 0.9), 0.05, True),
+    ],
+)
+def test_bboxes_overlap_tolerance(left, right, tolerance, expected):
+    assert _bboxes_overlap(left, right, tolerance) is expected
+    assert _bboxes_overlap(right, left, tolerance) is expected
 
 
 @pytest.mark.asyncio

--- a/src/tests/endpoints/test_detections.py
+++ b/src/tests/endpoints/test_detections.py
@@ -494,6 +494,27 @@ async def test_maybe_update_alert_updates_fields(detection_session: AsyncSession
 
 
 @pytest.mark.asyncio
+async def test_maybe_update_alert_widens_bounds_without_location(detection_session: AsyncSession):
+    alert_crud = AlertCRUD(detection_session)
+    now = utcnow()
+    alert = Alert(organization_id=1, lat=5.0, lon=6.0, started_at=now, last_seen_at=now)
+    detection_session.add(alert)
+    await detection_session.commit()
+    await detection_session.refresh(alert)
+
+    # A location-less group (e.g. same-mast only) must still extend the time bounds
+    # without erasing the existing location.
+    start_at = now - timedelta(seconds=60)
+    last_seen_at = now + timedelta(seconds=60)
+    await _maybe_update_alert(alert_crud, alert.id, None, start_at, last_seen_at)
+
+    updated = await alert_crud.get(alert.id, strict=True)
+    assert (updated.lat, updated.lon) == (5.0, 6.0)
+    assert updated.started_at == start_at
+    assert updated.last_seen_at == last_seen_at
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_alert_id_reuses_existing_alert(detection_session: AsyncSession):
     alert_crud = AlertCRUD(detection_session)
     now = utcnow()

--- a/src/tests/endpoints/test_detections.py
+++ b/src/tests/endpoints/test_detections.py
@@ -736,6 +736,71 @@ async def test_merge_alerts_absorbs_duplicates(detection_session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_alert_id_does_not_merge_distant_alerts_without_location(
+    detection_session: AsyncSession,
+):
+    """A location-less group bridging two located alerts far apart (e.g. two same-mast
+    cameras each watching a different fire along the same bearing) must not merge them."""
+    alert_crud = AlertCRUD(detection_session)
+    now = utcnow()
+    fire_a = Alert(organization_id=1, lat=SMOKE_LOCATION[0], lon=SMOKE_LOCATION[1], started_at=now, last_seen_at=now)
+    fire_b = Alert(
+        organization_id=1, lat=DISTANT_LOCATION[0], lon=DISTANT_LOCATION[1], started_at=now, last_seen_at=now
+    )
+    detection_session.add_all([fire_a, fire_b])
+    await detection_session.commit()
+    await detection_session.refresh(fire_a)
+    await detection_session.refresh(fire_b)
+
+    target_id, absorbed_ids = await _get_or_create_alert_id(
+        {fire_a.id, fire_b.id},
+        None,
+        1,
+        now - timedelta(seconds=10),
+        now + timedelta(seconds=10),
+        alert_crud,
+    )
+    assert target_id == min(fire_a.id, fire_b.id)
+    assert absorbed_ids == set()
+    assert await alert_crud.get(fire_a.id) is not None
+    assert await alert_crud.get(fire_b.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_alert_id_merges_close_alerts_without_location(detection_session: AsyncSession):
+    """A location-less group may still merge alerts that are themselves colocated (or unlocated)."""
+    alert_crud = AlertCRUD(detection_session)
+    now = utcnow()
+    located = Alert(organization_id=1, lat=SMOKE_LOCATION[0], lon=SMOKE_LOCATION[1], started_at=now, last_seen_at=now)
+    nearby = Alert(
+        organization_id=1,
+        lat=SMOKE_LOCATION[0] + 0.005,
+        lon=SMOKE_LOCATION[1] + 0.005,
+        started_at=now,
+        last_seen_at=now,
+    )
+    unlocated = Alert(organization_id=1, lat=None, lon=None, started_at=now, last_seen_at=now)
+    detection_session.add_all([located, nearby, unlocated])
+    await detection_session.commit()
+    for obj in (located, nearby, unlocated):
+        await detection_session.refresh(obj)
+
+    target_id, absorbed_ids = await _get_or_create_alert_id(
+        {located.id, nearby.id, unlocated.id},
+        None,
+        1,
+        now - timedelta(seconds=10),
+        now + timedelta(seconds=10),
+        alert_crud,
+    )
+    all_ids = {located.id, nearby.id, unlocated.id}
+    assert target_id == min(all_ids)
+    assert absorbed_ids == all_ids - {target_id}
+    for aid in absorbed_ids:
+        assert await alert_crud.get(aid) is None
+
+
+@pytest.mark.asyncio
 async def test_attach_sequence_to_alert_returns_without_overlap_records(detection_session: AsyncSession):
     seq_crud = SequenceCRUD(detection_session)
     alert_crud = AlertCRUD(detection_session)

--- a/src/tests/endpoints/test_detections.py
+++ b/src/tests/endpoints/test_detections.py
@@ -25,6 +25,7 @@ from app.api.api_v1.endpoints.detections import (
     _get_or_create_alert_id,
     _get_recent_sequences,
     _maybe_update_alert,
+    _merge_alerts,
     _parse_bbox,
     _resolve_groups_and_locations,
     create_detection,
@@ -505,7 +506,7 @@ async def test_get_or_create_alert_id_reuses_existing_alert(detection_session: A
     await detection_session.refresh(alert2)
 
     location = (1.5, 2.5)
-    target_id = await _get_or_create_alert_id(
+    target_id, absorbed_ids = await _get_or_create_alert_id(
         {alert2.id, alert1.id},
         location,
         1,
@@ -514,6 +515,7 @@ async def test_get_or_create_alert_id_reuses_existing_alert(detection_session: A
         alert_crud,
     )
     assert target_id == min(alert1.id, alert2.id)
+    assert absorbed_ids == {max(alert1.id, alert2.id)}
 
     updated = await alert_crud.get(target_id, strict=True)
     assert updated.lat == location[0]
@@ -620,7 +622,7 @@ async def test_get_or_create_alert_id_creates_new_when_existing_too_far(detectio
     await detection_session.commit()
     await detection_session.refresh(distant)
 
-    target_id = await _get_or_create_alert_id(
+    target_id, absorbed_ids = await _get_or_create_alert_id(
         {distant.id},
         SMOKE_LOCATION,
         1,
@@ -629,6 +631,7 @@ async def test_get_or_create_alert_id_creates_new_when_existing_too_far(detectio
         alert_crud,
     )
     assert target_id != distant.id
+    assert absorbed_ids == set()
     new_alert = await alert_crud.get(target_id, strict=True)
     assert (new_alert.lat, new_alert.lon) == SMOKE_LOCATION
 
@@ -658,7 +661,7 @@ async def test_get_or_create_alert_id_picks_nearby_over_distant(detection_sessio
     await detection_session.refresh(nearby)
 
     # Even though `distant` may have a smaller id, it must be filtered out by the distance gate.
-    target_id = await _get_or_create_alert_id(
+    target_id, absorbed_ids = await _get_or_create_alert_id(
         {distant.id, nearby.id},
         SMOKE_LOCATION,
         1,
@@ -667,6 +670,48 @@ async def test_get_or_create_alert_id_picks_nearby_over_distant(detection_sessio
         alert_crud,
     )
     assert target_id == nearby.id
+    assert absorbed_ids == set()
+
+
+@pytest.mark.asyncio
+async def test_merge_alerts_absorbs_duplicates(detection_session: AsyncSession):
+    alert_crud = AlertCRUD(detection_session)
+    now = utcnow()
+    cam = await detection_session.get(Camera, pytest.camera_table[0]["id"])
+    assert cam is not None
+    seq1 = Sequence(camera_id=cam.id, camera_azimuth=0.0, started_at=now, last_seen_at=now)
+    seq2 = Sequence(camera_id=cam.id, camera_azimuth=0.0, started_at=now, last_seen_at=now)
+    target = Alert(organization_id=1, lat=None, lon=None, started_at=now, last_seen_at=now - timedelta(seconds=30))
+    duplicate = Alert(
+        organization_id=1,
+        lat=SMOKE_LOCATION[0],
+        lon=SMOKE_LOCATION[1],
+        started_at=now - timedelta(seconds=60),
+        last_seen_at=now,
+    )
+    detection_session.add_all([seq1, seq2, target, duplicate])
+    await detection_session.commit()
+    for obj in (seq1, seq2, target, duplicate):
+        await detection_session.refresh(obj)
+    detection_session.add_all([
+        AlertSequence(alert_id=target.id, sequence_id=seq1.id),
+        AlertSequence(alert_id=duplicate.id, sequence_id=seq1.id),
+        AlertSequence(alert_id=duplicate.id, sequence_id=seq2.id),
+    ])
+    await detection_session.commit()
+
+    await _merge_alerts(target.id, {duplicate.id}, alert_crud)
+
+    merged = await alert_crud.get(target.id, strict=True)
+    # Bounds widened and location inherited from the absorbed alert
+    assert merged.started_at == duplicate.started_at
+    assert merged.last_seen_at == duplicate.last_seen_at
+    assert (merged.lat, merged.lon) == SMOKE_LOCATION
+    # Sequences relinked without duplicating the shared one
+    links_res = await detection_session.exec(select(AlertSequence))
+    links = {(link.alert_id, link.sequence_id) for link in links_res.all()}
+    assert links == {(target.id, seq1.id), (target.id, seq2.id)}
+    assert await alert_crud.get(duplicate.id) is None
 
 
 @pytest.mark.asyncio
@@ -1441,6 +1486,101 @@ async def test_attach_sequence_does_not_bridge_to_distant_alert(detection_sessio
     mappings_res = await detection_session.exec(select(AlertSequence).where(AlertSequence.alert_id == smoke_a_alert_id))
     seqs_in_a = {m.sequence_id for m in mappings_res.all()}
     assert seq_cam2.id not in seqs_in_a
+
+
+@pytest.mark.asyncio
+async def test_attach_sequence_merges_same_event_alerts(detection_session: AsyncSession):
+    """
+    Regression guard for the duplicate-alert bug (prod alerts 49341/49342/49343).
+
+    Two masts see the same fire, each mast carrying two cameras. The same-mast pairs
+    must group into ONE alert per mast without a location, and once a cross-mast
+    triangulation bridges the two events, the alerts must be merged into a single one.
+    """
+    seq_crud = SequenceCRUD(detection_session)
+    alert_crud = AlertCRUD(detection_session)
+    cam_crud = CameraCRUD(detection_session)
+    now = utcnow()
+
+    def make_camera(name: str, lat: float, lon: float) -> Camera:
+        return Camera(
+            organization_id=1,
+            name=name,
+            angle_of_view=54.2,
+            elevation=110.0,
+            lat=lat,
+            lon=lon,
+            is_trustable=True,
+            last_active_at=now,
+            last_image=None,
+            created_at=now,
+        )
+
+    # Two cameras per mast: mast A (croix-augas-like) and mast B (nemours-like)
+    cam_a1 = make_camera("mast-a-01", 48.4267, 2.7109)
+    cam_a2 = make_camera("mast-a-02", 48.4267, 2.7109)
+    cam_b1 = make_camera("mast-b-01", 48.2605, 2.7064)
+    cam_b2 = make_camera("mast-b-02", 48.2605, 2.7064)
+    detection_session.add_all([cam_a1, cam_a2, cam_b1, cam_b2])
+    await detection_session.commit()
+    for cam in (cam_a1, cam_a2, cam_b1, cam_b2):
+        await detection_session.refresh(cam)
+
+    def make_sequence(camera_id: int, azimuth: float, cone_angle: float, is_validated: bool) -> Sequence:
+        return Sequence(
+            camera_id=camera_id,
+            pose_id=None,
+            camera_azimuth=azimuth,
+            sequence_azimuth=azimuth,
+            cone_angle=cone_angle,
+            is_wildfire=None,
+            is_validated=is_validated,
+            started_at=now - timedelta(seconds=30),
+            last_seen_at=now,
+        )
+
+    # Mast B sequences are not validated yet: only mast A is visible to the first attaches.
+    seq_a1 = make_sequence(cam_a1.id, 163.4, 1.0, is_validated=True)
+    seq_a2 = make_sequence(cam_a2.id, 164.0, 2.0, is_validated=True)
+    seq_b1 = make_sequence(cam_b1.id, 8.3, 0.8, is_validated=False)
+    seq_b2 = make_sequence(cam_b2.id, 9.0, 0.8, is_validated=False)
+    detection_session.add_all([seq_a1, seq_a2, seq_b1, seq_b2])
+    await detection_session.commit()
+    for seq in (seq_a1, seq_a2, seq_b1, seq_b2):
+        await detection_session.refresh(seq)
+
+    # Mast A sequences validate first: one alert, no location (same-apex, no triangulation).
+    await _attach_sequence_to_alert(seq_a1, cam_a1, cam_crud, seq_crud, alert_crud)
+    mast_a_alert_id = await _attach_sequence_to_alert(seq_a2, cam_a2, cam_crud, seq_crud, alert_crud)
+    assert mast_a_alert_id is not None
+    mast_a_alert = await alert_crud.get(mast_a_alert_id, strict=True)
+    assert mast_a_alert.lat is None
+
+    # Mast B got its own alert earlier (e.g. attached before its cones crossed mast A's).
+    mast_b_alert = Alert(
+        organization_id=1, lat=None, lon=None, started_at=now - timedelta(seconds=20), last_seen_at=now
+    )
+    seq_b1.is_validated = True
+    seq_b2.is_validated = True
+    detection_session.add_all([mast_b_alert, seq_b1, seq_b2])
+    await detection_session.commit()
+    await detection_session.refresh(mast_b_alert)
+    detection_session.add(AlertSequence(alert_id=mast_b_alert.id, sequence_id=seq_b1.id))
+    await detection_session.commit()
+
+    # seq_b2 validates: the cross-mast group covers both alerts, which must merge into one.
+    target_id = await _attach_sequence_to_alert(seq_b2, cam_b2, cam_crud, seq_crud, alert_crud)
+    assert target_id == mast_a_alert_id
+
+    alerts = await alert_crud.fetch_all()
+    assert [a.id for a in alerts] == [mast_a_alert_id]
+    merged = alerts[0]
+    assert merged.lat is not None
+    assert merged.lon is not None
+
+    links_res = await detection_session.exec(select(AlertSequence))
+    links = {(link.alert_id, link.sequence_id) for link in links_res.all()}
+    assert links == {(mast_a_alert_id, seq.id) for seq in (seq_a1, seq_a2, seq_b1, seq_b2)}
 
 
 @pytest.mark.asyncio

--- a/src/tests/services/test_overlap.py
+++ b/src/tests/services/test_overlap.py
@@ -76,10 +76,10 @@ def test_compute_overlap_time_relaxation_recovers_just_started_pair() -> None:
     assert df_relaxed[df_relaxed["id"] == 21].iloc[0]["event_groups"] == [(20, 21)]
 
 
-def test_compute_overlap_skips_same_pose_pair() -> None:
+def test_compute_overlap_groups_same_pose_pair_without_location() -> None:
     now = utcnow()
-    # Two sequences from the exact same pose with time and angular overlap
-    # share the same apex, so they must not be triangulated together.
+    # Two sequences from the exact same pose with time and angular overlap see the same
+    # event, so they group together — but a shared apex cannot triangulate a location.
     seqs = [
         _make_sequence(
             10, 48.3792, 2.8208, 180.0, 10.0, now - timedelta(seconds=9), now - timedelta(seconds=1), pose_id=42
@@ -92,5 +92,41 @@ def test_compute_overlap_skips_same_pose_pair() -> None:
 
     row10 = df[df["id"] == 10].iloc[0]
     row11 = df[df["id"] == 11].iloc[0]
-    assert row10["event_groups"] == [(10,)]
-    assert row11["event_groups"] == [(11,)]
+    assert row10["event_groups"] == [(10, 11)]
+    assert row11["event_groups"] == [(10, 11)]
+    assert row10["event_smoke_locations"] == [None]
+    assert row11["event_smoke_locations"] == [None]
+
+
+def test_compute_overlap_groups_same_mast_pair_without_location() -> None:
+    now = utcnow()
+    # Two cameras on the same mast (distinct poses, ~same coordinates) with overlapping
+    # cones: same event, but no range information, so the group has no location.
+    seqs = [
+        _make_sequence(30, 48.4267, 2.7109, 100.0, 2.0, now - timedelta(seconds=9), now - timedelta(seconds=1)),
+        _make_sequence(31, 48.4268, 2.7110, 101.0, 2.0, now - timedelta(seconds=8), now - timedelta(seconds=2)),
+    ]
+    df = compute_overlap(pd.DataFrame.from_records(seqs))
+
+    row30 = df[df["id"] == 30].iloc[0]
+    assert row30["event_groups"] == [(30, 31)]
+    assert row30["event_smoke_locations"] == [None]
+
+
+def test_compute_overlap_mixed_group_locates_from_triangulable_pairs_only() -> None:
+    now = utcnow()
+    # A same-mast pair plus a distant camera: all three group together, and the location
+    # must come from the cross-site intersections only, not the degenerate near-apex pair.
+    seqs = [
+        _make_sequence(40, 48.4267, 2.7109, 163.4, 1.0, now - timedelta(seconds=9), now - timedelta(seconds=1)),
+        _make_sequence(41, 48.4267, 2.7109, 163.4, 1.0, now - timedelta(seconds=8), now - timedelta(seconds=2)),
+        _make_sequence(42, 48.2605, 2.7064, 8.3, 0.8, now - timedelta(seconds=7), now - timedelta(seconds=3)),
+    ]
+    df = compute_overlap(pd.DataFrame.from_records(seqs))
+
+    row40 = df[df["id"] == 40].iloc[0]
+    assert row40["event_groups"] == [(40, 41, 42)]
+    location = row40["event_smoke_locations"][0]
+    assert location is not None
+    # The triangulated point sits between the two sites, close to neither apex
+    assert 48.26 < location[0] < 48.43


### PR DESCRIPTION
## Why

Prod incident (org sdis-77, 2026-07-07): one fire produced three alerts (49341/49342/49343), two of which shared the same sequences.

- Same-mast camera pairs (e.g. croix-augas-01/02) formed cone-overlap groups whose degenerate intersection produced a bogus triangulated location.
- That bogus location then failed the 2 km `ALERT_MERGE_MAX_DISTANCE_KM` gate, so the later cross-site group forked a new alert instead of reusing the existing ones.
- Nothing ever merged alerts once duplicated.
- Upstream, sequence matching required strictly overlapping bboxes, so a drifting plume could fragment into several sequences on the same camera.

## What changes

- `compute_overlap` keeps near-apex pairs (same pose or same mast, `TRIANGULATION_MIN_APEX_DISTANCE_KM`, default 0.1 km) as grouping evidence but excludes them from all location math; same-mast-only groups get no location instead of a mid-ray centroid.
- `_get_or_create_alert_id` merges compatible duplicate alerts into the oldest one (relink sequences, widen bounds, inherit location, delete absorbed rows) when a group spans several of them.
- `_bboxes_overlap` accepts a gap tolerance (`SEQUENCE_BBOX_TOLERANCE`, default 0.05 relative coords) so near-miss bboxes still match their sequence.
- Location-less groups still widen a reused alert's time bounds without erasing its location.
- Safety guard: a location-less group bridging located alerts more than 2 km apart never merges them (two same-mast cameras can each watch a different fire along the same bearing) — it links to the oldest alert and leaves the others alive.
- Regression tests, including an end-to-end replay of the prod scenario.
