### PR TITLE
feat(alerts): add count endpoints for fromdate and unlabeled/latest

### DIFF
--- a/src/app/api/api_v1/endpoints/alerts.py
+++ b/src/app/api/api_v1/endpoints/alerts.py
@@ -7,7 +7,7 @@
 import csv
 import io
 from datetime import date, datetime, time, timedelta
-from typing import Any, Dict, Iterable, Iterator, List, Union, cast
+from typing import Any, Dict, Iterable, Iterator, List, Tuple, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Security, status
 from fastapi.responses import StreamingResponse
@@ -15,13 +15,14 @@ from sqlalchemy import asc, desc
 from sqlalchemy.sql import ColumnElement
 from sqlmodel import delete, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlmodel.sql.expression import SelectOfScalar
 
 from app.api.dependencies import get_alert_crud, get_camera_crud, get_jwt, get_sequence_crud
 from app.core.time import utcnow
 from app.crud import AlertCRUD, CameraCRUD, SequenceCRUD
 from app.db import get_session
 from app.models import Alert, AlertSequence, AnnotationType, Camera, Sequence, UserRole
-from app.schemas.alerts import AlertCreate, AlertReadWithSequences
+from app.schemas.alerts import AlertCount, AlertCreate, AlertReadWithSequences
 from app.schemas.login import TokenPayload
 from app.schemas.sequences import SequenceRead
 from app.services.alerts import refresh_alert_state
