### PR TITLE
fix(storage): make the bucket CORS policy best-effort

### DIFF
--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -198,11 +198,16 @@ class S3Service:
                 else {"CreateBucketConfiguration": {"LocationConstraint": self._s3.meta.region_name}}
             )
             self._s3.create_bucket(Bucket=bucket_name, **config_)
-            self._put_bucket_cors(bucket_name)
-            return True
         except ClientError as e:
             logger.warning(e)
             return False
+        # MinIO answers NotImplemented here, so CORS is best-effort: the bucket is usable
+        # without it, only cross-origin fetch() of presigned URLs degrades.
+        try:
+            self._put_bucket_cors(bucket_name)
+        except ClientError as e:
+            logger.warning(f"CORS policy not applied on {bucket_name}: {e}")
+        return True
 
     def _put_bucket_cors(self, bucket_name: str) -> None:
         """Apply the CORS policy so browsers can fetch() presigned URLs cross-origin.

--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -201,12 +201,19 @@ class S3Service:
         except ClientError as e:
             logger.warning(e)
             return False
-        # MinIO answers NotImplemented here, so CORS is best-effort: the bucket is usable
-        # without it, only cross-origin fetch() of presigned URLs degrades.
         try:
             self._put_bucket_cors(bucket_name)
         except ClientError as e:
-            logger.warning(f"CORS policy not applied on {bucket_name}: {e}")
+            if e.response.get("Error", {}).get("Code") != "NotImplemented":
+                # A genuine failure (AccessDenied, malformed S3_CORS_ORIGINS) on a backend that
+                # does support the API: stay loud and fail, so the caller rolls the organization
+                # back instead of silently keeping a bucket the frontend cannot fetch() from.
+                logger.error(f"unable to apply the CORS policy on {bucket_name}: {e}")
+                return False
+            # MinIO does not implement PutBucketCors. On that backend alone CORS is best-effort:
+            # the bucket is usable without it, only cross-origin fetch() of presigned urls
+            # degrades, so creation must not fail.
+            logger.warning(f"CORS policy unsupported by the backend, skipped on {bucket_name}: {e}")
         return True
 
     def _put_bucket_cors(self, bucket_name: str) -> None:

--- a/src/tests/services/test_storage.py
+++ b/src/tests/services/test_storage.py
@@ -68,10 +68,22 @@ async def test_s3_service(region, endpoint_url, access_key, secret_key, proxy_ur
             S3Service(region, endpoint_url, access_key, secret_key, proxy_url)
 
 
+@pytest.mark.parametrize(
+    ("error_code", "expected_created"),
+    [
+        # MinIO does not implement PutBucketCors: the bucket is usable without the policy, so
+        # creation must succeed and only cross-origin fetch() degrades.
+        ("NotImplemented", True),
+        # A backend that does support the API failing for a real reason must not be swallowed,
+        # otherwise the organization keeps a bucket its frontend cannot fetch() from.
+        ("AccessDenied", False),
+        ("MalformedXML", False),
+    ],
+)
 @pytest.mark.asyncio
-async def test_s3_service_create_bucket_survives_an_unsupported_cors_api(monkeypatch):
-    """MinIO answers NotImplemented to PutBucketCors, so a CORS failure must not fail the
-    creation: the bucket exists and is usable, only cross-origin fetch() degrades."""
+async def test_s3_service_create_bucket_only_tolerates_an_unsupported_cors_api(
+    error_code, expected_created, monkeypatch
+):
     service = S3Service(
         settings.S3_REGION,
         settings.S3_ENDPOINT_URL,
@@ -80,14 +92,18 @@ async def test_s3_service_create_bucket_survives_an_unsupported_cors_api(monkeyp
         settings.S3_PROXY_URL,
     )
 
-    def raise_not_implemented(bucket_name):
-        raise ClientError({"Error": {"Code": "NotImplemented"}}, "PutBucketCors")
+    def raise_cors_error(bucket_name):
+        raise ClientError({"Error": {"Code": error_code}}, "PutBucketCors")
 
-    monkeypatch.setattr(service, "_put_bucket_cors", raise_not_implemented)
-    bucket_name = "dummy-bucket-no-cors"
-    assert service.create_bucket(bucket_name)
-    assert service.get_bucket(bucket_name).name == bucket_name
-    await service.delete_bucket(bucket_name)
+    monkeypatch.setattr(service, "_put_bucket_cors", raise_cors_error)
+    bucket_name = f"dummy-bucket-cors-{error_code.lower()}"
+    try:
+        assert service.create_bucket(bucket_name) is expected_created
+        if expected_created:
+            # Tolerated only because the bucket really is there and usable.
+            assert service.get_bucket(bucket_name).name == bucket_name
+    finally:
+        await service.delete_bucket(bucket_name)
 
 
 @pytest.mark.parametrize(

--- a/src/tests/services/test_storage.py
+++ b/src/tests/services/test_storage.py
@@ -2,6 +2,7 @@ import io
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from fastapi import HTTPException
 
 from app.core.config import settings
@@ -65,6 +66,28 @@ async def test_s3_service(region, endpoint_url, access_key, secret_key, proxy_ur
     else:
         with pytest.raises(expected_error):
             S3Service(region, endpoint_url, access_key, secret_key, proxy_url)
+
+
+@pytest.mark.asyncio
+async def test_s3_service_create_bucket_survives_an_unsupported_cors_api(monkeypatch):
+    """MinIO answers NotImplemented to PutBucketCors, so a CORS failure must not fail the
+    creation: the bucket exists and is usable, only cross-origin fetch() degrades."""
+    service = S3Service(
+        settings.S3_REGION,
+        settings.S3_ENDPOINT_URL,
+        settings.S3_ACCESS_KEY,
+        settings.S3_SECRET_KEY,
+        settings.S3_PROXY_URL,
+    )
+
+    def raise_not_implemented(bucket_name):
+        raise ClientError({"Error": {"Code": "NotImplemented"}}, "PutBucketCors")
+
+    monkeypatch.setattr(service, "_put_bucket_cors", raise_not_implemented)
+    bucket_name = "dummy-bucket-no-cors"
+    assert service.create_bucket(bucket_name)
+    assert service.get_bucket(bucket_name).name == bucket_name
+    await service.delete_bucket(bucket_name)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #683

## What

`S3Service.create_bucket()` wrapped bucket creation and `put_bucket_cors()` in a single `try`/`except ClientError`. MinIO does not implement the `PutBucketCors` API. it answers `NotImplemented`, which boto3 raises as a `ClientError`  so the CORS failure was caught by the handler that returns `False`.

The result, reported in #683: the bucket **was** created, but the call reported failure, the organization transaction rolled back, and the bucket was left orphaned in storage. The API surfaced a misleading `Failed to create bucket`.

This splits the two concerns:

- a `ClientError` on `create_bucket` is still fatal → `return False`
- a `ClientError` on `put_bucket_cors` is logged as a warning → the bucket is reported as created

This is safe for production as S3 service implements `PutBucketCors`, so the production path is unchanged: bucket created, CORS applied, `True` returned.

## Tests

The existing CORS assertion in `test_s3_service` is untouched and still passes: CI runs against **localstack**, which implements `PutBucketCors`, so the policy is still guarded on a compliant backend.

Added `test_s3_service_create_bucket_survives_an_unsupported_cors_api`, which monkeypatches
`_put_bucket_cors` to raise a `NotImplemented` `ClientError` and asserts the bucket is still
created and usable. 
