### PR TITLE
perf(db): add hot-path indexes for sequence matching, latest-bbox and shared frame lookups

### DIFF
--- a/src/app/models.py
+++ b/src/app/models.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Union
 
+from sqlalchemy import Index
 from sqlmodel import Field, SQLModel
 
 from app.core.config import settings
@@ -83,6 +84,15 @@ class OcclusionMask(SQLModel, table=True):
 
 class Detection(SQLModel, table=True):
     __tablename__ = "detections"
+    # Declared here as well as in the migration so create_all-built databases (the test suite)
+    # carry the same indexes as production, instead of silently planning every query differently.
+    __table_args__ = (
+        # Latest-real-bbox lookups during spatial matching, and the sequence reads the player
+        # pages through: sequence_id equality then a created_at scan.
+        Index("ix_detections_sequence_id_created_at", "sequence_id", "created_at"),
+        # Sibling-row check on deletion (multi-bbox and continuity rows share one frame object).
+        Index("ix_detections_bucket_key", "bucket_key"),
+    )
     id: int = Field(None, primary_key=True)
     camera_id: int = Field(..., foreign_key="cameras.id", nullable=False)
     pose_id: int = Field(..., foreign_key="poses.id", nullable=False)
@@ -112,6 +122,10 @@ TERMINAL_VALIDATION_STATUSES = (WINDOW_EXHAUSTED, VALIDATION_FAILED)
 
 class Sequence(SQLModel, table=True):
     __tablename__ = "sequences"
+    __table_args__ = (
+        # Per-frame lookups of a pose's recently-seen sequences (spatial matching, continuity).
+        Index("ix_sequences_camera_pose_last_seen", "camera_id", "pose_id", "last_seen_at"),
+    )
     id: int = Field(None, primary_key=True)
     camera_id: int = Field(..., foreign_key="cameras.id", nullable=False)
     pose_id: Union[int, None] = Field(None, foreign_key="poses.id", nullable=True)

