### PR TITLE
ci(dependabot): restrict uv version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,7 @@ updates:
     schedule:
       interval: "daily"
       time: "08:00"
+    # Keep in sync with group patterns below; this list gates version updates.
     allow:
       - dependency-name: "PyJWT"
       - dependency-name: "passlib"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,18 @@ updates:
     schedule:
       interval: "daily"
       time: "08:00"
+    allow:
+      - dependency-name: "PyJWT"
+      - dependency-name: "passlib"
+      - dependency-name: "bcrypt"
+      - dependency-name: "ruff"
+      - dependency-name: "ty"
+      - dependency-name: "prek"
+      - dependency-name: "types-*"
+      - dependency-name: "sqlalchemy-stubs"
+      - dependency-name: "posthog"
+      - dependency-name: "sentry-sdk"
+      - dependency-name: "prometheus-fastapi-instrumentator"
     groups:
       security:
         patterns:
@@ -39,6 +51,11 @@ updates:
           - "prek"
           - "types-*"
           - "sqlalchemy-stubs"
+      observability:
+        patterns:
+          - "posthog"
+          - "sentry-sdk"
+          - "prometheus-fastapi-instrumentator"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- allow-list scheduled uv updates to dependencies already assigned to Dependabot groups
- group PostHog, Sentry SDK, and Prometheus FastAPI Instrumentator as `observability`
- leave other dependencies to default-branch security updates; GitHub documents that options in a `target-branch` entry do not apply to security updates

## Validation

- `uv run prek run --files .github/dependabot.yml`
- parsed YAML and verified the uv allow list exactly matches all group patterns

## Reference

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch-