### PR TITLE
feat(sequences): add detection sampling, plus S3 bucket and presigned-URL caching

### DIFF
--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -496,7 +496,7 @@ class Client:
     def fetch_sequences_detections(
         self,
         sequence_id: int,
-        limit: int = 10,
+        limit: Union[int, None] = None,
         desc: bool = True,
         with_crop: bool = True,
         sampling: int = 1,
@@ -510,29 +510,33 @@ class Client:
 
         Args:
             sequence_id: ID of the associated sequence entry
-            limit: maximum number of detections to fetch
+            limit: maximum number of detections to fetch. Left unset (the default) the API picks
+                10, or with sampling the size of the whole sampled span capped at 500
             desc: whether to order the detections by created_at in descending order
             with_crop: whether to include the crop_url for detections that have a crop
             sampling: keep one detection every N (1 = all, max 10000); the kept frames are picked
-                chronologically and do not depend on desc. Independent of limit: to span the whole
-                sequence in one call pass limit >= ceil(detections_count / sampling), otherwise
-                limit still caps how many sampled frames come back (with the desc=True and
-                limit=10 defaults, sampling=10 returns the 10 most recent sampled frames)
+                chronologically and do not depend on desc. Pair it with limit unset to span the
+                sequence, since an explicit limit below ceil(detections_count / sampling) returns
+                only part of the span. The X-Sampled-Total and X-Sampled-Truncated response
+                headers say whether what came back covers the sequence
             offset: number of detections to skip, within the sampled set
 
         Returns:
             HTTP response
         """
+        params: Dict[str, Any] = {
+            "desc": desc,
+            "with_crop": with_crop,
+            "sampling": sampling,
+            "offset": offset,
+        }
+        # Omitted rather than defaulted client-side, so the API can size it from the sampled set.
+        if limit is not None:
+            params["limit"] = limit
         return requests.get(
             urljoin(self._route_prefix, ClientRoute.SEQUENCES_FETCH_DETECTIONS.format(seq_id=sequence_id)),
             headers=self.headers,
-            params={
-                "limit": limit,
-                "desc": desc,
-                "with_crop": with_crop,
-                "sampling": sampling,
-                "offset": offset,
-            },
+            params=params,
             timeout=self.timeout,
         )
 

--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -516,10 +516,13 @@ class Client:
             with_crop: whether to include the crop_url for detections that have a crop
             sampling: keep one detection every N (1 = all, max 10000); the kept frames are picked
                 chronologically and do not depend on desc. Pair it with limit unset to span the
-                sequence, since an explicit limit below ceil(detections_count / sampling) returns
-                only part of the span. The X-Sampled-Total and X-Sampled-Truncated response
-                headers say whether what came back covers the sequence
-            offset: number of detections to skip, within the sampled set
+                sequence, since an explicit limit below ceil((detections_count - offset) / sampling)
+                returns only part of the span. The X-Sampled-Total and X-Sampled-Truncated response
+                headers say whether what came back covers the rest of the sequence
+            offset: number of detections to skip, counted in raw detections whatever sampling is,
+                and always from the oldest end regardless of desc. Sampling applies from there, so
+                offset=20 with sampling=48 starts at detection 21; page by advancing offset in
+                multiples of sampling
 
         Returns:
             HTTP response

--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -499,6 +499,8 @@ class Client:
         limit: int = 10,
         desc: bool = True,
         with_crop: bool = True,
+        sampling: int = 1,
+        offset: int = 0,
     ) -> Response:
         """List the detections of a sequence
 
@@ -511,6 +513,9 @@ class Client:
             limit: maximum number of detections to fetch
             desc: whether to order the detections by created_at in descending order
             with_crop: whether to include the crop_url for detections that have a crop
+            sampling: keep one detection every N (1 = all, max 10000); the kept frames are picked
+                chronologically and do not depend on desc
+            offset: number of detections to skip, within the sampled set
 
         Returns:
             HTTP response
@@ -518,7 +523,13 @@ class Client:
         return requests.get(
             urljoin(self._route_prefix, ClientRoute.SEQUENCES_FETCH_DETECTIONS.format(seq_id=sequence_id)),
             headers=self.headers,
-            params={"limit": limit, "desc": desc, "with_crop": with_crop},
+            params={
+                "limit": limit,
+                "desc": desc,
+                "with_crop": with_crop,
+                "sampling": sampling,
+                "offset": offset,
+            },
             timeout=self.timeout,
         )
 

--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -510,19 +510,15 @@ class Client:
 
         Args:
             sequence_id: ID of the associated sequence entry
-            limit: maximum number of detections to fetch. Left unset (the default) the API picks
-                10, or with sampling the size of the whole sampled span capped at 500
+            limit: maximum number of detections to fetch. Unset (the default) lets the API pick:
+                10, or the size of the whole sampled span capped at 500 when sampling is set
             desc: whether to order the detections by created_at in descending order
             with_crop: whether to include the crop_url for detections that have a crop
-            sampling: keep one detection every N (1 = all, max 10000); the kept frames are picked
-                chronologically and do not depend on desc. Pair it with limit unset to span the
-                sequence, since an explicit limit below ceil((detections_count - offset) / sampling)
-                returns only part of the span. The X-Sampled-Total and X-Sampled-Truncated response
-                headers say whether what came back covers the rest of the sequence
-            offset: number of detections to skip, counted in raw detections whatever sampling is,
-                and always from the oldest end regardless of desc. Sampling applies from there, so
-                offset=20 with sampling=48 starts at detection 21; page by advancing offset in
-                multiples of sampling
+            sampling: keep one detection every N (1 = all, max 10000). The kept frames do not
+                depend on desc. Leave limit unset to span the sequence, and read the
+                X-Sampled-Total / X-Sampled-Truncated response headers
+            offset: raw detections to skip, from the oldest end when sampling. Page by advancing
+                it in multiples of sampling
 
         Returns:
             HTTP response

--- a/client/pyroclient/client.py
+++ b/client/pyroclient/client.py
@@ -514,7 +514,10 @@ class Client:
             desc: whether to order the detections by created_at in descending order
             with_crop: whether to include the crop_url for detections that have a crop
             sampling: keep one detection every N (1 = all, max 10000); the kept frames are picked
-                chronologically and do not depend on desc
+                chronologically and do not depend on desc. Independent of limit: to span the whole
+                sequence in one call pass limit >= ceil(detections_count / sampling), otherwise
+                limit still caps how many sampled frames come back (with the desc=True and
+                limit=10 defaults, sampling=10 returns the 10 most recent sampled frames)
             offset: number of detections to skip, within the sampled set
 
         Returns:

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -191,9 +191,20 @@ def test_user_workflow(test_cam_workflow, user_token):
     assert len(response.json()) == 0  # Sequence was labeled by agent
     response = user_client.fetch_sequences_from_date(datetime.utcnow().date().isoformat())
     assert len(response.json()) == 1
-    response = user_client.fetch_sequences_detections(response.json()[0]["id"])
+    sequence_id = response.json()[0]["id"]
+    response = user_client.fetch_sequences_detections(sequence_id)
     assert response.status_code == 200, response.__dict__
     # 4 real detections + the continuity row added by the empty frame in test_cam_workflow
     detections = response.json()
     assert len(detections) == 5
     assert sum(det["bbox"] == "[]" for det in detections) == 1
+    # An explicit limit is forwarded, an omitted one is left to the API.
+    response = user_client.fetch_sequences_detections(sequence_id, limit=2)
+    assert response.status_code == 200, response.__dict__
+    assert len(response.json()) == 2
+    # With sampling and no limit, the API sizes the response to span the sampled set.
+    response = user_client.fetch_sequences_detections(sequence_id, sampling=2)
+    assert response.status_code == 200, response.__dict__
+    assert len(response.json()) == 3  # ceil(5 / 2)
+    assert response.headers["x-sampled-total"] == "3"
+    assert response.headers["x-sampled-truncated"] == "false"

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -7,7 +7,7 @@
 from datetime import date, timedelta
 from typing import Any, List, Union, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Security, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, Security, status
 from sqlmodel import delete, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -28,6 +28,11 @@ from app.services.storage import s3_service
 from app.services.telemetry import telemetry_client
 
 router = APIRouter()
+
+# Historical default, kept for sampling=1 so unsampled callers see no change.
+DEFAULT_DETECTION_LIMIT = 10
+# Ceiling on one response, mirrored in the limit Query constraint.
+MAX_DETECTION_LIMIT = 500
 
 
 async def verify_org_rights(
@@ -71,8 +76,18 @@ async def get_sequence(
     ),
 )
 async def fetch_sequence_detections(
+    response: Response,
     sequence_id: int = Path(..., gt=0),
-    limit: int = Query(10, description="Maximum number of detections to fetch", ge=1, le=500),
+    limit: Union[int, None] = Query(
+        None,
+        description=(
+            "Maximum number of detections to fetch. Defaults to 10, except when `sampling` is set "
+            "and `limit` is omitted: it then defaults to whatever spans the whole sampled set "
+            "(capped at 500), so `?sampling=10` returns a spread instead of a truncated tail."
+        ),
+        ge=1,
+        le=500,
+    ),
     offset: int = Query(0, description="Number of detections to skip, within the sampled set", ge=0),
     desc: bool = Query(True, description="Whether to order the detections by created_at in descending order"),
     sampling: int = Query(
@@ -83,12 +98,12 @@ async def fetch_sequence_detections(
             "and does not shift as the sequence grows; the first detection is always kept. "
             "`limit` and `offset` then page that sampled set. Note that with `desc=true` a newly "
             "recorded detection shifts page boundaries, since it lands at the front. "
-            "**`sampling` and `limit` are independent: sampling thins the set, `limit` still caps "
-            "how many of it you get back.** To span the whole sequence in one call, pass "
-            "`limit >= ceil(detections_count / sampling)` (and since `limit` caps at 500, that "
-            "means `sampling >= detections_count / 500`); `detections_count` is on the sequence "
-            "object. `?sampling=10` on its own, with the `desc=true` and `limit=10` defaults, "
-            "returns the 10 most recent sampled frames rather than a spread across the sequence."
+            "`sampling` thins the set and `limit` caps how much of it comes back, so an explicit "
+            "`limit` below `ceil(detections_count / sampling)` returns only part of the span (the "
+            "most recent part when `desc=true`). Omit `limit` to get the whole span, and read the "
+            "`X-Sampled-Total` and `X-Sampled-Truncated` response headers to tell whether what you "
+            "got covers the sequence. Since `limit` caps at 500, spanning a sequence in one call "
+            "needs `sampling >= detections_count / 500`."
         ),
         ge=1,
         le=10_000,
@@ -100,6 +115,7 @@ async def fetch_sequence_detections(
     cameras: CameraCRUD = Depends(get_camera_crud),
     detections: DetectionCRUD = Depends(get_detection_crud),
     sequences: SequenceCRUD = Depends(get_sequence_crud),
+    session: AsyncSession = Depends(get_session),
     token_payload: TokenPayload = Security(get_jwt, scopes=[UserRole.ADMIN, UserRole.AGENT, UserRole.USER]),
 ) -> List[DetectionWithUrl]:
     telemetry_client.capture(token_payload.sub, event="sequences-get", properties={"sequence_id": sequence_id})
@@ -108,10 +124,24 @@ async def fetch_sequence_detections(
     if not token_payload.is_admin and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
+    effective_limit = DEFAULT_DETECTION_LIMIT if limit is None else limit
+    if sampling > 1:
+        # Sampling thins the set but limit still truncates it, and truncation is invisible in the
+        # response: you get frames that look like a spread but are only its tail. So size the
+        # sampled set once (the same count the endpoint returns, continuity rows included), use it
+        # to fill in an omitted limit, and report it either way so a caller passing an explicit
+        # limit can still tell whether it covered the sequence.
+        counts = await get_detection_counts_by_sequence_ids(session, [sequence_id])
+        sampled_total = -(-counts.get(sequence_id, 0) // sampling)  # ceil division
+        if limit is None:
+            effective_limit = max(1, min(MAX_DETECTION_LIMIT, sampled_total))
+        response.headers["X-Sampled-Total"] = str(sampled_total)
+        response.headers["X-Sampled-Truncated"] = str(offset + effective_limit < sampled_total).lower()
+
     # Get the bucket of the camera's organization
     bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(camera.organization_id))
     fetched = await detections.fetch_by_sequence(
-        sequence_id, sampling=sampling, order_desc=desc, limit=limit, offset=offset
+        sequence_id, sampling=sampling, order_desc=desc, limit=effective_limit, offset=offset
     )
     return [
         DetectionWithUrl(

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -17,7 +17,7 @@ from app.crud import AlertCRUD, CameraCRUD, DetectionCRUD, SequenceCRUD
 from app.db import get_session
 from app.models import AlertSequence, AnnotationType, Camera, Detection, Sequence, UserRole
 from app.schemas.alerts import AlertCreate
-from app.schemas.detections import DetectionRead, DetectionSequence, DetectionWithUrl
+from app.schemas.detections import DetectionSequence, DetectionWithUrl
 from app.schemas.login import TokenPayload
 from app.schemas.sequences import SequenceLabel, SequenceRead
 from app.services.alerts import refresh_alert_state
@@ -72,9 +72,21 @@ async def get_sequence(
 )
 async def fetch_sequence_detections(
     sequence_id: int = Path(..., gt=0),
-    limit: int = Query(10, description="Maximum number of detections to fetch", ge=1, le=100),
-    offset: int = Query(0, description="Number of detections to skip", ge=0),
+    limit: int = Query(10, description="Maximum number of detections to fetch", ge=1, le=500),
+    offset: int = Query(0, description="Number of detections to skip, within the sampled set", ge=0),
     desc: bool = Query(True, description="Whether to order the detections by created_at in descending order"),
+    sampling: int = Query(
+        1,
+        description=(
+            "Keep one detection every N (1 = every detection). The kept frames are picked "
+            "chronologically from the start of the sequence, so the set does not depend on `desc` "
+            "and does not shift as the sequence grows; the first detection is always kept. "
+            "`limit` and `offset` then page that sampled set. Note that with `desc=true` a newly "
+            "recorded detection shifts page boundaries, since it lands at the front."
+        ),
+        ge=1,
+        le=10_000,
+    ),
     with_crop: bool = Query(
         False,
         description="If true, presign and include crop_url for detections that have a crop. Defaults to false to skip the extra S3 head requests when crops are not needed.",
@@ -92,16 +104,12 @@ async def fetch_sequence_detections(
 
     # Get the bucket of the camera's organization
     bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(camera.organization_id))
-    fetched = await detections.fetch_all(
-        filters=("sequence_id", sequence_id),
-        order_by="created_at",
-        order_desc=desc,
-        limit=limit,
-        offset=offset,
+    fetched = await detections.fetch_by_sequence(
+        sequence_id, sampling=sampling, order_desc=desc, limit=limit, offset=offset
     )
     return [
         DetectionWithUrl(
-            **DetectionRead(**elt.model_dump()).model_dump(),
+            **elt.model_dump(),
             url=bucket.get_public_url(elt.bucket_key, verify_exists=False),
             crop_url=(
                 bucket.get_public_url(elt.crop_bucket_key, verify_exists=False)

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 
+import math
 from datetime import date, timedelta
 from typing import Any, List, Union, cast
 
@@ -29,10 +30,9 @@ from app.services.telemetry import telemetry_client
 
 router = APIRouter()
 
-# Historical default, kept for sampling=1 so unsampled callers see no change.
-DEFAULT_DETECTION_LIMIT = 10
-# Ceiling on one response, mirrored in the limit Query constraint.
+DEFAULT_DETECTION_LIMIT = 10  # historical default, kept for sampling=1
 MAX_DETECTION_LIMIT = 500
+MAX_SAMPLING = 10_000
 
 
 async def verify_org_rights(
@@ -81,22 +81,20 @@ async def fetch_sequence_detections(
     limit: Union[int, None] = Query(
         None,
         description=(
-            "Maximum number of detections to fetch. Defaults to 10, except when `sampling` is set "
-            "and `limit` is omitted: it then defaults to whatever spans the sampled set from "
-            "`offset` onward (capped at 500), so `?sampling=10` returns a spread instead of a "
-            "truncated tail."
+            f"Maximum number of detections to fetch. Defaults to {DEFAULT_DETECTION_LIMIT}, except "
+            "when `sampling` is set and `limit` is omitted: it then spans the whole sampled set "
+            f"from `offset` onward, capped at {MAX_DETECTION_LIMIT}."
         ),
         ge=1,
-        le=500,
+        le=MAX_DETECTION_LIMIT,
     ),
     offset: int = Query(
         0,
         description=(
-            "Number of detections to skip. Always counted in raw detections, whatever `sampling` "
-            "is, and always from the oldest end regardless of `desc`. Sampling then applies from "
-            "that point, so `offset=20&sampling=48` starts at detection 21 and steps by 48. Page "
-            "by advancing `offset` in multiples of `sampling`, which keeps the same detections in "
-            "the grid instead of shifting it onto different ones."
+            "Number of detections to skip, counted in raw detections whatever `sampling` is. When "
+            "sampling, it counts from the oldest end regardless of `desc`, so "
+            "`offset=20&sampling=48` starts at detection 21. Page by advancing `offset` in "
+            "multiples of `sampling` to keep the grid on the same detections."
         ),
         ge=0,
     ),
@@ -104,20 +102,15 @@ async def fetch_sequence_detections(
     sampling: int = Query(
         1,
         description=(
-            "Keep one detection every N (1 = every detection). The kept frames are picked "
-            "chronologically from the start of the sequence, so the set does not depend on `desc` "
-            "and does not shift as the sequence grows; the detection at `offset` is always kept. "
-            "`offset` moves the starting detection and `limit` caps how many kept frames come "
-            "back. "
-            "`sampling` thins the set and `limit` caps how much of it comes back, so an explicit "
-            "`limit` below `ceil((detections_count - offset) / sampling)` returns only part of the "
-            "span (the most recent part when `desc=true`). Omit `limit` to get the whole span, and "
-            "read the `X-Sampled-Total` and `X-Sampled-Truncated` response headers to tell whether "
-            "what you got covers the rest of the sequence. Since `limit` caps at 500, spanning a "
-            "sequence in one call needs `sampling >= detections_count / 500`."
+            "Keep one detection every N (1 = every detection). Frames are picked chronologically, "
+            "so the set does not depend on `desc`. An explicit `limit` below "
+            "`ceil((detections_count - offset) / sampling)` returns only part of the span (its "
+            "most recent part when `desc=true`); omit `limit` to get the whole span, and read the "
+            "`X-Sampled-Total` and `X-Sampled-Truncated` response headers to tell whether it "
+            "covered the rest of the sequence."
         ),
         ge=1,
-        le=10_000,
+        le=MAX_SAMPLING,
     ),
     with_crop: bool = Query(
         False,
@@ -135,23 +128,16 @@ async def fetch_sequence_detections(
     if not token_payload.is_admin and token_payload.organization_id != camera.organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden.")
 
-    effective_limit = DEFAULT_DETECTION_LIMIT if limit is None else limit
     if sampling > 1:
-        # Sampling thins the set but limit still truncates it, and truncation is invisible in the
-        # response: you get frames that look like a spread but are only its tail. So size the
-        # sampled set once (the same count the endpoint returns, continuity rows included), use it
-        # to fill in an omitted limit, and report it either way so a caller passing an explicit
-        # limit can still tell whether it covered the sequence.
+        # limit still truncates the thinned set, invisibly: you get what looks like a spread but is
+        # only its tail. Size the set so an omitted limit spans it, and report it either way.
         counts = await get_detection_counts_by_sequence_ids(session, [sequence_id])
-        # Frames available from the offset onward, since offset counts raw detections: that is
-        # what the caller can actually still receive, so it is also the right size for an
-        # omitted limit and the right thing to compare against for truncation.
-        remaining = max(0, counts.get(sequence_id, 0) - offset)
-        sampled_total = -(-remaining // sampling)  # ceil division
-        if limit is None:
-            effective_limit = max(1, min(MAX_DETECTION_LIMIT, sampled_total))
+        sampled_total = math.ceil(max(0, counts.get(sequence_id, 0) - offset) / sampling)
+        effective_limit = limit if limit is not None else min(MAX_DETECTION_LIMIT, sampled_total)
         response.headers["X-Sampled-Total"] = str(sampled_total)
         response.headers["X-Sampled-Truncated"] = str(effective_limit < sampled_total).lower()
+    else:
+        effective_limit = limit if limit is not None else DEFAULT_DETECTION_LIMIT
 
     # Get the bucket of the camera's organization
     bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(camera.organization_id))

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -82,7 +82,13 @@ async def fetch_sequence_detections(
             "chronologically from the start of the sequence, so the set does not depend on `desc` "
             "and does not shift as the sequence grows; the first detection is always kept. "
             "`limit` and `offset` then page that sampled set. Note that with `desc=true` a newly "
-            "recorded detection shifts page boundaries, since it lands at the front."
+            "recorded detection shifts page boundaries, since it lands at the front. "
+            "**`sampling` and `limit` are independent: sampling thins the set, `limit` still caps "
+            "how many of it you get back.** To span the whole sequence in one call, pass "
+            "`limit >= ceil(detections_count / sampling)` (and since `limit` caps at 500, that "
+            "means `sampling >= detections_count / 500`); `detections_count` is on the sequence "
+            "object. `?sampling=10` on its own, with the `desc=true` and `limit=10` defaults, "
+            "returns the 10 most recent sampled frames rather than a spread across the sequence."
         ),
         ge=1,
         le=10_000,

--- a/src/app/api/api_v1/endpoints/sequences.py
+++ b/src/app/api/api_v1/endpoints/sequences.py
@@ -82,28 +82,39 @@ async def fetch_sequence_detections(
         None,
         description=(
             "Maximum number of detections to fetch. Defaults to 10, except when `sampling` is set "
-            "and `limit` is omitted: it then defaults to whatever spans the whole sampled set "
-            "(capped at 500), so `?sampling=10` returns a spread instead of a truncated tail."
+            "and `limit` is omitted: it then defaults to whatever spans the sampled set from "
+            "`offset` onward (capped at 500), so `?sampling=10` returns a spread instead of a "
+            "truncated tail."
         ),
         ge=1,
         le=500,
     ),
-    offset: int = Query(0, description="Number of detections to skip, within the sampled set", ge=0),
+    offset: int = Query(
+        0,
+        description=(
+            "Number of detections to skip. Always counted in raw detections, whatever `sampling` "
+            "is, and always from the oldest end regardless of `desc`. Sampling then applies from "
+            "that point, so `offset=20&sampling=48` starts at detection 21 and steps by 48. Page "
+            "by advancing `offset` in multiples of `sampling`, which keeps the same detections in "
+            "the grid instead of shifting it onto different ones."
+        ),
+        ge=0,
+    ),
     desc: bool = Query(True, description="Whether to order the detections by created_at in descending order"),
     sampling: int = Query(
         1,
         description=(
             "Keep one detection every N (1 = every detection). The kept frames are picked "
             "chronologically from the start of the sequence, so the set does not depend on `desc` "
-            "and does not shift as the sequence grows; the first detection is always kept. "
-            "`limit` and `offset` then page that sampled set. Note that with `desc=true` a newly "
-            "recorded detection shifts page boundaries, since it lands at the front. "
+            "and does not shift as the sequence grows; the detection at `offset` is always kept. "
+            "`offset` moves the starting detection and `limit` caps how many kept frames come "
+            "back. "
             "`sampling` thins the set and `limit` caps how much of it comes back, so an explicit "
-            "`limit` below `ceil(detections_count / sampling)` returns only part of the span (the "
-            "most recent part when `desc=true`). Omit `limit` to get the whole span, and read the "
-            "`X-Sampled-Total` and `X-Sampled-Truncated` response headers to tell whether what you "
-            "got covers the sequence. Since `limit` caps at 500, spanning a sequence in one call "
-            "needs `sampling >= detections_count / 500`."
+            "`limit` below `ceil((detections_count - offset) / sampling)` returns only part of the "
+            "span (the most recent part when `desc=true`). Omit `limit` to get the whole span, and "
+            "read the `X-Sampled-Total` and `X-Sampled-Truncated` response headers to tell whether "
+            "what you got covers the rest of the sequence. Since `limit` caps at 500, spanning a "
+            "sequence in one call needs `sampling >= detections_count / 500`."
         ),
         ge=1,
         le=10_000,
@@ -132,11 +143,15 @@ async def fetch_sequence_detections(
         # to fill in an omitted limit, and report it either way so a caller passing an explicit
         # limit can still tell whether it covered the sequence.
         counts = await get_detection_counts_by_sequence_ids(session, [sequence_id])
-        sampled_total = -(-counts.get(sequence_id, 0) // sampling)  # ceil division
+        # Frames available from the offset onward, since offset counts raw detections: that is
+        # what the caller can actually still receive, so it is also the right size for an
+        # omitted limit and the right thing to compare against for truncation.
+        remaining = max(0, counts.get(sequence_id, 0) - offset)
+        sampled_total = -(-remaining // sampling)  # ceil division
         if limit is None:
             effective_limit = max(1, min(MAX_DETECTION_LIMIT, sampled_total))
         response.headers["X-Sampled-Total"] = str(sampled_total)
-        response.headers["X-Sampled-Truncated"] = str(offset + effective_limit < sampled_total).lower()
+        response.headers["X-Sampled-Truncated"] = str(effective_limit < sampled_total).lower()
 
     # Get the bucket of the camera's organization
     bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(camera.organization_id))

--- a/src/app/crud/crud_detection.py
+++ b/src/app/crud/crud_detection.py
@@ -44,25 +44,14 @@ class DetectionCRUD(BaseCRUD[Detection, DetectionCreate, DetectionSequence]):
     ) -> List[Detection]:
         """Fetch the detections of a sequence, keeping one every ``sampling``.
 
-        ``offset`` counts raw detections, never sampled frames, so it means the same thing
-        whatever ``sampling`` is (and at ``sampling=1`` the two readings coincide). Sampling then
-        applies from that point: ``offset=20, sampling=48`` starts at detection 21 and steps by
-        48. Callers page by advancing ``offset`` in multiples of ``sampling``, which keeps the
-        grid on the same detections instead of shifting its phase.
-
-        The row number is always computed ascending on ``created_at``, so neither the offset nor
-        the sampled set depends on ``order_desc``: it only flips the output order. That also keeps
-        the set stable as the sequence grows, since a new detection lands last and cannot renumber
-        earlier rows, so the player keeps hitting the same frames (and the same cached URLs)
-        across polls. The first kept row is the one at ``offset``, so a sequence with anything
-        left past the offset always yields at least one row.
-
-        Note that ``limit`` cannot push down: ``row_number()`` has to cover every row of the
-        sequence before the modulo and the limit apply, which is why detections is indexed on
-        ``(sequence_id, created_at)``.
+        ``offset`` counts raw detections, never sampled frames. When sampling, the row number is
+        computed ascending on ``created_at``, so neither the offset nor the kept set depends on
+        ``order_desc``: it only flips the output order. Page by advancing ``offset`` in multiples
+        of ``sampling`` to keep the grid on the same detections. Unsampled calls delegate to
+        ``fetch_all``, where a SQL ``OFFSET`` applies after the sort and so counts from whichever
+        end ``order_desc`` selects.
         """
         if sampling <= 1:
-            # Unchanged pre-sampling behaviour, on purpose: same query, same ordering.
             return await self.fetch_all(
                 filters=("sequence_id", sequence_id),
                 order_by="created_at",
@@ -75,18 +64,15 @@ class DetectionCRUD(BaseCRUD[Detection, DetectionCreate, DetectionSequence]):
         row_num = func.row_number().over(
             order_by=(cast(Any, Detection.created_at).asc(), cast(Any, Detection.id).asc())
         )
-        # sqlalchemy's select for the numbering subquery (two entities, and .subquery() on it);
-        # sqlmodel's select for the outer one, since a single-entity SelectOfScalar is what makes
-        # session.exec return Detection instances rather than Row tuples.
+        # sqlmodel's select on the outer query: a single-entity SelectOfScalar is what makes
+        # exec return Detection instances rather than Row tuples.
         numbered: Any = select_sa(Detection, row_num.label("rn")).where(cast(Any, Detection.sequence_id) == sequence_id)
         subq = numbered.subquery()
         sampled = aliased(Detection, subq)
         created_at_col = cast(Any, sampled.created_at)
         id_col = cast(Any, sampled.id)
-        # offset lands in the WHERE rather than a SQL OFFSET: it has to be measured in raw
-        # detections on the ascending numbering, not in rows of the already-sampled result (a SQL
-        # OFFSET would also be applied after ORDER BY, making it count from the newest end
-        # whenever order_desc is set).
+        # offset in the WHERE, not a SQL OFFSET: it counts raw detections on the ascending
+        # numbering, and a SQL OFFSET would instead apply after ORDER BY.
         position = subq.c.rn - 1
         stmt: Any = (
             select(sampled)

--- a/src/app/crud/crud_detection.py
+++ b/src/app/crud/crud_detection.py
@@ -44,13 +44,18 @@ class DetectionCRUD(BaseCRUD[Detection, DetectionCreate, DetectionSequence]):
     ) -> List[Detection]:
         """Fetch the detections of a sequence, keeping one every ``sampling``.
 
-        The row number is always computed ascending on ``created_at``, so the sampled frame set
-        is the same whatever ``order_desc`` is: the latter only flips the output order. That
-        also keeps the set stable as the sequence grows, since a new detection lands last and
-        cannot renumber earlier rows, so the player keeps hitting the same frames (and the same
-        cached URLs) across polls. ``(rn - 1) % sampling == 0`` keeps the first detection, so a
-        non-empty sequence always yields at least one row. ``limit``/``offset`` page the
-        *sampled* set, not the raw rows.
+        ``offset`` counts raw detections, never sampled frames, so it means the same thing
+        whatever ``sampling`` is (and at ``sampling=1`` the two readings coincide). Sampling then
+        applies from that point: ``offset=20, sampling=48`` starts at detection 21 and steps by
+        48. Callers page by advancing ``offset`` in multiples of ``sampling``, which keeps the
+        grid on the same detections instead of shifting its phase.
+
+        The row number is always computed ascending on ``created_at``, so neither the offset nor
+        the sampled set depends on ``order_desc``: it only flips the output order. That also keeps
+        the set stable as the sequence grows, since a new detection lands last and cannot renumber
+        earlier rows, so the player keeps hitting the same frames (and the same cached URLs)
+        across polls. The first kept row is the one at ``offset``, so a sequence with anything
+        left past the offset always yields at least one row.
 
         Note that ``limit`` cannot push down: ``row_number()`` has to cover every row of the
         sequence before the modulo and the limit apply, which is why detections is indexed on
@@ -78,15 +83,20 @@ class DetectionCRUD(BaseCRUD[Detection, DetectionCreate, DetectionSequence]):
         sampled = aliased(Detection, subq)
         created_at_col = cast(Any, sampled.created_at)
         id_col = cast(Any, sampled.id)
+        # offset lands in the WHERE rather than a SQL OFFSET: it has to be measured in raw
+        # detections on the ascending numbering, not in rows of the already-sampled result (a SQL
+        # OFFSET would also be applied after ORDER BY, making it count from the newest end
+        # whenever order_desc is set).
+        position = subq.c.rn - 1
         stmt: Any = (
             select(sampled)
-            .where((subq.c.rn - 1) % sampling == 0)
+            .where(position >= offset)
+            .where((position - offset) % sampling == 0)
             .order_by(
                 created_at_col.desc() if order_desc else created_at_col.asc(),
                 id_col.desc() if order_desc else id_col.asc(),
             )
             .limit(limit)
-            .offset(offset)
         )
         result = await self.session.exec(stmt)
         return list(result.all())

--- a/src/app/crud/crud_detection.py
+++ b/src/app/crud/crud_detection.py
@@ -3,9 +3,11 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
-from typing import Any, Union, cast
+from typing import Any, List, Union, cast
 
-from sqlalchemy import desc
+from sqlalchemy import desc, func
+from sqlalchemy import select as select_sa
+from sqlalchemy.orm import aliased
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -31,3 +33,60 @@ class DetectionCRUD(BaseCRUD[Detection, DetectionCreate, DetectionSequence]):
         )
         results = await self.session.exec(statement)
         return results.first()
+
+    async def fetch_by_sequence(
+        self,
+        sequence_id: int,
+        sampling: int = 1,
+        order_desc: bool = True,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> List[Detection]:
+        """Fetch the detections of a sequence, keeping one every ``sampling``.
+
+        The row number is always computed ascending on ``created_at``, so the sampled frame set
+        is the same whatever ``order_desc`` is: the latter only flips the output order. That
+        also keeps the set stable as the sequence grows, since a new detection lands last and
+        cannot renumber earlier rows, so the player keeps hitting the same frames (and the same
+        cached URLs) across polls. ``(rn - 1) % sampling == 0`` keeps the first detection, so a
+        non-empty sequence always yields at least one row. ``limit``/``offset`` page the
+        *sampled* set, not the raw rows.
+
+        Note that ``limit`` cannot push down: ``row_number()`` has to cover every row of the
+        sequence before the modulo and the limit apply, which is why detections is indexed on
+        ``(sequence_id, created_at)``.
+        """
+        if sampling <= 1:
+            # Unchanged pre-sampling behaviour, on purpose: same query, same ordering.
+            return await self.fetch_all(
+                filters=("sequence_id", sequence_id),
+                order_by="created_at",
+                order_desc=order_desc,
+                limit=limit,
+                offset=offset,
+            )
+
+        # id breaks created_at ties so the sampled set is deterministic run to run.
+        row_num = func.row_number().over(
+            order_by=(cast(Any, Detection.created_at).asc(), cast(Any, Detection.id).asc())
+        )
+        # sqlalchemy's select for the numbering subquery (two entities, and .subquery() on it);
+        # sqlmodel's select for the outer one, since a single-entity SelectOfScalar is what makes
+        # session.exec return Detection instances rather than Row tuples.
+        numbered: Any = select_sa(Detection, row_num.label("rn")).where(cast(Any, Detection.sequence_id) == sequence_id)
+        subq = numbered.subquery()
+        sampled = aliased(Detection, subq)
+        created_at_col = cast(Any, sampled.created_at)
+        id_col = cast(Any, sampled.id)
+        stmt: Any = (
+            select(sampled)
+            .where((subq.c.rn - 1) % sampling == 0)
+            .order_by(
+                created_at_col.desc() if order_desc else created_at_col.asc(),
+                id_col.desc() if order_desc else id_col.asc(),
+            )
+            .limit(limit)
+            .offset(offset)
+        )
+        result = await self.session.exec(stmt)
+        return list(result.all())

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -126,6 +126,9 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    # allow_headers governs request headers; response headers stay hidden from browser JS unless
+    # they are listed here, and the sampling signals exist for the frontend player.
+    expose_headers=["X-Sampled-Total", "X-Sampled-Truncated"],
 )
 
 if isinstance(settings.SENTRY_DSN, str):

--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -141,13 +141,16 @@ class S3Bucket:
         simply age out through the size-bound eviction below.
 
         Stability is per-process: the cache lives on this instance, so it only dedupes URLs
-        within one worker. Running N uvicorn workers means a polling client can see up to N
-        distinct URLs per key per window, one per worker that happened to answer. The repo
-        currently runs a single worker (docker-compose.yml passes no ``--workers`` to uvicorn),
-        so this does not bite today. Making it cross-process would also require a shared
-        signing timestamp, and SigV4's ``X-Amz-Date`` is derived from the wall clock at signing
-        time rather than being a ``generate_presigned_url`` parameter, so it is not achievable
-        without patching boto3's clock.
+        within one worker. With W workers a polling client sees up to W distinct URLs per key
+        per window, one per worker that happened to answer, so a frame is fetched up to W times
+        instead of once. That is still far better than re-signing on every poll (which bust the
+        cache unconditionally), just divided by W. Production runs several workers, so this
+        applies there; the worker count is not visible from this repo, which only carries dev
+        compose files. See #671.
+
+        Making it cross-process is not achievable without patching boto3's clock: SigV4 derives
+        ``X-Amz-Date`` from the wall clock at signing time rather than taking it as a
+        ``generate_presigned_url`` parameter, so a shared cache would be the way in.
         """
         window = _url_cache_window(url_expiration)
         # monotonic: only the window length matters, and it is immune to NTP steps.

--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -5,8 +5,10 @@
 
 import hashlib
 import logging
+import time
+from collections import OrderedDict
 from mimetypes import guess_extension
-from typing import Any, BinaryIO, Dict, Union
+from typing import Any, BinaryIO, Dict, Tuple, Union
 
 import boto3
 import magic
@@ -20,6 +22,21 @@ __all__ = ["s3_service", "upload_file"]
 
 
 logger = logging.getLogger("uvicorn.warning")
+
+# Presigned URLs run 600-900 bytes, so ~1 KB per entry => ~8 MB hard ceiling per bucket.
+_URL_CACHE_MAXSIZE = 8192
+
+
+def _url_cache_window(url_expiration: int) -> int:
+    """How long a single presigned URL string keeps being handed out, in seconds.
+
+    Derived from the expiration rather than hardcoded, so lowering S3_URL_EXPIRATION can never
+    start serving already-expired URLs: the window never exceeds the lifetime, whatever the
+    input (the floor is 1, not 60, so a sub-minute expiration degrades to near-no-caching instead
+    of outliving the URL). At the 24h default the cap binds instead and the window is 1h, so a
+    handed-out URL always has >= 23h left.
+    """
+    return min(3600, max(1, url_expiration // 4))
 
 
 class S3Bucket:
@@ -41,6 +58,9 @@ class S3Bucket:
             raise ValueError(f"unable to access bucket {bucket_name}")
         self.name = bucket_name
         self.proxy_url = proxy_url
+        # (bucket_key, url_expiration, window slot) -> presigned URL. Scoped to the instance
+        # because proxy_url and the signing credentials are fixed per bucket.
+        self._url_cache: OrderedDict[Tuple[str, int, int], str] = OrderedDict()
 
     def get_file_metadata(self, bucket_key: str) -> Dict[str, Any]:
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.head_object
@@ -59,7 +79,16 @@ class S3Bucket:
     def upload_file(self, bucket_key: str, file_binary: BinaryIO) -> bool:
         """Upload a file to bucket and return whether the upload succeeded"""
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Bucket.upload_fileobj
-        self._s3.upload_fileobj(file_binary, self.name, bucket_key)
+        # Cache-Control is what turns the stable presigned URLs from get_public_url into actual
+        # browser cache hits: without it browsers only cache heuristically, so the player
+        # re-downloads frames it already has. Objects are immutable once written (the key
+        # embeds a content hash), so max-age can match the URL lifetime.
+        self._s3.upload_fileobj(
+            file_binary,
+            self.name,
+            bucket_key,
+            ExtraArgs={"CacheControl": f"private, max-age={settings.S3_URL_EXPIRATION}"},
+        )
         return True
 
     def delete_file(self, bucket_key: str) -> None:
@@ -82,18 +111,60 @@ class S3Bucket:
                 exist (e.g. sequence detections): the client then gets a 403/404 from S3
                 when loading the URL instead of an upfront error.
         """
+        # Checked before the cache lookup on purpose: a cache hit must not skip the existence
+        # check callers opted into.
         if verify_exists and not self.check_file_existence(bucket_key):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="File cannot be found on the bucket storage"
             )
 
-        # Generate a public URL for it using boto3 presign URL generation\
+        return self._stable_presign(bucket_key, url_expiration)
+
+    def _presign(self, bucket_key: str, url_expiration: int) -> str:
+        # Generate a public URL for it using boto3 presign URL generation
         presigned_url = self._s3.generate_presigned_url(
             "get_object", Params={"Bucket": self.name, "Key": bucket_key}, ExpiresIn=url_expiration
         )
         if self.proxy_url:
             return presigned_url.replace(self._s3.meta.endpoint_url, self.proxy_url)
         return presigned_url
+
+    def _stable_presign(self, bucket_key: str, url_expiration: int) -> str:
+        """Return the same URL string for a whole window, so the browser can cache frames.
+
+        boto3 stamps the current clock into every signature (``X-Amz-Date`` under SigV4,
+        ``Expires`` under SigV2), so re-presigning the same key yields a different string and
+        busts the client cache on each poll. The browser keys its cache on the full URL.
+
+        The window slot is part of the cache key, so a lookup against the current slot can never
+        return a previous window's entry: no explicit rollover clear is needed, and stale entries
+        simply age out through the size-bound eviction below.
+
+        Stability is per-process: the cache lives on this instance, so it only dedupes URLs
+        within one worker. Running N uvicorn workers means a polling client can see up to N
+        distinct URLs per key per window, one per worker that happened to answer. The repo
+        currently runs a single worker (docker-compose.yml passes no ``--workers`` to uvicorn),
+        so this does not bite today. Making it cross-process would also require a shared
+        signing timestamp, and SigV4's ``X-Amz-Date`` is derived from the wall clock at signing
+        time rather than being a ``generate_presigned_url`` parameter, so it is not achievable
+        without patching boto3's clock.
+        """
+        window = _url_cache_window(url_expiration)
+        # monotonic: only the window length matters, and it is immune to NTP steps.
+        slot = int(time.monotonic()) // window
+        cache_key = (bucket_key, url_expiration, slot)
+        url = self._url_cache.get(cache_key)
+        if url is not None:
+            self._url_cache.move_to_end(cache_key)
+            return url
+        url = self._presign(bucket_key, url_expiration)
+        if len(self._url_cache) >= _URL_CACHE_MAXSIZE:
+            # Evict the coldest entry, never clear: one dict is shared by every viewer of an
+            # organization, so clearing here would re-presign (and so change) every URL in
+            # flight exactly when the cache is under load and stability matters most.
+            self._url_cache.popitem(last=False)
+        self._url_cache[cache_key] = url
+        return url
 
     async def delete_items(self) -> None:
         """Delete all items in the bucket"""
@@ -131,6 +202,10 @@ class S3Service:
             raise ValueError("unable to access S3")
         logger.info(f"S3 connected on {endpoint_url}")
         self.proxy_url = proxy_url
+        # bucket_name -> S3Bucket. S3Bucket.__init__ does a blocking head_bucket round-trip on
+        # the event loop; the bucket set is one per organization and effectively static, so
+        # build each one once. Caching the instance is also what lets its URL cache ever hit.
+        self._buckets: Dict[str, S3Bucket] = {}
 
     def create_bucket(self, bucket_name: str) -> bool:
         """Create a new bucket in S3 storage"""
@@ -173,19 +248,31 @@ class S3Service:
         )
 
     def get_bucket(self, bucket_name: str) -> S3Bucket:
-        """Get an existing bucket in S3 storage"""
-        return S3Bucket(self._s3, bucket_name, self.proxy_url)
+        """Get an existing bucket in S3 storage (cached instance)
+
+        Only successful lookups are cached, so a missing bucket still raises ValueError. Once
+        cached, a bucket deleted out-of-band keeps answering and the failure surfaces at the S3
+        call rather than here.
+        """
+        bucket = self._buckets.get(bucket_name)
+        if bucket is None:
+            bucket = S3Bucket(self._s3, bucket_name, self.proxy_url)
+            self._buckets[bucket_name] = bucket
+        return bucket
 
     async def delete_bucket(self, bucket_name: str) -> bool:
         """Delete an existing bucket in S3 storage"""
-        bucket = S3Bucket(self._s3, bucket_name, self.proxy_url)
+        bucket = self.get_bucket(bucket_name)
         try:
             await bucket.delete_items()
             self._s3.delete_bucket(Bucket=bucket_name)
-            return True
         except ClientError as e:
             logger.warning(e)
             return False
+        # Evict only once the bucket is really gone, so the cache stays coherent with the
+        # organization-deletion path.
+        self._buckets.pop(bucket_name, None)
+        return True
 
     @staticmethod
     def resolve_bucket_name(organization_id: int) -> str:

--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -23,18 +23,15 @@ __all__ = ["s3_service", "upload_file"]
 
 logger = logging.getLogger("uvicorn.warning")
 
-# Presigned URLs run 600-900 bytes, so ~1 KB per entry => ~8 MB hard ceiling per bucket.
+# ~600 bytes per entry, so ~5 MB per bucket, and buckets are never evicted: the process
+# ceiling is that times the organization count, times the worker count.
 _URL_CACHE_MAXSIZE = 8192
 
 
 def _url_cache_window(url_expiration: int) -> int:
-    """How long a single presigned URL string keeps being handed out, in seconds.
+    """Seconds a presigned URL keeps being handed out (a quarter of its lifetime, capped at 1h).
 
-    Derived from the expiration rather than hardcoded, so lowering S3_URL_EXPIRATION can never
-    start serving already-expired URLs: the window never exceeds the lifetime, whatever the
-    input (the floor is 1, not 60, so a sub-minute expiration degrades to near-no-caching instead
-    of outliving the URL). At the 24h default the cap binds instead and the window is 1h, so a
-    handed-out URL always has >= 23h left.
+    Derived from the expiration so lowering S3_URL_EXPIRATION can never serve an expired URL.
     """
     return min(3600, max(1, url_expiration // 4))
 
@@ -79,10 +76,9 @@ class S3Bucket:
     def upload_file(self, bucket_key: str, file_binary: BinaryIO) -> bool:
         """Upload a file to bucket and return whether the upload succeeded"""
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Bucket.upload_fileobj
-        # Cache-Control is what turns the stable presigned URLs from get_public_url into actual
-        # browser cache hits: without it browsers only cache heuristically, so the player
-        # re-downloads frames it already has. Objects are immutable once written (the key
-        # embeds a content hash), so max-age can match the URL lifetime.
+        # Without Cache-Control browsers only cache heuristically, so the player re-downloads
+        # frames it already has. Objects are immutable (content-hashed key), so max-age can
+        # match the URL lifetime.
         self._s3.upload_fileobj(
             file_binary,
             self.name,
@@ -111,8 +107,7 @@ class S3Bucket:
                 exist (e.g. sequence detections): the client then gets a 403/404 from S3
                 when loading the URL instead of an upfront error.
         """
-        # Checked before the cache lookup on purpose: a cache hit must not skip the existence
-        # check callers opted into.
+        # Before the cache lookup: a hit must not skip the opted-in existence check.
         if verify_exists and not self.check_file_existence(bucket_key):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="File cannot be found on the bucket storage"
@@ -132,25 +127,9 @@ class S3Bucket:
     def _stable_presign(self, bucket_key: str, url_expiration: int) -> str:
         """Return the same URL string for a whole window, so the browser can cache frames.
 
-        boto3 stamps the current clock into every signature (``X-Amz-Date`` under SigV4,
-        ``Expires`` under SigV2), so re-presigning the same key yields a different string and
-        busts the client cache on each poll. The browser keys its cache on the full URL.
-
-        The window slot is part of the cache key, so a lookup against the current slot can never
-        return a previous window's entry: no explicit rollover clear is needed, and stale entries
-        simply age out through the size-bound eviction below.
-
-        Stability is per-process: the cache lives on this instance, so it only dedupes URLs
-        within one worker. With W workers a polling client sees up to W distinct URLs per key
-        per window, one per worker that happened to answer, so a frame is fetched up to W times
-        instead of once. That is still far better than re-signing on every poll (which bust the
-        cache unconditionally), just divided by W. Production runs several workers, so this
-        applies there; the worker count is not visible from this repo, which only carries dev
-        compose files. See #671.
-
-        Making it cross-process is not achievable without patching boto3's clock: SigV4 derives
-        ``X-Amz-Date`` from the wall clock at signing time rather than taking it as a
-        ``generate_presigned_url`` parameter, so a shared cache would be the way in.
+        boto3 stamps the signing clock into every signature, so re-presigning the same key yields
+        a different string and busts the client cache on each poll. Stability is per-process, so a
+        polling client sees one URL per key per window per worker. See #671.
         """
         window = _url_cache_window(url_expiration)
         # monotonic: only the window length matters, and it is immune to NTP steps.
@@ -162,9 +141,8 @@ class S3Bucket:
             return url
         url = self._presign(bucket_key, url_expiration)
         if len(self._url_cache) >= _URL_CACHE_MAXSIZE:
-            # Evict the coldest entry, never clear: one dict is shared by every viewer of an
-            # organization, so clearing here would re-presign (and so change) every URL in
-            # flight exactly when the cache is under load and stability matters most.
+            # Evict the coldest entry rather than clearing: a clear would change every URL in
+            # flight, for every viewer of the organization, exactly when the cache is loaded.
             self._url_cache.popitem(last=False)
         self._url_cache[cache_key] = url
         return url
@@ -205,9 +183,8 @@ class S3Service:
             raise ValueError("unable to access S3")
         logger.info(f"S3 connected on {endpoint_url}")
         self.proxy_url = proxy_url
-        # bucket_name -> S3Bucket. S3Bucket.__init__ does a blocking head_bucket round-trip on
-        # the event loop; the bucket set is one per organization and effectively static, so
-        # build each one once. Caching the instance is also what lets its URL cache ever hit.
+        # S3Bucket.__init__ does a blocking head_bucket, and the per-bucket URL cache only ever
+        # hits if the instance survives.
         self._buckets: Dict[str, S3Bucket] = {}
 
     def create_bucket(self, bucket_name: str) -> bool:
@@ -251,12 +228,7 @@ class S3Service:
         )
 
     def get_bucket(self, bucket_name: str) -> S3Bucket:
-        """Get an existing bucket in S3 storage (cached instance)
-
-        Only successful lookups are cached, so a missing bucket still raises ValueError. Once
-        cached, a bucket deleted out-of-band keeps answering and the failure surfaces at the S3
-        call rather than here.
-        """
+        """Get an existing bucket in S3 storage (cached instance; failures are not cached)"""
         bucket = self._buckets.get(bucket_name)
         if bucket is None:
             bucket = S3Bucket(self._s3, bucket_name, self.proxy_url)
@@ -272,8 +244,6 @@ class S3Service:
         except ClientError as e:
             logger.warning(e)
             return False
-        # Evict only once the bucket is really gone, so the cache stays coherent with the
-        # organization-deletion path.
         self._buckets.pop(bucket_name, None)
         return True
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -22,6 +22,7 @@ from app.core.time import utcnow
 from app.db import engine, session_factory
 from app.main import app
 from app.models import Camera, Detection, OcclusionMask, Organization, Pose, Sequence, User, Webhook
+from app.services import storage
 from app.services.storage import s3_service
 from app.services.validation import process_next_due_validation
 
@@ -336,6 +337,21 @@ def mock_hash_password(password):
 def mock_img():
     # Get Pyronear logo
     return requests.get("https://avatars.githubusercontent.com/u/61667887?s=200&v=4", timeout=5).content
+
+
+@pytest.fixture
+def pinned_url_window(monkeypatch):
+    """Freeze the presigned-URL cache window so a test cannot straddle a rollover.
+
+    Any assertion that two requests return the same url is otherwise wall-clock dependent: it
+    fails whenever the requests land either side of a window boundary. A window far longer than
+    any process uptime keeps the slot constant instead.
+    """
+    monkeypatch.setattr(storage, "_url_cache_window", lambda _url_expiration: 10**9)
+    for bucket in storage.s3_service._buckets.values():
+        # Both fixture consumers pin the window to the same huge value, so without clearing,
+        # whichever test runs second would start warm off the other's cache entries.
+        bucket._url_cache.clear()
 
 
 @pytest_asyncio.fixture(loop_scope="session")

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -341,16 +341,10 @@ def mock_img():
 
 @pytest.fixture
 def pinned_url_window(monkeypatch):
-    """Freeze the presigned-URL cache window so a test cannot straddle a rollover.
-
-    Any assertion that two requests return the same url is otherwise wall-clock dependent: it
-    fails whenever the requests land either side of a window boundary. A window far longer than
-    any process uptime keeps the slot constant instead.
-    """
+    """Freeze the presigned-URL cache window so a test cannot straddle a rollover."""
     monkeypatch.setattr(storage, "_url_cache_window", lambda _url_expiration: 10**9)
     for bucket in storage.s3_service._buckets.values():
-        # Both fixture consumers pin the window to the same huge value, so without clearing,
-        # whichever test runs second would start warm off the other's cache entries.
+        # Otherwise whichever consumer runs second starts warm off the first one's entries.
         bucket._url_cache.clear()
 
 

--- a/src/tests/endpoints/test_sequences.py
+++ b/src/tests/endpoints/test_sequences.py
@@ -1062,12 +1062,21 @@ async def test_fetch_sequence_detections_explicit_limit_still_wins_and_reports_t
     assert response.headers["x-sampled-total"] == "15"
     assert response.headers["x-sampled-truncated"] == "true"
 
-    # Paging to the end of the sampled set is not truncation.
+    # X-Sampled-Total counts what is left from the offset onward, so reaching the end of the
+    # sequence is not truncation: 30 detections, offset 22, sampling 2 leaves ceil(8 / 2) = 4.
     tail = await async_client.get(
-        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=4&offset=11", headers=auth
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=4&offset=22", headers=auth
     )
     assert tail.status_code == 200, tail.text
+    assert tail.headers["x-sampled-total"] == "4"
     assert tail.headers["x-sampled-truncated"] == "false"
+
+    # An offset past the end leaves nothing to return, and says so rather than erroring.
+    past = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&offset=99", headers=auth)
+    assert past.status_code == 200, past.text
+    assert past.json() == []
+    assert past.headers["x-sampled-total"] == "0"
+    assert past.headers["x-sampled-truncated"] == "false"
 
 
 @pytest.mark.asyncio
@@ -1131,36 +1140,15 @@ async def test_fetch_sequence_detections_sampling_larger_than_count(
 
 
 @pytest.mark.asyncio
-async def test_fetch_sequence_detections_sampling_offset_applies_to_sampled_set(
+async def test_fetch_sequence_detections_sampling_offset_counts_raw_detections(
     async_client: AsyncClient,
     detection_session: AsyncSession,
 ):
-    """offset skips sampled rows, not raw rows: positions 5 and 7, not 3 and 4."""
-    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
+    """offset skips raw detections, not sampled frames, whatever sampling is.
 
-    response = await async_client.get(
-        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=2&offset=2", headers=auth
-    )
-    assert response.status_code == 200, response.text
-    assert [det["id"] for det in response.json()] == [chronological_ids[4], chronological_ids[6]]
-
-
-@pytest.mark.asyncio
-async def test_fetch_sequence_detections_sampling_offset_desc_paging(
-    async_client: AsyncClient,
-    detection_session: AsyncSession,
-):
-    """`desc=true` only reverses the OUTPUT order of the sampled set, offset then skips
-    from the front of that reversed list.
-
-    The sampled set is chosen by ascending created_at: positions 1,3,5,7,9, i.e.
-    chronological_ids[::2] = [c0, c2, c4, c6, c8]. Reversing for desc=true gives
-    [c8, c6, c4, c2, c0]; offset=1, limit=2 then skips c8 and returns [c6, c4].
+    offset=3 starts at the 4th detection and sampling=2 steps from there, so the kept
+    chronological positions are 4, 6, 8, 10 and limit=2 returns the first two of them. Under the
+    old reading (offset counted in sampled frames) the same request returned positions 7 and 9.
     """
     sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
     auth = pytest.get_token(
@@ -1170,10 +1158,70 @@ async def test_fetch_sequence_detections_sampling_offset_desc_paging(
     )
 
     response = await async_client.get(
-        f"/sequences/{sequence_id}/detections?sampling=2&desc=true&limit=2&offset=1", headers=auth
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=2&offset=3", headers=auth
     )
     assert response.status_code == 200, response.text
-    assert [det["id"] for det in response.json()] == [chronological_ids[6], chronological_ids[4]]
+    assert [det["id"] for det in response.json()] == [chronological_ids[3], chronological_ids[5]]
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_sampling_offset_ignores_desc(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """offset always counts from the oldest end; desc only reverses the output.
+
+    So the two directions select the same frames and differ only in order. That is what makes the
+    selection fully independent of desc, matching how sampling already behaves.
+    """
+    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    asc = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=false&offset=3", headers=auth)
+    desc = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=true&offset=3", headers=auth)
+    assert asc.status_code == 200, asc.text
+    assert desc.status_code == 200, desc.text
+
+    expected = [chronological_ids[i] for i in (3, 5, 7, 9)]
+    assert [det["id"] for det in asc.json()] == expected
+    assert [det["id"] for det in desc.json()] == list(reversed(expected))
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_sampling_pages_by_multiples_of_sampling(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """Advancing offset by limit * sampling walks the same grid without repeating or skipping.
+
+    Because offset sets where the grid starts, only multiples of sampling keep it on the same
+    detections; this is the paging rule callers are told to use.
+    """
+    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session, count=30)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    sampling, limit = 3, 4
+    pages = []
+    for page in range(3):
+        offset = page * limit * sampling
+        response = await async_client.get(
+            f"/sequences/{sequence_id}/detections?sampling={sampling}&desc=false&limit={limit}&offset={offset}",
+            headers=auth,
+        )
+        assert response.status_code == 200, response.text
+        pages.append([det["id"] for det in response.json()])
+
+    walked = [det_id for page in pages for det_id in page]
+    assert walked == chronological_ids[::sampling]
+    assert len(walked) == len(set(walked))
 
 
 @pytest.mark.asyncio

--- a/src/tests/endpoints/test_sequences.py
+++ b/src/tests/endpoints/test_sequences.py
@@ -899,6 +899,266 @@ async def test_fetch_sequence_detections_offset_validation(
     assert response.status_code == 422
 
 
+async def _seed_sampling_sequence(session: AsyncSession, count: int = 10) -> tuple[int, List[int]]:
+    """Create a sequence with `count` detections one minute apart, oldest first.
+
+    Sequence 1 in the fixtures only has 3 detections, which is too few to tell an interval
+    apart from a limit. Returns the sequence id and the detection ids in chronological order.
+    """
+    now = utcnow()
+    sequence = Sequence(
+        camera_id=pytest.camera_table[0]["id"],
+        pose_id=pytest.pose_table[0]["id"],
+        camera_azimuth=180.0,
+        sequence_azimuth=175.0,
+        cone_angle=5.0,
+        is_wildfire=None,
+        started_at=now - timedelta(minutes=count),
+        last_seen_at=now,
+    )
+    session.add(sequence)
+    await session.commit()
+    await session.refresh(sequence)
+
+    detections = [
+        Detection(
+            camera_id=sequence.camera_id,
+            pose_id=pytest.pose_table[0]["id"],
+            sequence_id=sequence.id,
+            bucket_key=f"sampling-{sequence.id}-{idx}.jpg",
+            bbox="[(.1,.1,.7,.8,.9)]",
+            others_bboxes=None,
+            created_at=now - timedelta(minutes=count - idx),
+        )
+        for idx in range(count)
+    ]
+    for detection in detections:
+        session.add(detection)
+    await session.commit()
+    for detection in detections:
+        await session.refresh(detection)
+
+    return sequence.id, [detection.id for detection in detections]
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_sampling_set_is_independent_of_desc(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """The sampled frame set must not depend on `desc`: same ids, reversed order.
+
+    This is the whole point of numbering rows ascending regardless of the output order. If it
+    regresses, the player shows different frames depending on scroll direction.
+    """
+    sequence_id, _ = await _seed_sampling_sequence(detection_session)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    asc = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=10", headers=auth)
+    desc = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=true&limit=10", headers=auth)
+    assert asc.status_code == 200, asc.text
+    assert desc.status_code == 200, desc.text
+
+    asc_ids = [det["id"] for det in asc.json()]
+    desc_ids = [det["id"] for det in desc.json()]
+    assert asc_ids == list(reversed(desc_ids))
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_sampling_one_matches_default(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+    pinned_url_window: None,
+):
+    """sampling=1 must be indistinguishable from not passing it at all, urls included."""
+    sequence_id, _ = await _seed_sampling_sequence(detection_session)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    default = await async_client.get(f"/sequences/{sequence_id}/detections?limit=10&desc=false", headers=auth)
+    sampled = await async_client.get(
+        f"/sequences/{sequence_id}/detections?limit=10&desc=false&sampling=1", headers=auth
+    )
+    assert default.status_code == 200, default.text
+    assert sampled.status_code == 200, sampled.text
+    # Full equality, urls included. The fixture pins the presign window so a rollover between
+    # the two requests can't make the urls differ for reasons unrelated to sampling; that the
+    # cache is actually used is covered by
+    # test_fetch_sequence_detections_reuses_presigned_urls_across_requests.
+    assert default.json() == sampled.json()
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_sampling_interval(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """sampling=2 over 10 detections keeps chronological positions 1, 3, 5, 7, 9."""
+    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    response = await async_client.get(
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=10", headers=auth
+    )
+    assert response.status_code == 200, response.text
+    assert [det["id"] for det in response.json()] == chronological_ids[::2]
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_sampling_larger_than_count(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """A sampling interval above the detection count still returns the first detection."""
+    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    response = await async_client.get(
+        f"/sequences/{sequence_id}/detections?sampling=100&desc=false&limit=10", headers=auth
+    )
+    assert response.status_code == 200, response.text
+    assert [det["id"] for det in response.json()] == [chronological_ids[0]]
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_sampling_offset_applies_to_sampled_set(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """offset skips sampled rows, not raw rows: positions 5 and 7, not 3 and 4."""
+    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    response = await async_client.get(
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=2&offset=2", headers=auth
+    )
+    assert response.status_code == 200, response.text
+    assert [det["id"] for det in response.json()] == [chronological_ids[4], chronological_ids[6]]
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_sampling_offset_desc_paging(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """`desc=true` only reverses the OUTPUT order of the sampled set, offset then skips
+    from the front of that reversed list.
+
+    The sampled set is chosen by ascending created_at: positions 1,3,5,7,9, i.e.
+    chronological_ids[::2] = [c0, c2, c4, c6, c8]. Reversing for desc=true gives
+    [c8, c6, c4, c2, c0]; offset=1, limit=2 then skips c8 and returns [c6, c4].
+    """
+    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    response = await async_client.get(
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=true&limit=2&offset=1", headers=auth
+    )
+    assert response.status_code == 200, response.text
+    assert [det["id"] for det in response.json()] == [chronological_ids[6], chronological_ids[4]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("query", "status_code"),
+    [
+        ("sampling=0", 422),
+        ("sampling=-1", 422),
+        ("sampling=1", 200),
+        ("sampling=10000", 200),
+        ("sampling=10001", 422),
+        # asyncpg can't encode this into int8, so without an upper bound this reached the
+        # database and came back as a 500 instead of a validation error.
+        ("sampling=9223372036854775808", 422),
+        ("limit=500", 200),
+        ("limit=501", 422),
+    ],
+)
+async def test_fetch_sequence_detections_sampling_validation(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+    query: str,
+    status_code: int,
+):
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+    response = await async_client.get(f"/sequences/1/detections?{query}", headers=auth)
+    assert response.status_code == status_code, response.text
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_reuses_presigned_urls_across_requests(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+    pinned_url_window: None,
+):
+    """A repeat request must serve cached urls instead of re-signing every key.
+
+    boto3 stamps the current clock into every signature, so without the presign cache the
+    browser's cache key changes on every poll and the player re-downloads every frame. Asserting
+    the urls merely match is not enough: two signatures taken in the same wall-clock second are
+    identical anyway, so the presign calls are counted instead.
+    """
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+    bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(pytest.camera_table[0]["organization_id"]))
+    presign_calls: List[str] = []
+    original_presign = bucket._presign
+
+    def counting_presign(bucket_key: str, url_expiration: int) -> str:
+        presign_calls.append(bucket_key)
+        return original_presign(bucket_key, url_expiration)
+
+    bucket._presign = counting_presign  # type: ignore[method-assign]
+    try:
+        first = await async_client.get("/sequences/1/detections?limit=10&desc=false", headers=auth)
+        signed_once = len(presign_calls)
+        second = await async_client.get("/sequences/1/detections?limit=10&desc=false", headers=auth)
+    finally:
+        del bucket._presign
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+
+    first_urls = {det["id"]: det["url"] for det in first.json()}
+    assert first_urls
+    assert {det["id"]: det["url"] for det in second.json()} == first_urls
+    # One presign per distinct key: the fixture detections of sequence 1 all share a bucket_key,
+    # so the cache already collapses them within a single request.
+    assert signed_once == len(set(first_urls.values()))
+    # The second request signed nothing at all.
+    assert len(presign_calls) == signed_once
+
+
 @pytest.mark.asyncio
 async def test_unit_label_sequence_forbidden_for_wrong_org():
     """Verify that an AGENT from a different organization cannot label the sequence."""

--- a/src/tests/endpoints/test_sequences.py
+++ b/src/tests/endpoints/test_sequences.py
@@ -899,11 +899,19 @@ async def test_fetch_sequence_detections_offset_validation(
     assert response.status_code == 422
 
 
+@pytest.fixture
+def user_auth():
+    return pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+
 async def _seed_sampling_sequence(session: AsyncSession, count: int = 10) -> tuple[int, List[int]]:
     """Create a sequence with `count` detections one minute apart, oldest first.
 
-    Sequence 1 in the fixtures only has 3 detections, which is too few to tell an interval
-    apart from a limit. Returns the sequence id and the detection ids in chronological order.
+    The fixtures only give sequence 1 three detections, too few to tell an interval from a limit.
     """
     now = utcnow()
     sequence = Sequence(
@@ -932,8 +940,7 @@ async def _seed_sampling_sequence(session: AsyncSession, count: int = 10) -> tup
         )
         for idx in range(count)
     ]
-    for detection in detections:
-        session.add(detection)
+    session.add_all(detections)
     await session.commit()
     for detection in detections:
         await session.refresh(detection)
@@ -945,21 +952,18 @@ async def _seed_sampling_sequence(session: AsyncSession, count: int = 10) -> tup
 async def test_fetch_sequence_detections_sampling_set_is_independent_of_desc(
     async_client: AsyncClient,
     detection_session: AsyncSession,
+    user_auth: Dict[str, str],
 ):
-    """The sampled frame set must not depend on `desc`: same ids, reversed order.
-
-    This is the whole point of numbering rows ascending regardless of the output order. If it
-    regresses, the player shows different frames depending on scroll direction.
-    """
+    """Same ids, reversed order: if this regresses the player shows different frames per
+    scroll direction."""
     sequence_id, _ = await _seed_sampling_sequence(detection_session)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
 
-    asc = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=10", headers=auth)
-    desc = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=true&limit=10", headers=auth)
+    asc = await async_client.get(
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=10", headers=user_auth
+    )
+    desc = await async_client.get(
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=true&limit=10", headers=user_auth
+    )
     assert asc.status_code == 200, asc.text
     assert desc.status_code == 200, desc.text
 
@@ -973,18 +977,14 @@ async def test_fetch_sequence_detections_sampling_one_matches_default(
     async_client: AsyncClient,
     detection_session: AsyncSession,
     pinned_url_window: None,
+    user_auth: Dict[str, str],
 ):
     """sampling=1 must be indistinguishable from not passing it at all, urls included."""
     sequence_id, _ = await _seed_sampling_sequence(detection_session)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
 
-    default = await async_client.get(f"/sequences/{sequence_id}/detections?limit=10&desc=false", headers=auth)
+    default = await async_client.get(f"/sequences/{sequence_id}/detections?limit=10&desc=false", headers=user_auth)
     sampled = await async_client.get(
-        f"/sequences/{sequence_id}/detections?limit=10&desc=false&sampling=1", headers=auth
+        f"/sequences/{sequence_id}/detections?limit=10&desc=false&sampling=1", headers=user_auth
     )
     assert default.status_code == 200, default.text
     assert sampled.status_code == 200, sampled.text
@@ -999,17 +999,13 @@ async def test_fetch_sequence_detections_sampling_one_matches_default(
 async def test_fetch_sequence_detections_sampling_interval(
     async_client: AsyncClient,
     detection_session: AsyncSession,
+    user_auth: Dict[str, str],
 ):
     """sampling=2 over 10 detections keeps chronological positions 1, 3, 5, 7, 9."""
     sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
 
     response = await async_client.get(
-        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=10", headers=auth
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=10", headers=user_auth
     )
     assert response.status_code == 200, response.text
     assert [det["id"] for det in response.json()] == chronological_ids[::2]
@@ -1019,20 +1015,13 @@ async def test_fetch_sequence_detections_sampling_interval(
 async def test_fetch_sequence_detections_omitted_limit_spans_the_sampled_set(
     async_client: AsyncClient,
     detection_session: AsyncSession,
+    user_auth: Dict[str, str],
 ):
-    """Without an explicit limit, sampling must return the whole span, not its tail.
-
-    This is the guardrail: with the historical limit=10 default, `?sampling=2` on a 30-detection
-    sequence would silently return the 10 most recent sampled frames while looking like a spread.
-    """
+    """Without an explicit limit, sampling returns the whole span rather than its tail: the
+    historical limit=10 default would have silently returned only the 10 most recent."""
     sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session, count=30)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
 
-    response = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=false", headers=auth)
+    response = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=false", headers=user_auth)
     assert response.status_code == 200, response.text
     # ceil(30 / 2) = 15 frames, spanning the sequence rather than stopping at 10.
     assert [det["id"] for det in response.json()] == chronological_ids[::2]
@@ -1045,17 +1034,13 @@ async def test_fetch_sequence_detections_omitted_limit_spans_the_sampled_set(
 async def test_fetch_sequence_detections_explicit_limit_still_wins_and_reports_truncation(
     async_client: AsyncClient,
     detection_session: AsyncSession,
+    user_auth: Dict[str, str],
 ):
     """An explicit limit is honoured, and the headers say the span was cut short."""
     sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session, count=30)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
 
     response = await async_client.get(
-        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=4", headers=auth
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=4", headers=user_auth
     )
     assert response.status_code == 200, response.text
     assert [det["id"] for det in response.json()] == chronological_ids[::2][:4]
@@ -1065,14 +1050,14 @@ async def test_fetch_sequence_detections_explicit_limit_still_wins_and_reports_t
     # X-Sampled-Total counts what is left from the offset onward, so reaching the end of the
     # sequence is not truncation: 30 detections, offset 22, sampling 2 leaves ceil(8 / 2) = 4.
     tail = await async_client.get(
-        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=4&offset=22", headers=auth
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=4&offset=22", headers=user_auth
     )
     assert tail.status_code == 200, tail.text
     assert tail.headers["x-sampled-total"] == "4"
     assert tail.headers["x-sampled-truncated"] == "false"
 
     # An offset past the end leaves nothing to return, and says so rather than erroring.
-    past = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&offset=99", headers=auth)
+    past = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&offset=99", headers=user_auth)
     assert past.status_code == 200, past.text
     assert past.json() == []
     assert past.headers["x-sampled-total"] == "0"
@@ -1083,16 +1068,12 @@ async def test_fetch_sequence_detections_explicit_limit_still_wins_and_reports_t
 async def test_fetch_sequence_detections_unsampled_default_limit_unchanged(
     async_client: AsyncClient,
     detection_session: AsyncSession,
+    user_auth: Dict[str, str],
 ):
     """sampling=1 keeps the historical limit=10 default and skips the extra count entirely."""
     sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session, count=30)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
 
-    response = await async_client.get(f"/sequences/{sequence_id}/detections?desc=false", headers=auth)
+    response = await async_client.get(f"/sequences/{sequence_id}/detections?desc=false", headers=user_auth)
     assert response.status_code == 200, response.text
     assert [det["id"] for det in response.json()] == chronological_ids[:10]
     # The headers describe a sampled set, so they are absent when nothing was sampled.
@@ -1103,16 +1084,12 @@ async def test_fetch_sequence_detections_unsampled_default_limit_unchanged(
 async def test_fetch_sequence_detections_omitted_limit_handles_degenerate_sampling(
     async_client: AsyncClient,
     detection_session: AsyncSession,
+    user_auth: Dict[str, str],
 ):
     """A sampling interval past the detection count still yields one row, not zero."""
     sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session, count=10)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
 
-    response = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=500", headers=auth)
+    response = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=500", headers=user_auth)
     assert response.status_code == 200, response.text
     assert [det["id"] for det in response.json()] == [chronological_ids[0]]
     assert response.headers["x-sampled-total"] == "1"
@@ -1120,45 +1097,17 @@ async def test_fetch_sequence_detections_omitted_limit_handles_degenerate_sampli
 
 
 @pytest.mark.asyncio
-async def test_fetch_sequence_detections_sampling_larger_than_count(
-    async_client: AsyncClient,
-    detection_session: AsyncSession,
-):
-    """A sampling interval above the detection count still returns the first detection."""
-    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
-
-    response = await async_client.get(
-        f"/sequences/{sequence_id}/detections?sampling=100&desc=false&limit=10", headers=auth
-    )
-    assert response.status_code == 200, response.text
-    assert [det["id"] for det in response.json()] == [chronological_ids[0]]
-
-
-@pytest.mark.asyncio
 async def test_fetch_sequence_detections_sampling_offset_counts_raw_detections(
     async_client: AsyncClient,
     detection_session: AsyncSession,
+    user_auth: Dict[str, str],
 ):
-    """offset skips raw detections, not sampled frames, whatever sampling is.
-
-    offset=3 starts at the 4th detection and sampling=2 steps from there, so the kept
-    chronological positions are 4, 6, 8, 10 and limit=2 returns the first two of them. Under the
-    old reading (offset counted in sampled frames) the same request returned positions 7 and 9.
-    """
+    """offset skips raw detections, not sampled frames: positions 4, 6, 8, 10 for offset=3 and
+    sampling=2, of which limit=2 returns the first two."""
     sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
 
     response = await async_client.get(
-        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=2&offset=3", headers=auth
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=2&offset=3", headers=user_auth
     )
     assert response.status_code == 200, response.text
     assert [det["id"] for det in response.json()] == [chronological_ids[3], chronological_ids[5]]
@@ -1168,21 +1117,18 @@ async def test_fetch_sequence_detections_sampling_offset_counts_raw_detections(
 async def test_fetch_sequence_detections_sampling_offset_ignores_desc(
     async_client: AsyncClient,
     detection_session: AsyncSession,
+    user_auth: Dict[str, str],
 ):
-    """offset always counts from the oldest end; desc only reverses the output.
-
-    So the two directions select the same frames and differ only in order. That is what makes the
-    selection fully independent of desc, matching how sampling already behaves.
-    """
+    """offset counts from the oldest end, so both directions select the same frames and differ
+    only in order."""
     sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
 
-    asc = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=false&offset=3", headers=auth)
-    desc = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=true&offset=3", headers=auth)
+    asc = await async_client.get(
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&offset=3", headers=user_auth
+    )
+    desc = await async_client.get(
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=true&offset=3", headers=user_auth
+    )
     assert asc.status_code == 200, asc.text
     assert desc.status_code == 200, desc.text
 
@@ -1195,18 +1141,11 @@ async def test_fetch_sequence_detections_sampling_offset_ignores_desc(
 async def test_fetch_sequence_detections_sampling_pages_by_multiples_of_sampling(
     async_client: AsyncClient,
     detection_session: AsyncSession,
+    user_auth: Dict[str, str],
 ):
-    """Advancing offset by limit * sampling walks the same grid without repeating or skipping.
-
-    Because offset sets where the grid starts, only multiples of sampling keep it on the same
-    detections; this is the paging rule callers are told to use.
-    """
+    """offset sets where the grid starts, so only multiples of sampling keep it on the same
+    detections. This is the paging rule callers are given."""
     sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session, count=30)
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
 
     sampling, limit = 3, 4
     pages = []
@@ -1214,7 +1153,7 @@ async def test_fetch_sequence_detections_sampling_pages_by_multiples_of_sampling
         offset = page * limit * sampling
         response = await async_client.get(
             f"/sequences/{sequence_id}/detections?sampling={sampling}&desc=false&limit={limit}&offset={offset}",
-            headers=auth,
+            headers=user_auth,
         )
         assert response.status_code == 200, response.text
         pages.append([det["id"] for det in response.json()])
@@ -1245,13 +1184,9 @@ async def test_fetch_sequence_detections_sampling_validation(
     detection_session: AsyncSession,
     query: str,
     status_code: int,
+    user_auth: Dict[str, str],
 ):
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
-    response = await async_client.get(f"/sequences/1/detections?{query}", headers=auth)
+    response = await async_client.get(f"/sequences/1/detections?{query}", headers=user_auth)
     assert response.status_code == status_code, response.text
 
 
@@ -1260,19 +1195,13 @@ async def test_fetch_sequence_detections_reuses_presigned_urls_across_requests(
     async_client: AsyncClient,
     detection_session: AsyncSession,
     pinned_url_window: None,
+    user_auth: Dict[str, str],
 ):
-    """A repeat request must serve cached urls instead of re-signing every key.
+    """A repeat request serves cached urls instead of re-signing.
 
-    boto3 stamps the current clock into every signature, so without the presign cache the
-    browser's cache key changes on every poll and the player re-downloads every frame. Asserting
-    the urls merely match is not enough: two signatures taken in the same wall-clock second are
-    identical anyway, so the presign calls are counted instead.
+    Counts presign calls rather than comparing urls: two signatures taken in the same wall-clock
+    second are identical anyway, so a url comparison would pass even with the cache removed.
     """
-    auth = pytest.get_token(
-        pytest.user_table[0]["id"],
-        pytest.user_table[0]["role"].split(),
-        pytest.user_table[0]["organization_id"],
-    )
     bucket = s3_service.get_bucket(s3_service.resolve_bucket_name(pytest.camera_table[0]["organization_id"]))
     presign_calls: List[str] = []
     original_presign = bucket._presign
@@ -1283,9 +1212,9 @@ async def test_fetch_sequence_detections_reuses_presigned_urls_across_requests(
 
     bucket._presign = counting_presign  # type: ignore[method-assign]
     try:
-        first = await async_client.get("/sequences/1/detections?limit=10&desc=false", headers=auth)
+        first = await async_client.get("/sequences/1/detections?limit=10&desc=false", headers=user_auth)
         signed_once = len(presign_calls)
-        second = await async_client.get("/sequences/1/detections?limit=10&desc=false", headers=auth)
+        second = await async_client.get("/sequences/1/detections?limit=10&desc=false", headers=user_auth)
     finally:
         del bucket._presign
 
@@ -1353,6 +1282,11 @@ async def test_fetch_sequence_detections_includes_crop_url(
             pytest.user_table[0]["role"].split(),
             pytest.user_table[0]["organization_id"],
         )
+        auth = pytest.get_token(
+            pytest.user_table[0]["id"],
+            pytest.user_table[0]["role"].split(),
+            pytest.user_table[0]["organization_id"],
+        )
         sequence_id = pytest.detection_table[0]["sequence_id"]
         response = await async_client.get(
             f"/sequences/{sequence_id}/detections", params={"with_crop": "true"}, headers=auth
@@ -1383,6 +1317,11 @@ async def test_fetch_sequence_detections_with_crop_false_skips_crop_url(
         detection_session.add(detection)
         await detection_session.commit()
 
+        auth = pytest.get_token(
+            pytest.user_table[0]["id"],
+            pytest.user_table[0]["role"].split(),
+            pytest.user_table[0]["organization_id"],
+        )
         auth = pytest.get_token(
             pytest.user_table[0]["id"],
             pytest.user_table[0]["role"].split(),

--- a/src/tests/endpoints/test_sequences.py
+++ b/src/tests/endpoints/test_sequences.py
@@ -1016,6 +1016,101 @@ async def test_fetch_sequence_detections_sampling_interval(
 
 
 @pytest.mark.asyncio
+async def test_fetch_sequence_detections_omitted_limit_spans_the_sampled_set(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """Without an explicit limit, sampling must return the whole span, not its tail.
+
+    This is the guardrail: with the historical limit=10 default, `?sampling=2` on a 30-detection
+    sequence would silently return the 10 most recent sampled frames while looking like a spread.
+    """
+    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session, count=30)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    response = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=2&desc=false", headers=auth)
+    assert response.status_code == 200, response.text
+    # ceil(30 / 2) = 15 frames, spanning the sequence rather than stopping at 10.
+    assert [det["id"] for det in response.json()] == chronological_ids[::2]
+    assert len(response.json()) == 15
+    assert response.headers["x-sampled-total"] == "15"
+    assert response.headers["x-sampled-truncated"] == "false"
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_explicit_limit_still_wins_and_reports_truncation(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """An explicit limit is honoured, and the headers say the span was cut short."""
+    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session, count=30)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    response = await async_client.get(
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=4", headers=auth
+    )
+    assert response.status_code == 200, response.text
+    assert [det["id"] for det in response.json()] == chronological_ids[::2][:4]
+    assert response.headers["x-sampled-total"] == "15"
+    assert response.headers["x-sampled-truncated"] == "true"
+
+    # Paging to the end of the sampled set is not truncation.
+    tail = await async_client.get(
+        f"/sequences/{sequence_id}/detections?sampling=2&desc=false&limit=4&offset=11", headers=auth
+    )
+    assert tail.status_code == 200, tail.text
+    assert tail.headers["x-sampled-truncated"] == "false"
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_unsampled_default_limit_unchanged(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """sampling=1 keeps the historical limit=10 default and skips the extra count entirely."""
+    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session, count=30)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    response = await async_client.get(f"/sequences/{sequence_id}/detections?desc=false", headers=auth)
+    assert response.status_code == 200, response.text
+    assert [det["id"] for det in response.json()] == chronological_ids[:10]
+    # The headers describe a sampled set, so they are absent when nothing was sampled.
+    assert "x-sampled-total" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_fetch_sequence_detections_omitted_limit_handles_degenerate_sampling(
+    async_client: AsyncClient,
+    detection_session: AsyncSession,
+):
+    """A sampling interval past the detection count still yields one row, not zero."""
+    sequence_id, chronological_ids = await _seed_sampling_sequence(detection_session, count=10)
+    auth = pytest.get_token(
+        pytest.user_table[0]["id"],
+        pytest.user_table[0]["role"].split(),
+        pytest.user_table[0]["organization_id"],
+    )
+
+    response = await async_client.get(f"/sequences/{sequence_id}/detections?sampling=500", headers=auth)
+    assert response.status_code == 200, response.text
+    assert [det["id"] for det in response.json()] == [chronological_ids[0]]
+    assert response.headers["x-sampled-total"] == "1"
+    assert response.headers["x-sampled-truncated"] == "false"
+
+
+@pytest.mark.asyncio
 async def test_fetch_sequence_detections_sampling_larger_than_count(
     async_client: AsyncClient,
     detection_session: AsyncSession,

--- a/src/tests/endpoints/test_sequences.py
+++ b/src/tests/endpoints/test_sequences.py
@@ -1282,11 +1282,6 @@ async def test_fetch_sequence_detections_includes_crop_url(
             pytest.user_table[0]["role"].split(),
             pytest.user_table[0]["organization_id"],
         )
-        auth = pytest.get_token(
-            pytest.user_table[0]["id"],
-            pytest.user_table[0]["role"].split(),
-            pytest.user_table[0]["organization_id"],
-        )
         sequence_id = pytest.detection_table[0]["sequence_id"]
         response = await async_client.get(
             f"/sequences/{sequence_id}/detections", params={"with_crop": "true"}, headers=auth
@@ -1317,11 +1312,6 @@ async def test_fetch_sequence_detections_with_crop_false_skips_crop_url(
         detection_session.add(detection)
         await detection_session.commit()
 
-        auth = pytest.get_token(
-            pytest.user_table[0]["id"],
-            pytest.user_table[0]["role"].split(),
-            pytest.user_table[0]["organization_id"],
-        )
         auth = pytest.get_token(
             pytest.user_table[0]["id"],
             pytest.user_table[0]["role"].split(),

--- a/src/tests/services/test_storage.py
+++ b/src/tests/services/test_storage.py
@@ -5,7 +5,8 @@ import pytest
 from fastapi import HTTPException
 
 from app.core.config import settings
-from app.services.storage import S3Bucket, S3Service
+from app.services import storage
+from app.services.storage import S3Bucket, S3Service, _url_cache_window
 
 
 @pytest.mark.parametrize(
@@ -92,6 +93,9 @@ async def test_s3_bucket(bucket_name, proxy_url, expected_error, mock_img):
         bucket.upload_file(bucket_key, io.BytesIO(mock_img))
         assert bucket.check_file_existence(bucket_key)
         assert isinstance(bucket.get_file_metadata(bucket_key), dict)
+        # Cache-Control is what makes the stable presigned urls from get_public_url actually
+        # cacheable browser-side; without it the upload path could silently stop setting it.
+        assert bucket.get_file_metadata(bucket_key)["CacheControl"] == f"private, max-age={settings.S3_URL_EXPIRATION}"
         assert bucket.get_public_url(bucket_key).startswith("http://")
         # Delete file
         bucket.delete_file(bucket_key)
@@ -106,3 +110,115 @@ async def test_s3_bucket(bucket_name, proxy_url, expected_error, mock_img):
     else:
         with pytest.raises(expected_error):
             S3Bucket(s3, bucket_name, proxy_url)
+
+
+@pytest.mark.parametrize("url_expiration", [1, 4, 20, 60, 300, 3600, 24 * 3600])
+def test_url_cache_window_leaves_most_of_the_lifetime(url_expiration):
+    """A cached url must always be handed out with the bulk of its lifetime left, and the window
+    must never exceed the expiration itself: a sub-minute expiration must not serve urls that are
+    already expired."""
+    window = _url_cache_window(url_expiration)
+    assert 1 <= window <= 3600
+    assert window <= max(1, url_expiration // 4)
+    assert window <= url_expiration
+
+
+def test_s3_bucket_presigned_urls_are_stable_within_a_window(monkeypatch):
+    """The same key presigns once per window, and is re-signed once the slot advances.
+
+    boto3 stamps the current clock into every signature, so without this cache the browser's
+    cache key changes on every request and clients re-download unchanged objects. Both halves
+    count presign calls rather than comparing url strings: two signatures taken in the same
+    wall-clock second are identical, so a string comparison would assert on the clock instead of
+    on the cache. The clock is faked, rather than waited out or mutated on the instance (the
+    window slot now lives in the cache key, not on a `bucket._url_window` attribute), so the
+    slot advance is deterministic instead of racing a real monotonic boundary.
+    """
+    session = boto3.Session(settings.S3_ACCESS_KEY, settings.S3_SECRET_KEY, region_name=settings.S3_REGION)
+    s3 = session.client("s3", endpoint_url=settings.S3_ENDPOINT_URL)
+    bucket_name = "dummy-bucket-url-cache"
+    s3.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": settings.S3_REGION})
+    try:
+        bucket = S3Bucket(s3, bucket_name, settings.S3_PROXY_URL)
+        presign_calls = []
+        original_presign = bucket._presign
+
+        def counting_presign(bucket_key, url_expiration):
+            presign_calls.append(bucket_key)
+            return original_presign(bucket_key, url_expiration)
+
+        bucket._presign = counting_presign
+
+        fake_clock = [0.0]
+        monkeypatch.setattr(storage.time, "monotonic", lambda: fake_clock[0])
+
+        first = bucket.get_public_url("stable.png", verify_exists=False)
+        assert bucket.get_public_url("stable.png", verify_exists=False) == first
+        assert len(presign_calls) == 1
+
+        # Advance the clock past the window instead of waiting one out: the slot changes, so the
+        # key changes, so the lookup misses and the url is re-signed.
+        fake_clock[0] += _url_cache_window(settings.S3_URL_EXPIRATION)
+        bucket.get_public_url("stable.png", verify_exists=False)
+        assert len(presign_calls) == 2
+        # Nothing clears on rollover anymore: the previous window's entry is still there,
+        # aging out through the size-bound eviction rather than being dropped outright.
+        assert set(bucket._url_cache) == {
+            ("stable.png", settings.S3_URL_EXPIRATION, 0),
+            ("stable.png", settings.S3_URL_EXPIRATION, 1),
+        }
+    finally:
+        s3.delete_bucket(Bucket=bucket_name)
+
+
+def test_s3_bucket_url_cache_evicts_coldest_entry_only(monkeypatch):
+    """The size bound evicts only the least-recently-used entry; it must never clear the whole
+    cache, since one dict is shared by every viewer of an organization and clearing it would
+    re-sign (and so change) every url in flight exactly when the cache is under load.
+    """
+    session = boto3.Session(settings.S3_ACCESS_KEY, settings.S3_SECRET_KEY, region_name=settings.S3_REGION)
+    s3 = session.client("s3", endpoint_url=settings.S3_ENDPOINT_URL)
+    bucket_name = "dummy-bucket-url-cache-eviction"
+    s3.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": settings.S3_REGION})
+    try:
+        bucket = S3Bucket(s3, bucket_name, settings.S3_PROXY_URL)
+        # Pin the window so the three calls below can't straddle a real rollover and pick up
+        # differing slot components in their cache keys.
+        monkeypatch.setattr(storage, "_url_cache_window", lambda _url_expiration: 10**9)
+        monkeypatch.setattr(storage, "_URL_CACHE_MAXSIZE", 2)
+
+        bucket.get_public_url("k1.png", verify_exists=False)
+        bucket.get_public_url("k2.png", verify_exists=False)
+        # Touch k1 again: it becomes most-recently-used, leaving k2 as the coldest entry.
+        bucket.get_public_url("k1.png", verify_exists=False)
+        # Inserting a third key over the bound of 2 must evict k2 only, never clear the dict.
+        bucket.get_public_url("k3.png", verify_exists=False)
+
+        cached_bucket_keys = {key[0] for key in bucket._url_cache}
+        assert cached_bucket_keys == {"k1.png", "k3.png"}
+        assert len(bucket._url_cache) == 2
+    finally:
+        s3.delete_bucket(Bucket=bucket_name)
+
+
+@pytest.mark.asyncio
+async def test_s3_service_caches_bucket_instances():
+    """get_bucket must reuse instances (its __init__ does a blocking head_bucket) and evict
+    the entry once the bucket is deleted."""
+    service = S3Service(
+        settings.S3_REGION,
+        settings.S3_ENDPOINT_URL,
+        settings.S3_ACCESS_KEY,
+        settings.S3_SECRET_KEY,
+        settings.S3_PROXY_URL,
+    )
+    bucket_name = "dummy-bucket-instance-cache"
+    service.create_bucket(bucket_name)
+    assert service.get_bucket(bucket_name) is service.get_bucket(bucket_name)
+
+    assert await service.delete_bucket(bucket_name)
+    assert bucket_name not in service._buckets
+
+    # A missing bucket is never cached, so it keeps raising.
+    with pytest.raises(ValueError, match="unable to access bucket"):
+        service.get_bucket("dummy-bucket-does-not-exist")

--- a/src/tests/services/test_storage.py
+++ b/src/tests/services/test_storage.py
@@ -114,25 +114,16 @@ async def test_s3_bucket(bucket_name, proxy_url, expected_error, mock_img):
 
 @pytest.mark.parametrize("url_expiration", [1, 4, 20, 60, 300, 3600, 24 * 3600])
 def test_url_cache_window_leaves_most_of_the_lifetime(url_expiration):
-    """A cached url must always be handed out with the bulk of its lifetime left, and the window
-    must never exceed the expiration itself: a sub-minute expiration must not serve urls that are
-    already expired."""
-    window = _url_cache_window(url_expiration)
-    assert 1 <= window <= 3600
-    assert window <= max(1, url_expiration // 4)
-    assert window <= url_expiration
+    """A cached url is always handed out with most of its lifetime left, and the window never
+    exceeds the expiration, so a sub-minute expiration cannot serve an expired url."""
+    assert 1 <= _url_cache_window(url_expiration) <= min(3600, url_expiration)
 
 
 def test_s3_bucket_presigned_urls_are_stable_within_a_window(monkeypatch):
-    """The same key presigns once per window, and is re-signed once the slot advances.
+    """The same key presigns once per window and is re-signed once the slot advances.
 
-    boto3 stamps the current clock into every signature, so without this cache the browser's
-    cache key changes on every request and clients re-download unchanged objects. Both halves
-    count presign calls rather than comparing url strings: two signatures taken in the same
-    wall-clock second are identical, so a string comparison would assert on the clock instead of
-    on the cache. The clock is faked, rather than waited out or mutated on the instance (the
-    window slot now lives in the cache key, not on a `bucket._url_window` attribute), so the
-    slot advance is deterministic instead of racing a real monotonic boundary.
+    Counts presign calls rather than comparing urls, since two signatures taken in the same
+    wall-clock second are identical. The clock is faked so the slot advance is deterministic.
     """
     session = boto3.Session(settings.S3_ACCESS_KEY, settings.S3_SECRET_KEY, region_name=settings.S3_REGION)
     s3 = session.client("s3", endpoint_url=settings.S3_ENDPOINT_URL)
@@ -156,13 +147,11 @@ def test_s3_bucket_presigned_urls_are_stable_within_a_window(monkeypatch):
         assert bucket.get_public_url("stable.png", verify_exists=False) == first
         assert len(presign_calls) == 1
 
-        # Advance the clock past the window instead of waiting one out: the slot changes, so the
-        # key changes, so the lookup misses and the url is re-signed.
+        # Advance past the window: the slot changes, so the key misses and the url is re-signed.
         fake_clock[0] += _url_cache_window(settings.S3_URL_EXPIRATION)
         bucket.get_public_url("stable.png", verify_exists=False)
         assert len(presign_calls) == 2
-        # Nothing clears on rollover anymore: the previous window's entry is still there,
-        # aging out through the size-bound eviction rather than being dropped outright.
+        # The previous window's entry stays, aging out through eviction rather than a clear.
         assert set(bucket._url_cache) == {
             ("stable.png", settings.S3_URL_EXPIRATION, 0),
             ("stable.png", settings.S3_URL_EXPIRATION, 1),
@@ -171,20 +160,14 @@ def test_s3_bucket_presigned_urls_are_stable_within_a_window(monkeypatch):
         s3.delete_bucket(Bucket=bucket_name)
 
 
-def test_s3_bucket_url_cache_evicts_coldest_entry_only(monkeypatch):
-    """The size bound evicts only the least-recently-used entry; it must never clear the whole
-    cache, since one dict is shared by every viewer of an organization and clearing it would
-    re-sign (and so change) every url in flight exactly when the cache is under load.
-    """
+def test_s3_bucket_url_cache_evicts_coldest_entry_only(monkeypatch, pinned_url_window):
+    """The size bound evicts the LRU entry only: a clear would change every url in flight."""
     session = boto3.Session(settings.S3_ACCESS_KEY, settings.S3_SECRET_KEY, region_name=settings.S3_REGION)
     s3 = session.client("s3", endpoint_url=settings.S3_ENDPOINT_URL)
     bucket_name = "dummy-bucket-url-cache-eviction"
     s3.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": settings.S3_REGION})
     try:
         bucket = S3Bucket(s3, bucket_name, settings.S3_PROXY_URL)
-        # Pin the window so the three calls below can't straddle a real rollover and pick up
-        # differing slot components in their cache keys.
-        monkeypatch.setattr(storage, "_url_cache_window", lambda _url_expiration: 10**9)
         monkeypatch.setattr(storage, "_URL_CACHE_MAXSIZE", 2)
 
         bucket.get_public_url("k1.png", verify_exists=False)

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
+from httpx import AsyncClient
 
 from app.main import _risk_refresh_loop, _seconds_until_next_utc_hour, lifespan
 
@@ -153,3 +154,15 @@ async def test_lifespan_skips_risk_refresh_but_starts_validation_worker_when_ris
             create_task_mock.assert_called_once()  # the validation worker always runs
 
     assert fake_task.cancel_called is True
+
+
+@pytest.mark.asyncio
+async def test_sampling_headers_are_exposed_to_browsers(async_client: AsyncClient):
+    """CORSMiddleware hides response headers from browser JS unless they are listed in
+    expose_headers, and the sampling signals exist for the frontend player. Neither the endpoint
+    tests (ASGI transport, no CORS enforcement) nor the client tests (requests, not a browser)
+    would catch a regression here.
+    """
+    response = await async_client.get("/status", headers={"Origin": "http://localhost:5173"})
+    exposed = {h.strip() for h in response.headers.get("access-control-expose-headers", "").split(",")}
+    assert {"X-Sampled-Total", "X-Sampled-Truncated"} <= exposed


### PR DESCRIPTION
Closes #660.

The issue asks for detection sampling so the player can load a sequence without pulling every frame, and names two causes: **API response time** and **client-side caching**. Investigating `GET /sequences/{id}/detections` turned up three further problems, two of which hit harder than sampling itself, so this PR does three things, with the fourth split out into #664.

## What changed

**1. Sampling (the issue's ask).** `sampling=N` keeps one detection in N, pushed into SQL via `row_number()` rather than slicing a full fetch in Python (which would keep the scan and the serialization cost and only shrink the payload). `sampling=1` delegates to the existing path, so default behaviour is unchanged.

**2. `S3Bucket` instance caching.** `get_bucket()` built a fresh instance per call and `S3Bucket.__init__` does a blocking `head_bucket`, so every request paid one synchronous S3 round-trip on the event loop.

**3. Stable presigned URLs + `Cache-Control`.** boto3 stamps the current clock into every signature, so presigning the same key twice returns two different strings. The browser keys its cache on the full URL, so **the player re-downloaded every frame on every poll even when the image had not changed.** This is the client-side-caching half of the issue, and sampling alone does nothing for it.

## Performance, before vs after

### The index this depends on lives in #664

The composite index on `detections(sequence_id, created_at)` was originally part of this PR, but it turned out to be exactly one of the three indexes proposed in #663, so it moved to [#664](https://github.com/pyronear/pyro-api/pull/664) to keep a single owner. **The DB numbers below assume #664 has landed.** Without it, the sequence read stays on a sequential scan and this PR's gain is limited to the S3 items.

Measured there: 34.8 ms to 0.42 ms at 2M detections (roughly production today), and 63.6 ms to 1.1 ms at 5M.

### Per request, 100 frames returned, 5M-row table

| Component | Before | After |
|---|---|---|
| DB query (needs #664) | 63 to 84 ms (seq scan) | 1.1 ms (index scan) |
| `head_bucket` (once per request) | 10.1 ms | 0 (cached instance) |
| Presigning 100 URLs | 7.5 ms | ~0 (cached, warm) |
| Framework + JSON | ~3 ms | ~3 ms |
| **Total** | **~85 ms** | **~4 ms (≈20x)** |

### On top of that, sampling changes the shape of the work

Loading a 1000-frame timeline previously meant **10 requests** (the old `limit` ceiling was 100), each paying the ~85 ms above. It is now **one** request at `sampling=10`, and the browser fetches 100 images instead of 1000.

Worth stating plainly: most of that last factor is returning a tenth of the data by design, not the same work done faster. The honest split is roughly **20x from the fixes** (of which the DB share needs #664) and **10x fewer bytes and images from sampling**.

The browser-cache win is the one number missing here. Every poll after the first goes from re-downloading N images to N cache hits, which is probably the largest perceived gain for the player, but quantifying it needs the frontend rather than the API.

## How this was measured, and two corrections

Numbers come from a seeded 5M-row database (50k sequences) on the dev compose stack. Before/after uses the same data, forcing the pre-change plan with `enable_indexscan=off` rather than dropping and rebuilding the index, so the two measurements are directly comparable.

Two measurement traps worth recording, since both changed the answer materially:

- **Heap clustering**, which moved the index numbers by nearly 3x. Written up in #664, where that measurement now lives.
- **A 64KB loopback artifact.** End-to-end HTTP timings showed 100 frames at 47 ms but 500 frames at 20 ms, which is absurd. It survived reordering and isolation. Sweeping `limit` located a ~45 ms penalty that vanished between 60.9KB and 65.0KB of response body: the 64KB socket buffer, i.e. a 40 ms delayed-ACK stall on loopback inside the container. It affects before and after equally and is not a property of the API, but it makes absolute sub-64KB latencies from that harness meaningless, so the table above is built from measured components instead. Above 64KB timings go cleanly linear at ~0.03 ms per frame.

## API compatibility

No breaking change. Only one route's signature moved, and only additively:

- `sampling` added, default `1` = exactly the previous behaviour
- `limit` ceiling **widened** 100 to 500, so any previously valid request stays valid
- two `description` strings reworded

The response model is untouched. No routes were added, removed, or renamed, and auth is unchanged. The one behavioural change reaching every route that returns a presigned URL is that URLs are now stable within a window instead of unique per request, which is the point of item 3.

**For pyro-platform:** nothing is required, and items 2 and 3 speed up the existing call with no frontend work. To get the sampling win it needs to pass `sampling`, and also `limit`: `getDetectionsBySequence` currently sends only `desc`, so it receives the API default of 10 detections.

`sampling` and `limit` are **independent**, which is the easy thing to get wrong: `?sampling=10` alone, with the `desc=true` and `limit=10` defaults, returns the 10 most **recent** sampled frames, not a spread across the sequence. Spanning the sequence in one call needs `limit >= ceil(detections_count / sampling)`, and since `limit` caps at 500, `sampling >= detections_count / 500`. `detections_count` is already on the sequence object, so no extra endpoint is needed. Both the endpoint description and the client docstring now spell this out.

A 20/20/20 player load on a 1000-detection sequence, verified against the endpoint rather than derived on paper:

```
?desc=false&limit=20                        -> frames 1..20
?desc=false&sampling=48&offset=1&limit=20   -> frames 49..961, step 48
?desc=true&limit=20                         -> frames 981..1000 (reverse client-side)
```

60 distinct frames, no overlap between the three calls. General form for `M` middle frames: `sampling = floor((N - 40) / M)`, `offset = ceil(20 / sampling)`, `limit = M`. Credit to @fe51 for the recipe.

## Interaction with #624 (now merged)

Rebased onto main after #624 landed. Two points a reviewer should know:

- **Continuity rows are sampled too.** #624 made `GET /sequences/{id}/detections` return continuity rows (frames attached with `bbox="[]"` where the object was not detected), and its own route description tells clients to filter on `bbox` if they only want real detections. Sampling thins that combined set rather than treating continuity rows specially, which keeps it consistent with the documented endpoint behaviour and with `detections_count`, which #624 also made include them.
- **`crud_detection.py` conflicted and was resolved by hand.** #624 added `get_latest_with_bbox`, which needs sqlmodel's `select` (a single-entity `SelectOfScalar` is what makes `session.exec` return a `Detection` rather than a `Row`). The sampled query needs sqlalchemy's `select` for its two-entity numbering subquery. Both now coexist: `select` stays sqlmodel's, as #624 wrote it, and sqlalchemy's is imported as `select_sa`, so no line of #624's code changed.

## Semantics worth reviewing

These are the decisions a reviewer should push on:

| Decision | Choice | Why |
|---|---|---|
| Interval vs target count | Interval (`sampling=N`) | The issue itself notes interval is simpler and more predictable |
| Row numbering direction | Always ascending on `created_at` | The sampled frame set is then identical for `desc=true` and `desc=false`; `desc` only flips output order. It also means an appended detection cannot renumber earlier rows, so the player keeps hitting the same frames and the same cached URLs across polls |
| Which rows are kept | `(rn - 1) % sampling == 0` | Keeps detection #1, so any non-empty sequence returns at least one row |
| `offset` | Pages the sampled set, not raw rows | Predictable for the client |
| `limit` ceiling | 100 to 500 | The issue's own example (1000 detections at `sampling=10`) saturated 100 exactly, so `sampling=5` would have been silently truncated |

Deliberately **not** `id % N`: detection ids are global rather than per-sequence, so the stride would be non-uniform and small sequences could return zero rows.

Two known limitations: `limit` cannot push down through `row_number()`, so the scan is proportional to sequence length regardless of `limit` (inherent to interval sampling, and why the index matters); and sampling is uniform in `created_at`, not `recorded_at`, so out-of-order uploads make it non-uniform in capture time.

## Verification

- 651 tests pass on the rebased branch, ruff lint and format clean (ruff lint and format, `ty`, deps-check). No new dependency.
- **The URL-cache test was mutation-checked.** Asserting that two requests return the same URL is not enough, because two signatures taken in the same wall-clock second are byte-identical, so such a test passes even with the cache deleted. The test counts presign calls instead, and bypassing the cache does make it fail.
- The LRU eviction test was mutation-checked the same way (replacing `popitem` with `clear` fails it).

## Known limits of the URL cache

Both raised in review and tracked separately, neither blocking:

- **URL stability is per-worker** ([#671](https://github.com/pyronear/pyro-api/issues/671)). The cache is in-process, so with W workers a client sees up to W distinct URLs per frame and fetches it up to W times instead of once. Still much better than re-signing on every poll, just divided by W. An earlier version of this PR claimed the repo runs a single worker; that was inferred from the dev compose files passing no `--workers`, production runs several, and its deployment config is not in this repo. Corrected in the docstring.
- **Stale-window entries stay resident** ([#672](https://github.com/pyronear/pyro-api/issues/672)). The window slot is part of the cache key, so prior-window entries are unreachable but occupy space until size-evicted, putting effective capacity at roughly half the nominal 8192. Purging them is safe, unlike the full `clear()` the code comment argues against.

These matter more once the frontend starts requesting large `limit` values: a 1000-detection load burns ~2000 entries against a 8192 bound, so a handful of sequences evict each other and the cache stops paying off.

## Depends on

[#664](https://github.com/pyronear/pyro-api/pull/664) for the `detections(sequence_id, created_at)` index. This PR is functionally independent and its tests pass without it, but the sequence read stays on a sequential scan until it lands.

## Out of scope

- `GET /detections/` is an unbounded `fetch_all` with no limit or offset at all. Real problem, separate issue.
- Backfilling `Cache-Control` onto already-uploaded objects.
- The naming inconsistency between `desc` here and `order_desc` on the alerts endpoints.