@@ -76,6 +77,53 @@ async def _resolve_fwi_class_per_camera(
     return {cid: cls for cid, cls in risk_service.scores().items()}
 
 
+async def _build_unlabeled_alerts_stmt(
+    session: AsyncSession,
+    organization_id: int,
+    risk_score: Union[FwiClass, None],
+) -> Tuple[Any, Union[ColumnElement[bool], None]]:
+    fwi_classes_by_camera = await _resolve_fwi_class_per_camera(session, organization_id, override_class=risk_score)
+    seq_filter = max_conf_filter_clause(fwi_classes_by_camera)
+
+    seq_match: Any = cast(
+        Any,
+        select(AlertSequence.alert_id).join(Sequence, cast(Any, Sequence.id == AlertSequence.sequence_id)),
+    )
+    seq_match = (
+        seq_match.where(Sequence.last_seen_at > utcnow() - timedelta(hours=24)).where(Sequence.is_wildfire.is_(None))  # type: ignore[union-attr]
+    )
+    if seq_filter is not None:
+        seq_match = seq_match.where(seq_filter)
+
+    alerts_stmt: Any = (
+        select(Alert).where(Alert.organization_id == organization_id).where(cast(Any, Alert.id).in_(seq_match))
+    )
+    return alerts_stmt, seq_filter
+
+
+async def _build_alerts_from_date_stmt(
+    session: AsyncSession,
+    organization_id: int,
+    from_date: date,
+    risk_score: Union[FwiClass, None],
+) -> Tuple[Any, Union[ColumnElement[bool], None]]:
+    fwi_classes_by_camera = await _resolve_fwi_class_per_camera(
+        session, organization_id, target_date=from_date, override_class=risk_score
+    )
+    seq_filter = max_conf_filter_clause(fwi_classes_by_camera)
+
+    alerts_stmt: Any = (
+        select(Alert).where(Alert.organization_id == organization_id).where(func.date(Alert.started_at) == from_date)
+    )
+    if seq_filter is not None:
+        seq_match: Any = select(AlertSequence.alert_id).join(
+            Sequence, cast(Any, Sequence.id == AlertSequence.sequence_id)
+        )
+        seq_match = seq_match.where(seq_filter)
+        alerts_stmt = alerts_stmt.where(cast(Any, Alert.id).in_(seq_match))
+    return alerts_stmt, seq_filter
+
+
 def _serialize_sequence(sequence: Sequence, detections_count: int = 0) -> SequenceRead:
     return SequenceRead(**sequence.model_dump(), detections_count=detections_count)
 
@@ -87,6 +135,19 @@ def _serialize_alert(
         **alert.model_dump(),
         sequences=[_serialize_sequence(sequence, detection_counts.get(sequence.id, 0)) for sequence in sequences],
     )
+
+
+async def _serialize_alerts_page(
+    session: AsyncSession, alerts_stmt: SelectOfScalar[Alert], seq_filter: Union[ColumnElement[bool], None]
+) -> List[AlertReadWithSequences]:
+    """Run an alert-selecting statement and hydrate each row with its filtered sequences and detection counts."""
+    alerts = list((await session.exec(alerts_stmt)).all())
+    seq_map = await _fetch_sequences_by_alert_ids(session, [alert.id for alert in alerts], seq_filter)
+    detection_counts = await get_detection_counts_by_sequence_ids(
+        session,
+        list({sequence.id for sequences in seq_map.values() for sequence in sequences}),
+    )
+    return [_serialize_alert(alert, seq_map.get(alert.id, []), detection_counts) for alert in alerts]
 
 
 _ALERT_EXPORT_COLUMNS = [
@@ -299,37 +360,27 @@ async def fetch_latest_unlabeled_alerts(
 ) -> List[AlertReadWithSequences]:
     telemetry_client.capture(token_payload.sub, event="alerts-fetch-latest")
 
-    fwi_classes_by_camera = await _resolve_fwi_class_per_camera(
-        session, token_payload.organization_id, override_class=risk_score
-    )
-    seq_filter = max_conf_filter_clause(fwi_classes_by_camera)
+    alerts_stmt, seq_filter = await _build_unlabeled_alerts_stmt(session, token_payload.organization_id, risk_score)
+    alerts_stmt = alerts_stmt.order_by(Alert.started_at.desc()).limit(limit).offset(offset)  # type: ignore[attr-defined]
+    return await _serialize_alerts_page(session, alerts_stmt, seq_filter)
 
-    seq_match: Any = cast(
-        Any,
-        select(AlertSequence.alert_id).join(Sequence, cast(Any, Sequence.id == AlertSequence.sequence_id)),
-    )
-    seq_match = (
-        seq_match.where(Sequence.last_seen_at > utcnow() - timedelta(hours=24)).where(Sequence.is_wildfire.is_(None))  # type: ignore[union-attr]
-    )
-    if seq_filter is not None:
-        seq_match = seq_match.where(seq_filter)
 
-    alerts_stmt: Any = (
-        select(Alert)
-        .where(Alert.organization_id == token_payload.organization_id)
-        .where(cast(Any, Alert.id).in_(seq_match))
-        .order_by(Alert.started_at.desc())  # type: ignore[attr-defined]
-        .limit(limit)
-        .offset(offset)
-    )
-    alerts = list((await session.exec(alerts_stmt)).all())
-    alert_ids = [alert.id for alert in alerts]
-    seq_map = await _fetch_sequences_by_alert_ids(session, alert_ids, seq_filter)
-    detection_counts = await get_detection_counts_by_sequence_ids(
-        session,
-        list({sequence.id for sequences in seq_map.values() for sequence in sequences}),
-    )
-    return [_serialize_alert(alert, seq_map.get(alert.id, []), detection_counts) for alert in alerts]
+@router.get(
+    "/unlabeled/latest/count",
+    status_code=status.HTTP_200_OK,
+    summary="Count the alerts with unlabeled sequences from the last 24 hours",
+)
+async def count_latest_unlabeled_alerts(
+    risk_score: Union[FwiClass, None] = Query(
+        None, description="Override FWI class applied to every sequence; bypasses risk-api lookup."
+    ),
+    session: AsyncSession = Depends(get_session),
+    token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
+) -> AlertCount:
+    telemetry_client.capture(token_payload.sub, event="alerts-count-latest")
+    alerts_stmt, _ = await _build_unlabeled_alerts_stmt(session, token_payload.organization_id, risk_score)
+    count_stmt: Any = select(func.count()).select_from(alerts_stmt.subquery())
+    return AlertCount(count=int((await session.exec(count_stmt)).one()))
 
 
 @router.get("/all/fromdate", status_code=status.HTTP_200_OK, summary="Fetch all the alerts for a specific date")
@@ -345,32 +396,30 @@ async def fetch_alerts_from_date(
 ) -> List[AlertReadWithSequences]:
     telemetry_client.capture(token_payload.sub, event="alerts-fetch-from-date")
 
-    fwi_classes_by_camera = await _resolve_fwi_class_per_camera(
-        session, token_payload.organization_id, target_date=from_date, override_class=risk_score
+    alerts_stmt, seq_filter = await _build_alerts_from_date_stmt(
+        session, token_payload.organization_id, from_date, risk_score
     )
-    seq_filter = max_conf_filter_clause(fwi_classes_by_camera)
-
-    alerts_stmt: Any = (
-        select(Alert)
-        .where(Alert.organization_id == token_payload.organization_id)
-        .where(func.date(Alert.started_at) == from_date)
-    )
-    if seq_filter is not None:
-        seq_match: Any = select(AlertSequence.alert_id).join(
-            Sequence, cast(Any, Sequence.id == AlertSequence.sequence_id)
-        )
-        seq_match = seq_match.where(seq_filter)
-        alerts_stmt = alerts_stmt.where(cast(Any, Alert.id).in_(seq_match))
     alerts_stmt = alerts_stmt.order_by(Alert.started_at.desc()).limit(limit).offset(offset)  # type: ignore[attr-defined]
+    return await _serialize_alerts_page(session, alerts_stmt, seq_filter)
 
-    alerts = list((await session.exec(alerts_stmt)).all())
-    alert_ids = [alert.id for alert in alerts]
-    seq_map = await _fetch_sequences_by_alert_ids(session, alert_ids, seq_filter)
-    detection_counts = await get_detection_counts_by_sequence_ids(
-        session,
-        list({sequence.id for sequences in seq_map.values() for sequence in sequences}),
-    )
-    return [_serialize_alert(alert, seq_map.get(alert.id, []), detection_counts) for alert in alerts]
+
+@router.get(
+    "/all/fromdate/count",
+    status_code=status.HTTP_200_OK,
+    summary="Count the alerts for a specific date",
+)
+async def count_alerts_from_date(
+    from_date: date = Query(),
+    risk_score: Union[FwiClass, None] = Query(
+        None, description="Override FWI class applied to every sequence; bypasses risk-api lookup."
+    ),
+    session: AsyncSession = Depends(get_session),
+    token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
+) -> AlertCount:
+    telemetry_client.capture(token_payload.sub, event="alerts-count-from-date")
+    alerts_stmt, _ = await _build_alerts_from_date_stmt(session, token_payload.organization_id, from_date, risk_score)
+    count_stmt: Any = select(func.count()).select_from(alerts_stmt.subquery())
+    return AlertCount(count=int((await session.exec(count_stmt)).one()))
 
 
 @router.post(

--- a/src/app/schemas/alerts.py
+++ b/src/app/schemas/alerts.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 
 from app.schemas.sequences import SequenceRead
 
-__all__ = ["AlertBase", "AlertCreate", "AlertRead", "AlertReadWithSequences", "AlertUpdate"]
+__all__ = ["AlertBase", "AlertCount", "AlertCreate", "AlertRead", "AlertReadWithSequences", "AlertUpdate"]
 
 
 class AlertBase(BaseModel):
@@ -37,3 +37,7 @@ class AlertRead(AlertCreate):
 
 class AlertReadWithSequences(AlertRead):
     sequences: List[SequenceRead] = Field(default_factory=list)
+
+
+class AlertCount(BaseModel):
+    count: int

--- a/src/tests/endpoints/test_alerts.py
+++ b/src/tests/endpoints/test_alerts.py
@@ -210,6 +210,68 @@ async def test_alerts_from_date(async_client: AsyncClient, detection_session: As
 
 
 @pytest.mark.asyncio
+async def test_alerts_unlabeled_latest_count(async_client: AsyncClient, detection_session: AsyncSession):
+    await _create_alert_with_sequences(detection_session, org_id=1, camera_id=1, lat=48.0, lon=2.0)
+    await _create_alert_with_sequences(detection_session, org_id=1, camera_id=1, lat=48.1, lon=2.1)
+
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"], pytest.user_table[0]["role"].split(), pytest.user_table[0]["organization_id"]
+    )
+    resp = await async_client.get("/alerts/unlabeled/latest/count", headers=auth)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 2}
+
+    resp = await async_client.get("/alerts/unlabeled/latest?limit=100&offset=0", headers=auth)
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()) == 2
+
+    other_org_auth = pytest.get_token(
+        pytest.user_table[2]["id"], pytest.user_table[2]["role"].split(), pytest.user_table[2]["organization_id"]
+    )
+    resp = await async_client.get("/alerts/unlabeled/latest/count", headers=other_org_auth)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 0}
+
+
+@pytest.mark.asyncio
+async def test_alerts_from_date_count(async_client: AsyncClient, detection_session: AsyncSession):
+    alert, _, _ = await _create_alert_with_sequences(detection_session, org_id=1, camera_id=1, lat=48.0, lon=2.0)
+    await _create_alert_with_sequences(detection_session, org_id=1, camera_id=1, lat=48.1, lon=2.1)
+    date_str = alert.started_at.date().isoformat()
+
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"], pytest.user_table[0]["role"].split(), pytest.user_table[0]["organization_id"]
+    )
+    resp = await async_client.get(f"/alerts/all/fromdate/count?from_date={date_str}", headers=auth)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 2}
+
+    resp = await async_client.get(f"/alerts/all/fromdate?from_date={date_str}&limit=100&offset=0", headers=auth)
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()) == 2
+
+    resp = await async_client.get("/alerts/all/fromdate/count?from_date=2019-01-01", headers=auth)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 0}
+
+    other_org_auth = pytest.get_token(
+        pytest.user_table[2]["id"], pytest.user_table[2]["role"].split(), pytest.user_table[2]["organization_id"]
+    )
+    resp = await async_client.get(f"/alerts/all/fromdate/count?from_date={date_str}", headers=other_org_auth)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 0}
+
+
+@pytest.mark.asyncio
+async def test_alerts_count_unauthenticated(async_client: AsyncClient):
+    resp = await async_client.get("/alerts/unlabeled/latest/count")
+    assert resp.status_code == 401, resp.text
+
+    resp = await async_client.get("/alerts/all/fromdate/count?from_date=2019-01-01")
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
 async def test_triangulation_creates_single_alert(
     async_client: AsyncClient, detection_session: AsyncSession, mock_img: bytes
 ):