--- a/src/migrations/versions/2026_07_30_1000-e8f3a6c9d1b7_add_hot_path_indexes.py
+++ b/src/migrations/versions/2026_07_30_1000-e8f3a6c9d1b7_add_hot_path_indexes.py
@@ -1,0 +1,84 @@
+"""add hot-path indexes for sequence matching, latest-bbox and shared frame lookups
+
+Revision ID: e8f3a6c9d1b7
+Revises: c4e9f1a2b3d5
+Create Date: 2026-07-30 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "e8f3a6c9d1b7"
+down_revision: Union[str, None] = "c4e9f1a2b3d5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (index name, table, columns). Kept in sync with the __table_args__ declarations in
+# app.models, which is what puts these indexes in create_all-built test databases too.
+INDEXES = (
+    ("ix_sequences_camera_pose_last_seen", "sequences", ["camera_id", "pose_id", "last_seen_at"]),
+    ("ix_detections_sequence_id_created_at", "detections", ["sequence_id", "created_at"]),
+    ("ix_detections_bucket_key", "detections", ["bucket_key"]),
+)
+
+
+def _drop_if_invalid(index_name: str, table_name: str) -> None:
+    """Drop an index left INVALID by a cancelled CONCURRENTLY build.
+
+    Without this the migration is not safely re-runnable: if_not_exists sees the leftover
+    relation and skips creating it, the revision stamps, and the upgrade reports success while
+    the planner ignores the invalid index, silently leaving these queries on sequential scans.
+
+    The lookup joins pg_class by name rather than casting the name to regclass, since that cast
+    raises when the relation does not exist yet (the common case) instead of returning no rows.
+    """
+    row = (
+        op
+        .get_bind()
+        .execute(
+            text(
+                "SELECT idx.indisvalid FROM pg_index idx "
+                "JOIN pg_class c ON c.oid = idx.indexrelid "
+                "WHERE c.relname = :name"
+            ),
+            {"name": index_name},
+        )
+        .first()
+    )
+    if row is not None and not row[0]:
+        op.drop_index(index_name, table_name=table_name, if_exists=True, postgresql_concurrently=True)
+
+
+def upgrade() -> None:
+    # Three query shapes on the detection hot path had no index backing them:
+    #   - a pose's recently-seen sequences (camera_id, pose_id, last_seen_at), run on every
+    #     POST /detections during spatial matching
+    #   - the latest real bbox of a sequence (sequence_id, created_at), run once per candidate
+    #     sequence per detection, and also the shape the player's sequence reads sort on
+    #   - sibling rows sharing a frame object (bucket_key), on DELETE /detections/{id}
+    #
+    # detections is the highest-write table, so a plain CREATE INDEX would hold ACCESS EXCLUSIVE
+    # against camera ingest for the whole build. CONCURRENTLY cannot run inside a transaction and
+    # env.py wraps the migration run in one, hence the autocommit block.
+    with op.get_context().autocommit_block():
+        for index_name, table_name, columns in INDEXES:
+            _drop_if_invalid(index_name, table_name)
+            op.create_index(
+                index_name,
+                table_name,
+                columns,
+                unique=False,
+                if_not_exists=True,
+                postgresql_concurrently=True,
+            )
+
+
+def downgrade() -> None:
+    # DROP INDEX CONCURRENTLY is likewise non-transactional.
+    with op.get_context().autocommit_block():
+        for index_name, table_name, _ in reversed(INDEXES):
+            op.drop_index(index_name, table_name=table_name, if_exists=True, postgresql_concurrently=True)

--- a/src/migrations/versions/2026_07_30_1000-e8f3a6c9d1b7_add_hot_path_indexes.py
+++ b/src/migrations/versions/2026_07_30_1000-e8f3a6c9d1b7_add_hot_path_indexes.py
@@ -26,31 +26,48 @@ INDEXES = (
 )
 
 
-def _drop_if_invalid(index_name: str, table_name: str) -> None:
-    """Drop an index left INVALID by a cancelled CONCURRENTLY build.
+def _ensure_absent_or_replaceable(index_name: str, table_name: str, columns: list) -> None:
+    """Clear the way for the create below, or fail loudly rather than silently skip.
 
-    Without this the migration is not safely re-runnable: if_not_exists sees the leftover
-    relation and skips creating it, the revision stamps, and the upgrade reports success while
-    the planner ignores the invalid index, silently leaving these queries on sequential scans.
+    ``CREATE INDEX IF NOT EXISTS`` matches on the **name alone**: Postgres never compares the
+    definition. So a same-named index over the wrong columns, or a leftover INVALID one from a
+    cancelled CONCURRENTLY build, makes the create a no-op, the revision stamp, and the upgrade
+    report success while the queries stay on sequential scans. Both are reachable on the manual
+    pre-creation path, where a human types the column list.
 
-    The lookup joins pg_class by name rather than casting the name to regclass, since that cast
-    raises when the relation does not exist yet (the common case) instead of returning no rows.
+    Anything else holding the name (a table, a view) is not ours to drop, so raise instead.
     """
     row = (
         op
         .get_bind()
         .execute(
             text(
-                "SELECT idx.indisvalid FROM pg_index idx "
-                "JOIN pg_class c ON c.oid = idx.indexrelid "
-                "WHERE c.relname = :name"
+                "SELECT c.relkind, i.indisvalid, t.relname, "
+                "  (SELECT array_agg(a.attname ORDER BY k.ord) "
+                "     FROM unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) "
+                "     JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum) AS cols "
+                "FROM pg_class c "
+                "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                "LEFT JOIN pg_index i ON i.indexrelid = c.oid "
+                "LEFT JOIN pg_class t ON t.oid = i.indrelid "
+                "WHERE c.relname = :name AND n.nspname = ANY (current_schemas(false))"
             ),
             {"name": index_name},
         )
         .first()
     )
-    if row is not None and not row[0]:
-        op.drop_index(index_name, table_name=table_name, if_exists=True, postgresql_concurrently=True)
+    if row is None:
+        return
+    relkind, is_valid, owning_table, cols = row
+    # pg_class.relkind is Postgres "char", which comes back as bytes over this driver.
+    kind = relkind.decode() if isinstance(relkind, (bytes, bytearray)) else str(relkind)
+    if kind != "i":
+        raise RuntimeError(f"{index_name!r} already exists as relkind {kind!r}, not an index")
+    if owning_table != table_name:
+        raise RuntimeError(f"{index_name!r} already indexes {owning_table!r}, not {table_name!r}")
+    if is_valid and list(cols or []) == list(columns):
+        return
+    op.drop_index(index_name, table_name=table_name, if_exists=True, postgresql_concurrently=True)
 
 
 def upgrade() -> None:
