### PR TITLE
feat(storage): apply CORS policy on organization S3 buckets at creation (#642)

### DIFF
--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -68,6 +68,11 @@ class Settings(BaseSettings):
     S3_ENDPOINT_URL: str = os.environ["S3_ENDPOINT_URL"]
     S3_PROXY_URL: str = os.environ.get("S3_PROXY_URL", "")
     S3_URL_EXPIRATION: int = int(os.environ.get("S3_URL_EXPIRATION") or 24 * 3600)
+    # Comma-separated browser origins allowed to fetch bucket objects cross-origin (the frontend
+    # platform URLs). Applied as a CORS policy at bucket creation so the frontend can fetch()
+    # presigned image URLs (e.g. the "download all" buttons). Deployments MUST set this to the
+    # real frontend origins; the localhost default only serves local dev.
+    S3_CORS_ORIGINS: str = os.environ.get("S3_CORS_ORIGINS", "http://localhost:5173")
 
     # Sequence handling: three windows gate sequence behaviour, each on its own timescale.
     # All three are tuned against the cameras' frame interval (time between two frames of the

--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -143,10 +143,34 @@ class S3Service:
                 else {"CreateBucketConfiguration": {"LocationConstraint": self._s3.meta.region_name}}
             )
             self._s3.create_bucket(Bucket=bucket_name, **config_)
+            self._put_bucket_cors(bucket_name)
             return True
         except ClientError as e:
             logger.warning(e)
             return False
+
+    def _put_bucket_cors(self, bucket_name: str) -> None:
+        """Apply the CORS policy so browsers can fetch() presigned URLs cross-origin.
+
+        Allows the frontend origins (settings.S3_CORS_ORIGINS) to GET bucket objects, which the
+        platform's "download all" buttons rely on (native fetch triggers CORS, unlike a plain
+        <img> or <a download>).
+        """
+        origins = [origin.strip() for origin in settings.S3_CORS_ORIGINS.split(",") if origin.strip()]
+        self._s3.put_bucket_cors(
+            Bucket=bucket_name,
+            CORSConfiguration={
+                "CORSRules": [
+                    {
+                        "AllowedOrigins": origins,
+                        "AllowedMethods": ["GET", "HEAD"],
+                        "AllowedHeaders": ["*"],
+                        "ExposeHeaders": ["Content-Length", "Content-Type"],
+                        "MaxAgeSeconds": 3000,
+                    }
+                ]
+            },
+        )
 
     def get_bucket(self, bucket_name: str) -> S3Bucket:
         """Get an existing bucket in S3 storage"""

--- a/src/tests/services/test_storage.py
+++ b/src/tests/services/test_storage.py
@@ -53,6 +53,12 @@ async def test_s3_service(region, endpoint_url, access_key, secret_key, proxy_ur
         # Create random bucket
         bucket_name = "dummy-bucket"
         service.create_bucket(bucket_name)
+        # The CORS policy is applied at creation so the frontend can fetch() presigned URLs
+        cors_rules = service._s3.get_bucket_cors(Bucket=bucket_name)["CORSRules"]
+        assert cors_rules[0]["AllowedMethods"] == ["GET", "HEAD"]
+        assert cors_rules[0]["AllowedOrigins"] == [
+            origin.strip() for origin in settings.S3_CORS_ORIGINS.split(",") if origin.strip()
+        ]
         # Delete the bucket
         await service.delete_bucket(bucket_name)
     else:


### PR DESCRIPTION
Closes #642 

## What and Why

Apply a CORS policy on organization S3 buckets **at creation**, so the platform's
"download all (ZIP)" and "download all + bounding boxes" buttons work.

These buttons use native `fetch()` on presigned S3 URLs, which is subject to CORS —
unlike the single-image download, which uses `<a download>` and isn't. With no CORS
config on the buckets, the browser blocked those cross-origin `fetch()`es.

## How

`S3Service.create_bucket` now applies a CORS rule right after creating the bucket:

- `AllowedMethods`: `GET`, `HEAD` (browser only reads images; uploads are server-side)
- `AllowedOrigins`: from the new `S3_CORS_ORIGINS` setting
- `AllowedHeaders`: `*`
- `ExposeHeaders`: `Content-Length`, `Content-Type`
- `MaxAgeSeconds`: `3000`

## Config / default

`S3_CORS_ORIGINS` is a **comma-separated** list of allowed frontend origins.
**Deployments must set it to the real frontend URLs (prod/preprod).** The default
`http://localhost:5173` is a fail-closed fallback for local dev only — deliberately
**not** `*`, so a forgotten env var breaks visibly instead of silently allowing any origin.

## Existing buckets

This only applies to **newly created** buckets. I'll backfill the existing prod/preprod
buckets separately with a one-off script after merge.

## Validation

- Verified against real cloud provider object storage service: `put_bucket_cors` is honored and served
  (confirmed the `Access-Control-Allow-Origin` header is returned and the frontend
  download works end-to-end).
- Added a LocalStack test asserting the CORS policy is set on the bucket at creation.