### PR TITLE
feat(api): let admins fetch alerts and sequences across organizations

### DIFF
--- a/src/app/api/api_v1/endpoints/alerts.py
+++ b/src/app/api/api_v1/endpoints/alerts.py
@@ -222,11 +222,13 @@ async def export_alerts_csv(
 
     stmt: Any = (
         select(Alert)
-        .where(Alert.organization_id == token_payload.organization_id)
         .where(Alert.started_at >= start_dt)
         .where(Alert.started_at <= end_dt)
         .order_by(Alert.started_at.asc())  # type: ignore[attr-defined]
     )
+    # Admins export every organization's alerts
+    if UserRole.ADMIN not in token_payload.scopes:
+        stmt = stmt.where(Alert.organization_id == token_payload.organization_id)
     alerts = list((await session.exec(stmt)).all())
     seq_map = await _fetch_sequences_by_alert_ids(session, [alert.id for alert in alerts])
     camera_names_by_id = await _fetch_camera_names_by_ids(
@@ -292,17 +294,22 @@ async def fetch_latest_unlabeled_alerts(
     limit: Union[int, None] = Query(15, ge=1, description="Maximum number of alerts to fetch"),
     offset: Union[int, None] = Query(0, description="Number of alerts to skip before starting to fetch"),
     risk_score: Union[FwiClass, None] = Query(
-        None, description="Override FWI class applied to every sequence; bypasses risk-api lookup."
+        None,
+        description="Override FWI class applied to every sequence; bypasses risk-api lookup. Ignored for admins.",
     ),
     session: AsyncSession = Depends(get_session),
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[AlertReadWithSequences]:
     telemetry_client.capture(token_payload.sub, event="alerts-fetch-latest")
+    is_admin = UserRole.ADMIN in token_payload.scopes
 
-    fwi_classes_by_camera = await _resolve_fwi_class_per_camera(
-        session, token_payload.organization_id, override_class=risk_score
-    )
-    seq_filter = max_conf_filter_clause(fwi_classes_by_camera)
+    # Admins see every organization's alerts without risk-score filtering
+    seq_filter = None
+    if not is_admin:
+        fwi_classes_by_camera = await _resolve_fwi_class_per_camera(
+            session, token_payload.organization_id, override_class=risk_score
+        )
+        seq_filter = max_conf_filter_clause(fwi_classes_by_camera)
 
     seq_match: Any = cast(
         Any,
@@ -314,9 +321,11 @@ async def fetch_latest_unlabeled_alerts(
     if seq_filter is not None:
         seq_match = seq_match.where(seq_filter)
 
-    alerts_stmt: Any = (
-        select(Alert)
-        .where(Alert.organization_id == token_payload.organization_id)
+    alerts_stmt: Any = select(Alert)
+    if not is_admin:
+        alerts_stmt = alerts_stmt.where(Alert.organization_id == token_payload.organization_id)
+    alerts_stmt = (
+        alerts_stmt
         .where(cast(Any, Alert.id).in_(seq_match))
         .order_by(Alert.started_at.desc())  # type: ignore[attr-defined]
         .limit(limit)
@@ -338,23 +347,26 @@ async def fetch_alerts_from_date(
     limit: Union[int, None] = Query(15, description="Maximum number of alerts to fetch"),
     offset: Union[int, None] = Query(0, description="Number of alerts to skip before starting to fetch"),
     risk_score: Union[FwiClass, None] = Query(
-        None, description="Override FWI class applied to every sequence; bypasses risk-api lookup."
+        None,
+        description="Override FWI class applied to every sequence; bypasses risk-api lookup. Ignored for admins.",
     ),
     session: AsyncSession = Depends(get_session),
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[AlertReadWithSequences]:
     telemetry_client.capture(token_payload.sub, event="alerts-fetch-from-date")
+    is_admin = UserRole.ADMIN in token_payload.scopes
 
-    fwi_classes_by_camera = await _resolve_fwi_class_per_camera(
-        session, token_payload.organization_id, target_date=from_date, override_class=risk_score
-    )
-    seq_filter = max_conf_filter_clause(fwi_classes_by_camera)
+    # Admins see every organization's alerts without risk-score filtering
+    seq_filter = None
+    if not is_admin:
+        fwi_classes_by_camera = await _resolve_fwi_class_per_camera(
+            session, token_payload.organization_id, target_date=from_date, override_class=risk_score
+        )
+        seq_filter = max_conf_filter_clause(fwi_classes_by_camera)
 
-    alerts_stmt: Any = (
-        select(Alert)
-        .where(Alert.organization_id == token_payload.organization_id)
-        .where(func.date(Alert.started_at) == from_date)
-    )
+    alerts_stmt: Any = select(Alert).where(func.date(Alert.started_at) == from_date)
+    if not is_admin:
+        alerts_stmt = alerts_stmt.where(Alert.organization_id == token_payload.organization_id)
     if seq_filter is not None:
         seq_match: Any = select(AlertSequence.alert_id).join(
             Sequence, cast(Any, Sequence.id == AlertSequence.sequence_id)

--- a/src/app/api/api_v1/endpoints/alerts.py
+++ b/src/app/api/api_v1/endpoints/alerts.py
@@ -297,7 +297,7 @@ async def export_alerts_csv(
         .order_by(Alert.started_at.asc())  # type: ignore[attr-defined]
     )
     # Admins export every organization's alerts
-    if UserRole.ADMIN not in token_payload.scopes:
+    if not token_payload.is_admin:
         stmt = stmt.where(Alert.organization_id == token_payload.organization_id)
     alerts = list((await session.exec(stmt)).all())
     seq_map = await _fetch_sequences_by_alert_ids(session, [alert.id for alert in alerts])
@@ -318,7 +318,7 @@ async def get_alert(
     telemetry_client.capture(token_payload.sub, event="alerts-get", properties={"alert_id": alert_id})
     alert = cast(Alert, await alerts.get(alert_id, strict=True))
 
-    if UserRole.ADMIN not in token_payload.scopes:
+    if not token_payload.is_admin:
         verify_org_rights(token_payload.organization_id, alert)
 
     seq_map = await _fetch_sequences_by_alert_ids(session, [alert.id])
@@ -341,7 +341,7 @@ async def fetch_alert_sequences(
 ) -> List[SequenceRead]:
     telemetry_client.capture(token_payload.sub, event="alerts-sequences-get", properties={"alert_id": alert_id})
     alert = cast(Alert, await alerts.get(alert_id, strict=True))
-    if UserRole.ADMIN not in token_payload.scopes:
+    if not token_payload.is_admin:
         verify_org_rights(token_payload.organization_id, alert)
 
     order_clause: Any = desc(cast(Any, Sequence.last_seen_at)) if order_desc else asc(cast(Any, Sequence.last_seen_at))
@@ -371,7 +371,7 @@ async def fetch_latest_unlabeled_alerts(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[AlertReadWithSequences]:
     telemetry_client.capture(token_payload.sub, event="alerts-fetch-latest")
-    is_admin = UserRole.ADMIN in token_payload.scopes
+    is_admin = token_payload.is_admin
 
     alerts_stmt, seq_filter = await _build_unlabeled_alerts_stmt(
         session, token_payload.organization_id, risk_score, is_admin=is_admin
@@ -394,7 +394,7 @@ async def count_latest_unlabeled_alerts(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> AlertCount:
     telemetry_client.capture(token_payload.sub, event="alerts-count-latest")
-    is_admin = UserRole.ADMIN in token_payload.scopes
+    is_admin = token_payload.is_admin
     alerts_stmt, _ = await _build_unlabeled_alerts_stmt(
         session, token_payload.organization_id, risk_score, is_admin=is_admin
     )
@@ -415,7 +415,7 @@ async def fetch_alerts_from_date(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[AlertReadWithSequences]:
     telemetry_client.capture(token_payload.sub, event="alerts-fetch-from-date")
-    is_admin = UserRole.ADMIN in token_payload.scopes
+    is_admin = token_payload.is_admin
 
     alerts_stmt, seq_filter = await _build_alerts_from_date_stmt(
         session, token_payload.organization_id, from_date, risk_score, is_admin=is_admin
@@ -439,7 +439,7 @@ async def count_alerts_from_date(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> AlertCount:
     telemetry_client.capture(token_payload.sub, event="alerts-count-from-date")
-    is_admin = UserRole.ADMIN in token_payload.scopes
+    is_admin = token_payload.is_admin
     alerts_stmt, _ = await _build_alerts_from_date_stmt(
         session, token_payload.organization_id, from_date, risk_score, is_admin=is_admin
     )
@@ -467,7 +467,7 @@ async def unmatch_alert_sequence(
         properties={"alert_id": alert_id, "sequence_id": sequence_id},
     )
     alert = cast(Alert, await alerts.get(alert_id, strict=True))
-    if UserRole.ADMIN not in token_payload.scopes:
+    if not token_payload.is_admin:
         verify_org_rights(token_payload.organization_id, alert)
 
     link_stmt: Any = select(AlertSequence).where(

--- a/src/app/api/api_v1/endpoints/camera_proxy.py
+++ b/src/app/api/api_v1/endpoints/camera_proxy.py
@@ -93,7 +93,7 @@ async def _require_read(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> Camera:
     camera = cast(Camera, await cameras.get(camera_id, strict=True))
-    if token_payload.organization_id != camera.organization_id and UserRole.ADMIN not in token_payload.scopes:
+    if token_payload.organization_id != camera.organization_id and not token_payload.is_admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
     return camera
 
@@ -104,7 +104,7 @@ async def _require_write(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT]),
 ) -> Camera:
     camera = cast(Camera, await cameras.get(camera_id, strict=True))
-    if token_payload.organization_id != camera.organization_id and UserRole.ADMIN not in token_payload.scopes:
+    if token_payload.organization_id != camera.organization_id and not token_payload.is_admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
     return camera
 

--- a/src/app/api/api_v1/endpoints/cameras.py
+++ b/src/app/api/api_v1/endpoints/cameras.py
@@ -41,7 +41,7 @@ async def register_camera(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT]),
 ) -> CameraOut:
     telemetry_client.capture(token_payload.sub, event="cameras-create", properties={"device_login": payload.name})
-    if token_payload.organization_id != payload.organization_id and UserRole.ADMIN not in token_payload.scopes:
+    if token_payload.organization_id != payload.organization_id and not token_payload.is_admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
     camera = await cameras.create(payload)
     return CameraOut(**camera.model_dump())
@@ -61,7 +61,7 @@ async def get_camera(
 ) -> CameraRead:
     telemetry_client.capture(token_payload.sub, event="cameras-get", properties={"camera_id": camera_id})
     camera = cast(Camera, await cameras.get(camera_id, strict=True))
-    if token_payload.organization_id != camera.organization_id and UserRole.ADMIN not in token_payload.scopes:
+    if token_payload.organization_id != camera.organization_id and not token_payload.is_admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     cam_poses = await poses.fetch_all(
@@ -92,7 +92,7 @@ async def fetch_cameras(
 ) -> List[CameraRead]:
     telemetry_client.capture(token_payload.sub, event="cameras-fetch")
     trustable_filter: list[tuple[str, Any]] | None = None if include_non_trustable else [("is_trustable", True)]
-    if UserRole.ADMIN in token_payload.scopes:
+    if token_payload.is_admin:
         cams = [elt for elt in await cameras.fetch_all(order_by="id", filters=trustable_filter)]
 
         async def get_url_for_cam(cam: Camera) -> str | None:  # noqa: RUF029

--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -622,7 +622,7 @@ async def get_detection(
     telemetry_client.capture(token_payload.sub, event="detections-get", properties={"detection_id": detection_id})
     detection = cast(Detection, await detections.get(detection_id, strict=True))
 
-    if UserRole.ADMIN in token_payload.scopes:
+    if token_payload.is_admin:
         return detection
 
     camera = cast(Camera, await cameras.get(detection.camera_id, strict=True))
@@ -644,7 +644,7 @@ async def get_detection_url(
     detection = cast(Detection, await detections.get(detection_id, strict=True))
 
     camera = cast(Camera, await cameras.get(detection.camera_id, strict=True))
-    if UserRole.ADMIN not in token_payload.scopes and token_payload.organization_id != camera.organization_id:
+    if not token_payload.is_admin and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
     bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(camera.organization_id))
     crop_url = bucket.get_public_url(detection.crop_bucket_key) if detection.crop_bucket_key else None
@@ -658,7 +658,7 @@ async def fetch_detections(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[DetectionRead]:
     telemetry_client.capture(token_payload.sub, event="detections-fetch")
-    if UserRole.ADMIN in token_payload.scopes:
+    if token_payload.is_admin:
         return [DetectionRead(**elt.model_dump()) for elt in await detections.fetch_all(order_by="id")]
 
     cameras_list = await cameras.fetch_all(filters=("organization_id", token_payload.organization_id))

--- a/src/app/api/api_v1/endpoints/occlusion_masks.py
+++ b/src/app/api/api_v1/endpoints/occlusion_masks.py
@@ -61,7 +61,7 @@ async def create_mask(
     pose = cast(Pose, await poses.get(payload.pose_id, strict=True))
     camera = cast(Camera, await cameras.get(pose.camera_id, strict=True))
 
-    if UserRole.ADMIN not in token_payload.scopes and token_payload.organization_id != camera.organization_id:
+    if not token_payload.is_admin and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     telemetry_client.capture(
@@ -93,7 +93,7 @@ async def get_mask(
     pose = cast(Pose, await poses.get(mask.pose_id, strict=True))
     camera = cast(Camera, await cameras.get(pose.camera_id, strict=True))
 
-    if UserRole.ADMIN not in token_payload.scopes and token_payload.organization_id != camera.organization_id:
+    if not token_payload.is_admin and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     telemetry_client.capture(
@@ -128,7 +128,7 @@ async def update_mask(
     pose = cast(Pose, await poses.get(mask.pose_id, strict=True))
     camera = cast(Camera, await cameras.get(pose.camera_id, strict=True))
 
-    if UserRole.ADMIN not in token_payload.scopes and token_payload.organization_id != camera.organization_id:
+    if not token_payload.is_admin and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     telemetry_client.capture(
@@ -160,7 +160,7 @@ async def delete_mask(
     pose = cast(Pose, await poses.get(mask.pose_id, strict=True))
     camera = cast(Camera, await cameras.get(pose.camera_id, strict=True))
 
-    if UserRole.ADMIN not in token_payload.scopes and token_payload.organization_id != camera.organization_id:
+    if not token_payload.is_admin and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     telemetry_client.capture(

--- a/src/app/api/api_v1/endpoints/poses.py
+++ b/src/app/api/api_v1/endpoints/poses.py
@@ -38,7 +38,7 @@ async def create_pose(
     if Role.CAMERA in token_payload.scopes:
         if payload.camera_id != token_payload.sub:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
-    elif token_payload.organization_id != camera.organization_id and UserRole.ADMIN not in token_payload.scopes:
+    elif token_payload.organization_id != camera.organization_id and not token_payload.is_admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     db_pose = await poses.create(payload)
@@ -67,7 +67,7 @@ async def get_pose(
     pose = cast(Pose, await poses.get(pose_id, strict=True))
     camera = cast(Camera, await cameras.get(pose.camera_id, strict=True))
 
-    if token_payload.organization_id != camera.organization_id and UserRole.ADMIN not in token_payload.scopes:
+    if token_payload.organization_id != camera.organization_id and not token_payload.is_admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     if pose.image is None:
@@ -91,7 +91,7 @@ async def update_pose(
     if Role.CAMERA in token_payload.scopes:
         if pose.camera_id != token_payload.sub:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
-    elif token_payload.organization_id != camera.organization_id and UserRole.ADMIN not in token_payload.scopes:
+    elif token_payload.organization_id != camera.organization_id and not token_payload.is_admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     db_pose = await poses.update(pose_id, payload)
@@ -115,7 +115,7 @@ async def update_pose_image(
     if Role.CAMERA in token_payload.scopes:
         if pose.camera_id != token_payload.sub:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
-    elif token_payload.organization_id != camera.organization_id and UserRole.ADMIN not in token_payload.scopes:
+    elif token_payload.organization_id != camera.organization_id and not token_payload.is_admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     # Upload the file using the camera_id (poses belong to cameras)
@@ -157,7 +157,7 @@ async def list_pose_masks(
     pose = cast(Pose, await poses.get(pose_id, strict=True))
     camera = cast(Camera, await cameras.get(pose.camera_id, strict=True))
 
-    if token_payload.organization_id != camera.organization_id and UserRole.ADMIN not in token_payload.scopes:
+    if token_payload.organization_id != camera.organization_id and not token_payload.is_admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     rows = await masks.get_by_pose(pose_id)

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -109,28 +109,32 @@ async def fetch_sequence_detections(
 )
 async def fetch_latest_unlabeled_sequences(
     risk_score: Union[FwiClass, None] = Query(
-        None, description="Override FWI class applied to every sequence; bypasses risk-api lookup."
+        None,
+        description="Override FWI class applied to every sequence; bypasses risk-api lookup. Ignored for admins.",
     ),
     session: AsyncSession = Depends(get_session),
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[SequenceRead]:
     telemetry_client.capture(token_payload.sub, event="sequence-fetch-latest")
-    camera_ids = (
-        await session.exec(select(Camera.id).where(Camera.organization_id == token_payload.organization_id))
-    ).all()
-    classes: dict[int, Union[str, None]] = (
-        dict.fromkeys(camera_ids, risk_score) if risk_score is not None else dict(risk_service.scores())
-    )
+    is_admin = UserRole.ADMIN in token_payload.scopes
 
     stmt: Any = (
         select(Sequence)
         .where(Sequence.started_at > utcnow() - timedelta(hours=24))
-        .where(Sequence.camera_id.in_(camera_ids))  # type: ignore[attr-defined]
         .where(Sequence.is_wildfire.is_(None))  # type: ignore[union-attr]
     )
-    seq_filter = max_conf_filter_clause(classes)
-    if seq_filter is not None:
-        stmt = stmt.where(seq_filter)
+    # Admins see every organization's sequences without risk-score filtering
+    if not is_admin:
+        camera_ids = (
+            await session.exec(select(Camera.id).where(Camera.organization_id == token_payload.organization_id))
+        ).all()
+        classes: dict[int, Union[str, None]] = (
+            dict.fromkeys(camera_ids, risk_score) if risk_score is not None else dict(risk_service.scores())
+        )
+        stmt = stmt.where(Sequence.camera_id.in_(camera_ids))  # type: ignore[attr-defined]
+        seq_filter = max_conf_filter_clause(classes)
+        if seq_filter is not None:
+            stmt = stmt.where(seq_filter)
     stmt = stmt.order_by(Sequence.started_at.desc()).limit(15)  # type: ignore[attr-defined]
 
     fetched_sequences = (await session.exec(stmt)).all()
@@ -144,29 +148,33 @@ async def fetch_sequences_from_date(
     limit: Union[int, None] = Query(15, description="Maximum number of sequences to fetch"),
     offset: Union[int, None] = Query(0, description="Number of sequences to skip before starting to fetch"),
     risk_score: Union[FwiClass, None] = Query(
-        None, description="Override FWI class applied to every sequence; bypasses risk-api lookup."
+        None,
+        description="Override FWI class applied to every sequence; bypasses risk-api lookup. Ignored for admins.",
     ),
     session: AsyncSession = Depends(get_session),
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[SequenceRead]:
     telemetry_client.capture(token_payload.sub, event="sequence-fetch-from-date")
-    # Limit to cameras in the same organization
-    camera_ids = (
-        await session.exec(select(Camera.id).where(Camera.organization_id == token_payload.organization_id))
-    ).all()
-    classes: dict[int, str | None]
-    if risk_score is not None:
-        classes = dict.fromkeys(camera_ids, risk_score)
-    else:
-        scores = await risk_service.get_scores_for_date(from_date, organization_id=token_payload.organization_id)
-        classes = dict(scores)
+    is_admin = UserRole.ADMIN in token_payload.scopes
 
-    stmt: Any = (
-        select(Sequence).where(func.date(Sequence.started_at) == from_date).where(Sequence.camera_id.in_(camera_ids))  # type: ignore[attr-defined]
-    )
-    seq_filter = max_conf_filter_clause(classes)
-    if seq_filter is not None:
-        stmt = stmt.where(seq_filter)
+    stmt: Any = select(Sequence).where(func.date(Sequence.started_at) == from_date)
+    # Admins see every organization's sequences without risk-score filtering
+    if not is_admin:
+        # Limit to cameras in the same organization
+        camera_ids = (
+            await session.exec(select(Camera.id).where(Camera.organization_id == token_payload.organization_id))
+        ).all()
+        classes: dict[int, str | None]
+        if risk_score is not None:
+            classes = dict.fromkeys(camera_ids, risk_score)
+        else:
+            scores = await risk_service.get_scores_for_date(from_date, organization_id=token_payload.organization_id)
+            classes = dict(scores)
+
+        stmt = stmt.where(Sequence.camera_id.in_(camera_ids))  # type: ignore[attr-defined]
+        seq_filter = max_conf_filter_clause(classes)
+        if seq_filter is not None:
+            stmt = stmt.where(seq_filter)
     stmt = stmt.order_by(Sequence.started_at.desc()).limit(limit).offset(offset)  # type: ignore[attr-defined]
 
     fetched_sequences = (await session.exec(stmt)).all()

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -53,7 +53,7 @@ async def get_sequence(
     telemetry_client.capture(token_payload.sub, event="sequences-get", properties={"sequence_id": sequence_id})
     sequence = cast(Sequence, await sequences.get(sequence_id, strict=True))
 
-    if UserRole.ADMIN not in token_payload.scopes:
+    if not token_payload.is_admin:
         await verify_org_rights(token_payload.organization_id, sequence.camera_id, cameras)
 
     counts = await get_detection_counts_by_sequence_ids(session, [sequence.id])
@@ -80,7 +80,7 @@ async def fetch_sequence_detections(
     telemetry_client.capture(token_payload.sub, event="sequences-get", properties={"sequence_id": sequence_id})
     sequence = cast(Sequence, await sequences.get(sequence_id, strict=True))
     camera = cast(Camera, await cameras.get(sequence.camera_id, strict=True))
-    if UserRole.ADMIN not in token_payload.scopes and token_payload.organization_id != camera.organization_id:
+    if not token_payload.is_admin and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
     # Get the bucket of the camera's organization
@@ -116,7 +116,7 @@ async def fetch_latest_unlabeled_sequences(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[SequenceRead]:
     telemetry_client.capture(token_payload.sub, event="sequence-fetch-latest")
-    is_admin = UserRole.ADMIN in token_payload.scopes
+    is_admin = token_payload.is_admin
 
     stmt: Any = (
         select(Sequence)
@@ -155,7 +155,7 @@ async def fetch_sequences_from_date(
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[SequenceRead]:
     telemetry_client.capture(token_payload.sub, event="sequence-fetch-from-date")
-    is_admin = UserRole.ADMIN in token_payload.scopes
+    is_admin = token_payload.is_admin
 
     stmt: Any = select(Sequence).where(func.date(Sequence.started_at) == from_date)
     # Admins see every organization's sequences without risk-score filtering
@@ -222,7 +222,7 @@ async def label_sequence(
     telemetry_client.capture(token_payload.sub, event="sequence-label", properties={"sequence_id": sequence_id})
     sequence = cast(Sequence, await sequences.get(sequence_id, strict=True))
 
-    if UserRole.ADMIN not in token_payload.scopes:
+    if not token_payload.is_admin:
         await verify_org_rights(token_payload.organization_id, sequence.camera_id, cameras)
 
     updated = await sequences.update(sequence_id, payload)

--- a/src/app/schemas/login.py
+++ b/src/app/schemas/login.py
@@ -26,3 +26,7 @@ class TokenPayload(BaseModel):
     sub: int = Field(..., gt=0)
     scopes: List[Role] = Field([], description="scopes of the token")
     organization_id: int = Field(..., gt=0)
+
+    @property
+    def is_admin(self) -> bool:
+        return Role.ADMIN in self.scopes

--- a/src/tests/endpoints/test_alerts.py
+++ b/src/tests/endpoints/test_alerts.py
@@ -210,6 +210,42 @@ async def test_alerts_from_date(async_client: AsyncClient, detection_session: As
 
 
 @pytest.mark.asyncio
+async def test_alerts_admin_sees_all_organizations(async_client: AsyncClient, detection_session: AsyncSession):
+    org1_alert, _, _ = await _create_alert_with_sequences(detection_session, org_id=1, camera_id=1, lat=48.0, lon=2.0)
+    org2_alert, _, _ = await _create_alert_with_sequences(detection_session, org_id=2, camera_id=2, lat=44.0, lon=5.0)
+
+    admin_auth = pytest.get_token(
+        pytest.user_table[0]["id"], pytest.user_table[0]["role"].split(), pytest.user_table[0]["organization_id"]
+    )
+    agent_auth = pytest.get_token(
+        pytest.user_table[1]["id"], pytest.user_table[1]["role"].split(), pytest.user_table[1]["organization_id"]
+    )
+
+    # Admin of organization 1 sees both organizations' alerts
+    resp = await async_client.get("/alerts/unlabeled/latest", headers=admin_auth)
+    assert resp.status_code == 200, resp.text
+    assert {org1_alert.id, org2_alert.id}.issubset({item["id"] for item in resp.json()})
+
+    date_str = org1_alert.started_at.date().isoformat()
+    resp = await async_client.get(f"/alerts/all/fromdate?from_date={date_str}", headers=admin_auth)
+    assert resp.status_code == 200, resp.text
+    assert {org1_alert.id, org2_alert.id}.issubset({item["id"] for item in resp.json()})
+
+    # Agent of organization 1 only sees its own organization's alerts
+    resp = await async_client.get("/alerts/unlabeled/latest", headers=agent_auth)
+    assert resp.status_code == 200, resp.text
+    returned_ids = {item["id"] for item in resp.json()}
+    assert org1_alert.id in returned_ids
+    assert org2_alert.id not in returned_ids
+
+    resp = await async_client.get(f"/alerts/all/fromdate?from_date={date_str}", headers=agent_auth)
+    assert resp.status_code == 200, resp.text
+    returned_ids = {item["id"] for item in resp.json()}
+    assert org1_alert.id in returned_ids
+    assert org2_alert.id not in returned_ids
+
+
+@pytest.mark.asyncio
 async def test_triangulation_creates_single_alert(
     async_client: AsyncClient, detection_session: AsyncSession, mock_img: bytes
 ):
@@ -828,6 +864,23 @@ async def test_alerts_export_org_isolation(
     returned_ids = {int(r["alert_id"]) for r in rows}
     assert org1_alert.id in returned_ids
     assert org2_alert.id not in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_alerts_export_admin_sees_all_organizations(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+    export_base_dt: datetime,
+    org1_admin_auth: Dict[str, str],
+):
+    org1_alert = await _create_alert(detection_session, 1, export_base_dt, export_base_dt + timedelta(minutes=5))
+    await _attach_sequence(detection_session, org1_alert, camera_id=1)
+    org2_alert = await _create_alert(detection_session, 2, export_base_dt, export_base_dt + timedelta(minutes=5))
+    await _attach_sequence(detection_session, org2_alert, camera_id=2)
+
+    _, rows = await _get_export(async_client, org1_admin_auth, "2026-04-10", "2026-04-10")
+    returned_ids = {int(r["alert_id"]) for r in rows}
+    assert {org1_alert.id, org2_alert.id}.issubset(returned_ids)
 
 
 @pytest.mark.asyncio

--- a/src/tests/endpoints/test_risk_filter.py
+++ b/src/tests/endpoints/test_risk_filter.py
@@ -62,15 +62,37 @@ async def test_unlabeled_latest_drops_low_conf_when_camera_is_low_risk(
     risk_service._scores = {camera_id: "low"}
 
     auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
+        pytest.user_table[1]["id"],
+        pytest.user_table[1]["role"].split(),
+        pytest.user_table[1]["organization_id"],
     )
     response = await async_client.get("/sequences/unlabeled/latest", headers=auth)
     assert response.status_code == 200, print(response.__dict__)
     returned_ids = {item["id"] for item in response.json()}
     assert low_seq.id not in returned_ids
     assert high_seq.id in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_unlabeled_latest_admin_bypasses_risk_filter(
+    async_client: AsyncClient, detection_session: AsyncSession, reset_risk_cache
+):
+    """Admins skip the risk filter entirely; the ``risk_score`` override is ignored for them."""
+    camera_id = pytest.camera_table[0]["id"]
+    pose_id = pytest.pose_table[0]["id"]
+    low_seq = await _seed_unlabeled_sequence(detection_session, camera_id, pose_id, max_conf=0.40, minutes_ago=30)
+
+    risk_service._scores = {camera_id: "low"}  # 0.45 threshold would drop the sequence
+
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+    for url in ("/sequences/unlabeled/latest", "/sequences/unlabeled/latest?risk_score=low"):
+        response = await async_client.get(url, headers=auth)
+        assert response.status_code == 200, print(response.__dict__)
+        assert low_seq.id in {item["id"] for item in response.json()}
 
 
 @pytest.mark.asyncio
@@ -85,9 +107,9 @@ async def test_unlabeled_latest_drops_below_very_low_threshold(
     risk_service._scores = {camera_id: "very_low"}
 
     auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
+        pytest.user_table[1]["id"],
+        pytest.user_table[1]["role"].split(),
+        pytest.user_table[1]["organization_id"],
     )
     response = await async_client.get("/sequences/unlabeled/latest", headers=auth)
     assert response.status_code == 200, print(response.__dict__)
@@ -107,9 +129,9 @@ async def test_unlabeled_latest_keeps_all_when_class_is_moderate_or_above(
     risk_service._scores = {camera_id: fwi_class}
 
     auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
+        pytest.user_table[1]["id"],
+        pytest.user_table[1]["role"].split(),
+        pytest.user_table[1]["organization_id"],
     )
     response = await async_client.get("/sequences/unlabeled/latest", headers=auth)
     assert response.status_code == 200, print(response.__dict__)
@@ -128,9 +150,9 @@ async def test_unlabeled_latest_keeps_seq_with_null_max_conf_under_filter(
     risk_service._scores = {camera_id: "low"}  # 0.45 threshold, would normally drop
 
     auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
+        pytest.user_table[1]["id"],
+        pytest.user_table[1]["role"].split(),
+        pytest.user_table[1]["organization_id"],
     )
     response = await async_client.get("/sequences/unlabeled/latest", headers=auth)
     assert response.status_code == 200, print(response.__dict__)
@@ -156,9 +178,9 @@ async def test_unlabeled_latest_keeps_seq_for_camera_unknown_to_risk_api(
 
     # known_cam belongs to org 1; unknown_cam belongs to org 2 -> query both orgs.
     auth_org1 = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
+        pytest.user_table[1]["id"],
+        pytest.user_table[1]["role"].split(),
+        pytest.user_table[1]["organization_id"],
     )
     auth_org2 = pytest.get_token(
         pytest.user_table[2]["id"],

--- a/src/tests/endpoints/test_risk_filter.py
+++ b/src/tests/endpoints/test_risk_filter.py
@@ -91,7 +91,7 @@ async def test_unlabeled_latest_admin_bypasses_risk_filter(
     )
     for url in ("/sequences/unlabeled/latest", "/sequences/unlabeled/latest?risk_score=low"):
         response = await async_client.get(url, headers=auth)
-        assert response.status_code == 200, print(response.__dict__)
+        assert response.status_code == 200, response.__dict__
         assert low_seq.id in {item["id"] for item in response.json()}
 
 

--- a/src/tests/endpoints/test_sequences.py
+++ b/src/tests/endpoints/test_sequences.py
@@ -235,7 +235,17 @@ async def test_label_sequence(
         # datetime != date, weird, but works
         (0, "2018-06-06T00:00:00", 200, None, []),
         (0, "2018-06-06", 200, None, []),
-        (0, "2023-11-07", 200, None, [{**pytest.sequence_table[0], "detections_count": 3}]),
+        # Admins see every organization's sequences
+        (
+            0,
+            "2023-11-07",
+            200,
+            None,
+            [
+                {**pytest.sequence_table[1], "detections_count": 1},
+                {**pytest.sequence_table[0], "detections_count": 3},
+            ],
+        ),
         (1, "2023-11-07", 200, None, [{**pytest.sequence_table[0], "detections_count": 3}]),
         (2, "2023-11-07", 200, None, [{**pytest.sequence_table[1], "detections_count": 1}]),
     ],
@@ -362,6 +372,42 @@ async def test_latest_sequences_include_detections_count(async_client: AsyncClie
     counts_by_sequence_id = {item["id"]: item["detections_count"] for item in returned}
     assert counts_by_sequence_id[sequence_with_detections.id] == 2
     assert counts_by_sequence_id[sequence_without_detections.id] == 0
+
+
+@pytest.mark.asyncio
+async def test_latest_sequences_admin_sees_all_organizations(
+    async_client: AsyncClient, detection_session: AsyncSession
+):
+    now = utcnow()
+    org2_sequence = Sequence(
+        camera_id=pytest.camera_table[1]["id"],  # camera of organization 2
+        pose_id=None,
+        camera_azimuth=180.0,
+        sequence_azimuth=175.0,
+        cone_angle=5.0,
+        is_wildfire=None,
+        started_at=now - timedelta(minutes=15),
+        last_seen_at=now - timedelta(minutes=5),
+    )
+    detection_session.add(org2_sequence)
+    await detection_session.commit()
+    await detection_session.refresh(org2_sequence)
+
+    # Admin of organization 1 sees the sequence of organization 2
+    admin_auth = pytest.get_token(
+        pytest.user_table[0]["id"], pytest.user_table[0]["role"].split(), pytest.user_table[0]["organization_id"]
+    )
+    response = await async_client.get("/sequences/unlabeled/latest", headers=admin_auth)
+    assert response.status_code == 200, print(response.__dict__)
+    assert org2_sequence.id in {item["id"] for item in response.json()}
+
+    # Agent of organization 1 does not
+    agent_auth = pytest.get_token(
+        pytest.user_table[1]["id"], pytest.user_table[1]["role"].split(), pytest.user_table[1]["organization_id"]
+    )
+    response = await async_client.get("/sequences/unlabeled/latest", headers=agent_auth)
+    assert response.status_code == 200, print(response.__dict__)
+    assert org2_sequence.id not in {item["id"] for item in response.json()}
 
 
 @pytest.mark.asyncio

--- a/src/tests/endpoints/test_sequences.py
+++ b/src/tests/endpoints/test_sequences.py
@@ -398,7 +398,7 @@ async def test_latest_sequences_admin_sees_all_organizations(
         pytest.user_table[0]["id"], pytest.user_table[0]["role"].split(), pytest.user_table[0]["organization_id"]
     )
     response = await async_client.get("/sequences/unlabeled/latest", headers=admin_auth)
-    assert response.status_code == 200, print(response.__dict__)
+    assert response.status_code == 200, response.__dict__
     assert org2_sequence.id in {item["id"] for item in response.json()}
 
     # Agent of organization 1 does not
@@ -406,7 +406,7 @@ async def test_latest_sequences_admin_sees_all_organizations(
         pytest.user_table[1]["id"], pytest.user_table[1]["role"].split(), pytest.user_table[1]["organization_id"]
     )
     response = await async_client.get("/sequences/unlabeled/latest", headers=agent_auth)
-    assert response.status_code == 200, print(response.__dict__)
+    assert response.status_code == 200, response.__dict__
     assert org2_sequence.id not in {item["id"] for item in response.json()}
 
 


### PR DESCRIPTION
- Alert and sequence list endpoints (`unlabeled/latest`, `all/fromdate`, `alerts/export`) were hard-scoped to the caller's organization; admins now see all organizations, matching the existing behavior of the camera and detection listings.
- The FWI risk-score filter is skipped for admins (it is resolved per organization); the `risk_score` override param is ignored for them and documented as such.
- Non-admin behavior is unchanged and covered by updated risk-filter tests plus new cross-organization tests.