@@ -61,12 +78,12 @@ def upgrade() -> None:
     #     sequence per detection, and also the shape the player's sequence reads sort on
     #   - sibling rows sharing a frame object (bucket_key), on DELETE /detections/{id}
     #
-    # detections is the highest-write table, so a plain CREATE INDEX would hold ACCESS EXCLUSIVE
-    # against camera ingest for the whole build. CONCURRENTLY cannot run inside a transaction and
+    # detections is the highest-write table, so a plain CREATE INDEX holds SHARE against camera
+    # ingest for the whole build (blocking writes, not reads). CONCURRENTLY cannot run inside a transaction and
     # env.py wraps the migration run in one, hence the autocommit block.
     with op.get_context().autocommit_block():
         for index_name, table_name, columns in INDEXES:
-            _drop_if_invalid(index_name, table_name)
+            _ensure_absent_or_replaceable(index_name, table_name, columns)
             op.create_index(
                 index_name,
                 table_name,

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -1,0 +1,29 @@
+import pytest
+from sqlmodel import SQLModel, text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+# Hot-path indexes, declared in two places that must not drift: the alembic migration (what
+# production runs) and __table_args__ in app.models (what create_all gives a test database built
+# without migrations). Drift is invisible at runtime, it just makes one environment plan queries
+# differently from the other, so both sides are pinned against this list.
+EXPECTED_INDEXES = {
+    "detections": {"ix_detections_sequence_id_created_at", "ix_detections_bucket_key"},
+    "sequences": {"ix_sequences_camera_pose_last_seen"},
+}
+
+
+@pytest.mark.parametrize(("table", "expected"), EXPECTED_INDEXES.items())
+def test_hot_path_indexes_are_declared_on_the_models(table: str, expected: set):
+    """Guards the model side. A DB assertion cannot cover this: the test database is migrated,
+    so the indexes are present whether or not __table_args__ still declares them."""
+    declared = {index.name for index in SQLModel.metadata.tables[table].indexes}
+    assert expected <= declared, f"not declared on {table}: {sorted(expected - declared)}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("table", "expected"), EXPECTED_INDEXES.items())
+async def test_hot_path_indexes_exist_in_the_database(async_session: AsyncSession, table: str, expected: set):
+    """Guards the migration side: a fresh database must end up with all of them."""
+    stmt = text("SELECT indexname FROM pg_indexes WHERE tablename = :table").bindparams(table=table)
+    present = {row[0] for row in (await async_session.exec(stmt)).all()}
+    assert expected <= present, f"missing on {table}: {sorted(expected - present)}"

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -4,26 +4,51 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 # Hot-path indexes, declared in two places that must not drift: the alembic migration (what
 # production runs) and __table_args__ in app.models (what create_all gives a test database built
-# without migrations). Drift is invisible at runtime, it just makes one environment plan queries
-# differently from the other, so both sides are pinned against this list.
+# without migrations). Column ORDER is pinned, not just the names: a B-tree on (a, b) sorts by a
+# first and is useless for b alone, so a reordered index serves none of these queries while still
+# looking like harmless tidying. It also propagates, since the next --autogenerate turns a
+# models.py reorder into a migration that drops and recreates the real index the wrong way round.
 EXPECTED_INDEXES = {
-    "detections": {"ix_detections_sequence_id_created_at", "ix_detections_bucket_key"},
-    "sequences": {"ix_sequences_camera_pose_last_seen"},
+    "detections": {
+        "ix_detections_sequence_id_created_at": ["sequence_id", "created_at"],
+        "ix_detections_bucket_key": ["bucket_key"],
+    },
+    "sequences": {
+        "ix_sequences_camera_pose_last_seen": ["camera_id", "pose_id", "last_seen_at"],
+    },
 }
 
 
 @pytest.mark.parametrize(("table", "expected"), EXPECTED_INDEXES.items())
-def test_hot_path_indexes_are_declared_on_the_models(table: str, expected: set):
-    """Guards the model side. A DB assertion cannot cover this: the test database is migrated,
-    so the indexes are present whether or not __table_args__ still declares them."""
-    declared = {index.name for index in SQLModel.metadata.tables[table].indexes}
-    assert expected <= declared, f"not declared on {table}: {sorted(expected - declared)}"
+def test_hot_path_indexes_are_declared_on_the_models(table: str, expected: dict):
+    """Guards the model side, which no database assertion can cover: the test database is
+    migrated, so the indexes are there whether or not __table_args__ still declares them."""
+    declared = {index.name: [c.name for c in index.columns] for index in SQLModel.metadata.tables[table].indexes}
+    for name, columns in expected.items():
+        assert name in declared, f"not declared on {table}: {name}"
+        assert declared[name] == columns, f"{name} declared as {declared[name]}, expected {columns}"
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(("table", "expected"), EXPECTED_INDEXES.items())
-async def test_hot_path_indexes_exist_in_the_database(async_session: AsyncSession, table: str, expected: set):
-    """Guards the migration side: a fresh database must end up with all of them."""
-    stmt = text("SELECT indexname FROM pg_indexes WHERE tablename = :table").bindparams(table=table)
-    present = {row[0] for row in (await async_session.exec(stmt)).all()}
-    assert expected <= present, f"missing on {table}: {sorted(expected - present)}"
+async def test_hot_path_indexes_exist_in_the_database(async_session: AsyncSession, table: str, expected: dict):
+    """Guards the migration side: a fresh database must end up with all of them, in order.
+
+    Only non-tautological because the container runs `alembic upgrade head` before pytest.
+    `async_session` calls create_all, so against an unmigrated database this would pass off the
+    model declarations alone.
+    """
+    stmt = text(
+        "SELECT c.relname, "
+        "  (SELECT array_agg(a.attname ORDER BY k.ord) "
+        "     FROM unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) "
+        "     JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum) "
+        "FROM pg_index i "
+        "JOIN pg_class c ON c.oid = i.indexrelid "
+        "JOIN pg_class t ON t.oid = i.indrelid "
+        "WHERE t.relname = :table"
+    ).bindparams(table=table)
+    present = {row[0]: list(row[1] or []) for row in (await async_session.exec(stmt)).all()}
+    for name, columns in expected.items():
+        assert name in present, f"missing on {table}: {name}"
+        assert present[name] == columns, f"{name} built as {present[name]}, expected {columns}"


### PR DESCRIPTION
Closes #663.

Three query shapes on the detection hot path had no index behind them, so each one seq-scanned a table that keeps growing (~2.6M rows in `detections`, ~56k in `sequences` today).

```sql
CREATE INDEX CONCURRENTLY ix_sequences_camera_pose_last_seen ON sequences (camera_id, pose_id, last_seen_at);
CREATE INDEX CONCURRENTLY ix_detections_sequence_id_created_at ON detections (sequence_id, created_at);
CREATE INDEX CONCURRENTLY ix_detections_bucket_key ON detections (bucket_key);
```

| Query | Call site | Without index | With index |
|---|---|---|---|
| Recently-seen sequences of a pose (`camera_id`, `pose_id`, `last_seen_at >`) | spatial matching and continuity, on every `POST /detections` | 8 ms | 0.07 ms |
| Latest real bbox of a sequence (`sequence_id`, `created_at DESC`, limit 1) | spatial matching, once per candidate sequence per detection | 128 ms | 0.08 ms |
| Sibling rows by `bucket_key` | shared-frame check in `DELETE /detections/{id}` | 48 ms | 0.10 ms |

**Attribution:** rows 1 and 3 are the figures from #663 and I have not independently reproduced them. Row 2's query shape is the one I did measure, in more detail below. Happy to benchmark the other two if that is worth it before merge.

## The `(sequence_id, created_at)` index, measured by table size

Index scan vs forced seq scan (`enable_indexscan=off`) on byte-identical data, so the two are directly comparable, for a 1000-frame sequence:

| `detections` rows | On disk | Seq scan | Index scan | Speedup |
|---|---|---|---|---|
| 200k | 29 MB | 7.6 ms | 0.45 ms | 17x |
| 1M | 140 MB | 18.0 ms | 0.53 ms | 34x |
| **2M** (roughly production today) | 266 MB | **34.8 ms** | **0.42 ms** | **83x** |
| 5M | 672 MB | 63.6 ms | 1.14 ms | 56x |

The seq-scan side grows linearly with the whole table while the index scan stays flat, so this gain keeps widening as detections accumulate. Note this index serves two independent hot paths: the per-detection latest-bbox lookup described in #663, and the sequence reads the player pages through.

One measurement caveat worth recording, because it moves the number by nearly 3x: a first attempt showed 160x, because the test sequence's 1000 rows had been inserted consecutively and so occupied only 14 heap pages (~71 rows/page). Real detections arrive interleaved with the rest of the fleet's writes, so the sequence was rebuilt 1-in-24 across a 24k-row window (321 pages, ~3 rows/page). The table above uses the interleaved layout.

## Implementation notes

**`CONCURRENTLY`, in an autocommit block.** `detections` is the highest-write table, and a plain `CREATE INDEX` holds ACCESS EXCLUSIVE against camera ingest for the whole build. `CONCURRENTLY` cannot run inside a transaction and `env.py` wraps the migration run in one, hence `op.get_context().autocommit_block()`.

**The migration self-heals.** A cancelled `CONCURRENTLY` build (deploy timeout, dropped connection) leaves an INVALID index behind. `if_not_exists` would then see the relation and skip creating it, the revision would stamp, and the upgrade would report success while the planner ignored the invalid index, silently leaving these queries on seq scans. So each index is checked in `pg_index` and dropped first if invalid. The existence check joins `pg_class` by name rather than casting to `regclass`, since that cast raises when the relation is absent (the common case) instead of returning no rows.

**Declared in `models.py` too.** Per the issue, `__table_args__` declarations keep `create_all`-built test databases matching production.

## Verification

- 630 tests pass on the rebased branch, ruff lint and format clean.
- **The concurrent build was verified on the real asyncpg path**, which was the one genuine unknown: `env.py` drives an async engine through `run_sync`, so `autocommit_block()` flips isolation on a greenlet-backed sync facade. All three indexes come out `indisvalid = true` after `alembic upgrade head`.
- **The self-heal was verified end to end**, not just read: forced all three to `indisvalid = false`, re-ran the migration, and confirmed all three came back valid.
- **The new sync tests were mutation-checked in both directions.** My first attempt at this test was tautological and I want to flag it, since it is an easy trap: asserting the indexes exist in `pg_indexes` passes whether or not `models.py` declares them, because the test database is migrated. So there are now two tests pinning each side against one canonical list. Removing an index from `models.py` fails the declaration test; removing it from the migration fails the database test. Both were confirmed to fail.

## Coordination with #661

[#661](https://github.com/pyronear/pyro-api/pull/661) (detection sampling for the player, issue #660) originally carried `ix_detections_sequence_id_created_at` on its own, since the player's sequence reads need exactly that index. It has been rebased to drop that migration and now depends on this PR, so the index has a single owner and stays independently revertable, which is the point of having split it out of #624.

Worth noting the shared index is probably more valuable here than there: on this path it runs several times per `POST /detections`, once per candidate sequence.

## Sequencing

**#624 has now merged, so the dependency the issue mentions is satisfied.** That also raises the value of this PR: the continuity pass doubles how often the `(camera_id, pose_id, last_seen_at)` query runs, and `get_latest_with_bbox` (added by #624, `src/app/crud/crud_detection.py`) is exactly the `(sequence_id, created_at DESC, limit 1)` shape the second index serves, so it is now unindexed on every detection request.

Rebased onto main after #624; no conflicts, and `down_revision` is still the current head (`c4e9f1a2b3d5`, since #624 added no migration).

One deployment decision needs a human call: the container start command runs `alembic upgrade head`, so on the first deploy the concurrent builds run at boot and delay the healthcheck in proportion to table size. Pre-creating the three indexes manually beforehand makes the migration a no-op (`if_not_exists`), which may be the calmer path for production.