--- a/src/tests/endpoints/test_risk_filter.py
+++ b/src/tests/endpoints/test_risk_filter.py
@@ -234,6 +234,43 @@ async def test_alerts_unlabeled_latest_risk_score_override(
 
 
 @pytest.mark.asyncio
+async def test_alerts_unlabeled_latest_count_matches_list_under_risk_filter(
+    async_client: AsyncClient, detection_session: AsyncSession, reset_risk_cache
+):
+    """The count endpoint must apply the same risk_score filter as the list, so the two stay in sync."""
+    camera_id = pytest.camera_table[1]["id"]
+    pose_id = pytest.pose_table[2]["id"]
+    low_seq = await _seed_unlabeled_sequence(detection_session, camera_id, pose_id, max_conf=0.30, minutes_ago=20)
+    high_seq = await _seed_unlabeled_sequence(detection_session, camera_id, pose_id, max_conf=0.55, minutes_ago=15)
+    await _seed_alert_with_sequence(detection_session, organization_id=2, seq=low_seq)
+    kept_alert = await _seed_alert_with_sequence(detection_session, organization_id=2, seq=high_seq)
+
+    risk_service._scores = {camera_id: "moderate"}  # no filter from the cache; override drives the filter
+
+    auth = pytest.get_token(
+        pytest.user_table[2]["id"],
+        pytest.user_table[2]["role"].split(),
+        pytest.user_table[2]["organization_id"],
+    )
+
+    # low threshold (0.45) drops the 0.30 alert but keeps the 0.55 one.
+    count_resp = await async_client.get("/alerts/unlabeled/latest/count?risk_score=low", headers=auth)
+    assert count_resp.status_code == 200, print(count_resp.__dict__)
+    assert count_resp.json() == {"count": 1}
+
+    list_resp = await async_client.get("/alerts/unlabeled/latest?risk_score=low&limit=100", headers=auth)
+    assert list_resp.status_code == 200, print(list_resp.__dict__)
+    list_ids = [item["id"] for item in list_resp.json()]
+    assert list_ids == [kept_alert.id]
+    assert count_resp.json()["count"] == len(list_ids)
+
+    # Without the override the cache class is moderate (no filter): both alerts count.
+    count_resp = await async_client.get("/alerts/unlabeled/latest/count", headers=auth)
+    assert count_resp.status_code == 200, print(count_resp.__dict__)
+    assert count_resp.json() == {"count": 2}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("fwi_class", ["moderate", "high", "very_high", "extreme"])
 async def test_alerts_unlabeled_latest_risk_score_moderate_or_above_keeps_everything(
     fwi_class: str, async_client: AsyncClient, detection_session: AsyncSession, reset_risk_cache


### PR DESCRIPTION
## What

Adds two dedicated count endpoints so the frontend can paginate the alert lists:

- `GET /api/v1/alerts/all/fromdate/count` (params: `from_date`, `risk_score`)
- `GET /api/v1/alerts/unlabeled/latest/count` (param: `risk_score`)

Each returns `{"count": n}`, the number of alerts matching exactly the same filters as its list counterpart, minus `limit`/`offset`.

## Why

Closes #636. `GET /alerts/all/fromdate` and `GET /alerts/unlabeled/latest` return paginated lists but no total, so the frontend cannot compute the number of pages. Rather than embed a count in the list responses (a breaking shape change), these are separate, non-breaking endpoints. They accept the same filtering params (`from_date`, `risk_score`) so the count always matches what the list will show under those filters.

## How

- Extracted the filter-building for each endpoint into shared `_build_unlabeled_alerts_stmt` / `_build_alerts_from_date_stmt` helpers. The list and count handlers for a given endpoint call the same builder, so the count cannot drift from the list.
- Added a `_serialize_alerts_page` helper that removes the previously duplicated list-materialization tail (query exec, sequence fetch, detection counts, serialize) shared by both list handlers.
- Added an `AlertCount` response schema.

## Testing

- New endpoint tests: happy-path counts, `count == len(list)` consistency under the same params, cross-org isolation, empty date, and unauthenticated (401).
- Added a parity test in `test_risk_filter.py` verifying count and list agree while a `risk_score` filter is active.
- Full suite green (608 passed, 1 skipped); `ruff` and `ty` clean.