### PR TITLE
Skip s3 obj existence

### DIFF
--- a/src/app/api/api_v1/endpoints/detections.py
+++ b/src/app/api/api_v1/endpoints/detections.py
@@ -647,8 +647,10 @@ async def get_detection_url(
     if UserRole.ADMIN not in token_payload.scopes and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
     bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(camera.organization_id))
-    crop_url = bucket.get_public_url(detection.crop_bucket_key) if detection.crop_bucket_key else None
-    return DetectionUrl(url=bucket.get_public_url(detection.bucket_key), crop_url=crop_url)
+    crop_url = (
+        bucket.get_public_url(detection.crop_bucket_key, verify_exists=False) if detection.crop_bucket_key else None
+    )
+    return DetectionUrl(url=bucket.get_public_url(detection.bucket_key, verify_exists=False), crop_url=crop_url)
 
 
 @router.get("/", status_code=status.HTTP_200_OK, summary="Fetch all the detections")

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -95,8 +95,12 @@ async def fetch_sequence_detections(
     return [
         DetectionWithUrl(
             **DetectionRead(**elt.model_dump()).model_dump(),
-            url=bucket.get_public_url(elt.bucket_key),
-            crop_url=(bucket.get_public_url(elt.crop_bucket_key) if with_crop and elt.crop_bucket_key else None),
+            url=bucket.get_public_url(elt.bucket_key, verify_exists=False),
+            crop_url=(
+                bucket.get_public_url(elt.crop_bucket_key, verify_exists=False)
+                if with_crop and elt.crop_bucket_key
+                else None
+            ),
         )
         for elt in fetched
     ]

--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -67,9 +67,22 @@ class S3Bucket:
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.delete_object
         self._s3.delete_object(Bucket=self.name, Key=bucket_key)
 
-    def get_public_url(self, bucket_key: str, url_expiration: int = settings.S3_URL_EXPIRATION) -> str:
-        """Generate a temporary public URL for a bucket file"""
-        if not self.check_file_existence(bucket_key):
+    def get_public_url(
+        self, bucket_key: str, url_expiration: int = settings.S3_URL_EXPIRATION, verify_exists: bool = True
+    ) -> str:
+        """Generate a temporary public URL for a bucket file
+
+        Args:
+            bucket_key: the key of the file on the bucket
+            url_expiration: how long the presigned URL stays valid, in seconds
+            verify_exists: when True (default), raise a 404 if the object is missing on the
+                bucket. Presigning itself is a local signature computation with no network
+                I/O, whereas this check adds one blocking S3 ``head_object`` round-trip per
+                file. Set it to False on hot paths where the object is expected to always
+                exist (e.g. sequence detections): the client then gets a 403/404 from S3
+                when loading the URL instead of an upfront error.
+        """
+        if verify_exists and not self.check_file_existence(bucket_key):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="File cannot be found on the bucket storage"
             )

--- a/src/tests/services/test_storage.py
+++ b/src/tests/services/test_storage.py
@@ -2,6 +2,7 @@ import io
 
 import boto3
 import pytest
+from fastapi import HTTPException
 
 from app.core.config import settings
 from app.services.storage import S3Bucket, S3Service
@@ -77,6 +78,11 @@ async def test_s3_bucket(bucket_name, proxy_url, expected_error, mock_img):
         bucket_key = "logo.png"
         # Create file
         assert not bucket.check_file_existence(bucket_key)
+        # By default get_public_url verifies existence and raises a 404 when the object is missing
+        with pytest.raises(HTTPException):
+            bucket.get_public_url(bucket_key)
+        # With verify_exists=False it skips the check and presigns a URL even when the object is missing
+        assert bucket.get_public_url(bucket_key, verify_exists=False).startswith("http://")
         bucket.upload_file(bucket_key, io.BytesIO(mock_img))
         assert bucket.check_file_existence(bucket_key)
         assert isinstance(bucket.get_file_metadata(bucket_key), dict)


### PR DESCRIPTION
Fixes #639  (and will help to implement frontend player with better performances)

# About implementation decisions


## Why not just remove the check globally

The check is not dead weight everywhere. The **camera** endpoints rely on it as a
contract: `last_image` points to a single mutable/rotating image that can legitimately be
gone, so `get_public_url` raising a 404 is caught and turned into `last_image_url: null`
(`cameras.py` `get_camera` / `fetch_cameras`). Removing the check globally breaks that —
and indeed broke `test_get_camera_s3_unavailable_returns_null_url` and
`test_fetch_cameras_s3_unavailable_returns_null_url`.

So there are two real options.

## Option A — change the contract (drop the check everywhere)

Remove the existence check entirely; endpoints always return a URL. If a file is missing,
the **frontend** handles the broken/expired URL (S3 returns 403/404 on load).

- **Pros:** simplest server code; no per-call flag; the frontend already has to handle
  expired presigned URLs anyway.
- **Cons:** changes the camera contract — `last_image_url` would no longer be `null` for a
  missing image, so the frontend must detect the broken image and the camera endpoints +
  their tests must be reworked. Error moves from back to front for every image type.

## **Option B — opt-out flag (`verify_exists`) -> **chosen****

Add `verify_exists: bool = True` to `get_public_url`. Default keeps today's behaviour
(cameras unchanged); hot paths pass `verify_exists=False` (sequence detections + detection
url) to skip the `head_object`.

- **Pros:** breaks the least — camera contract and its tests stay intact; the perf win
  lands exactly where the image always exists; localized, low-risk change.
- **Cons:** one extra parameter to reason about; the "verify or not" decision now lives at
  each call site rather than being uniform.

## Decision

Going with **Option B**: after reflection it is the cleanest — it delivers the perf win on
the hot path without forcing a contract change and frontend rework on cameras. Option A
stays on the table if we later decide the frontend should own missing-image handling
uniformly.


Happy to discuss it ! 